### PR TITLE
Use lts/iron in .nvmrc

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-slts/iron
+lts/iron


### PR DESCRIPTION
https://discord.com/channels/1079490158639976609/1255007614417375344/1260958705738846248

`slts/iron` was giving me grief:

```
~/projects
❯ cd musd
Found '/Users/beaushinkle/projects/musd/.nvmrc' with version <slts/iron>
Version 'slts/iron' not found - try `nvm ls-remote` to browse available versions.

musd main
❯ cat .nvmrc
File: .nvmrc
slts/iron
```
So we switch to `lts/iron` which isn't giving me grief. It's also what we're using in `mezo-portal`.

Side note: I'm curious if this is a just-me problem or where `slts/iron` came from, but I don't especially want to burn time on it if `lts/iron` works for everyone.

Tagging @rwatts07 for review