### PR TITLE
Manually deploy PriceFeed in Tests

### DIFF
--- a/solidity/test/v1/normal/PriceFeed.test.ts
+++ b/solidity/test/v1/normal/PriceFeed.test.ts
@@ -24,8 +24,7 @@ async function deployAndGetContract(name: string) {
 }
 
 async function deployPriceFeed() {
-  await deployments.fixture(["PriceFeed"])
-  const priceFeed = await getContract("PriceFeed")
+  const priceFeed = await deployAndGetContract("PriceFeed")
   const eightDecimalAggregator = await deployAndGetContract(
     "MockEightDecimalAggregator",
   )


### PR DESCRIPTION
thread: https://discord.com/channels/1079490158639976609/1265008785513250826/1265120168355303585

We're running into a problem where calling `deployments.fixture` is breaking other tets due to a known bug in hardhat.

In the short term, we fix this by manually deploying it. Long-term, we can create a universal test deployment and use that for everything, pulling in acre's helper functions for snapshots.

Tagging @benthesis or @rwatts07 for review