### PR TITLE
Disable PriceFeed slither `unused-return` warnings

### DIFF
--- a/solidity/contracts/v1/PriceFeed.sol
+++ b/solidity/contracts/v1/PriceFeed.sol
@@ -24,6 +24,7 @@ contract PriceFeed is IPriceFeed, Ownable {
             );
 
         require(chainLinkOracle.decimals() > 0, "Invalid Decimals from Oracle");
+        // slither-disable-next-line unused-return
         (, int256 price, , , ) = chainLinkOracle.latestRoundData();
         require(price != 0, "Oracle returns 0 for price");
 
@@ -35,6 +36,7 @@ contract PriceFeed is IPriceFeed, Ownable {
     // Public functions -------------------------------------------------------------------------------------------------
 
     function fetchPrice() public view virtual returns (uint256) {
+        // slither-disable-next-line unused-return
         (, int256 price, , , ) = oracle.latestRoundData();
         return _scalePriceByDigits(uint256(price), oracle.decimals());
     }


### PR DESCRIPTION
This PR finally gets us to green!

We were previously failing from

> INFO:Detectors:
> PriceFeed.setOracle(address) (contracts/v1/PriceFeed.sol#21-33) ignores return value by (price) = chainLinkOracle.latestRoundData() (contracts/v1/PriceFeed.sol#27)
> PriceFeed.fetchPrice() (contracts/v1/PriceFeed.sol#37-40) ignores return value by (price) = oracle.latestRoundData() (contracts/v1/PriceFeed.sol#38)
> Reference: https://github.com/crytic/slither/wiki/Detector-Documentation#unused-return
> INFO:Slither:. analyzed (63 contracts with 82 detectors), 2 result(s) found

presumably due to destructuring the tuple. I'm all ears if there's a better way to fix it, but I think we should get back to green builds ASAP