### PR TITLE
Porting withdrawMUSD tests

### DIFF
--- a/solidity/test/v1/recovery/BorrowerOperations.test.ts
+++ b/solidity/test/v1/recovery/BorrowerOperations.test.ts
@@ -517,4 +517,75 @@ describe("BorrowerOperations in Recovery Mode", () => {
 
     context("State change in other contracts", () => {})
   })
+
+  describe("withdrawMUSD", () => {
+    /**
+     *
+     * Expected Reverts
+     *
+     */
+
+    context("Expected Reverts", () => {
+      it("withdrawMUSD(): reverts when system is in Recovery Mode", async () => {
+        const maxFeePercentage = to1e18(1)
+        const amount = 1n
+
+        await expect(
+          contracts.borrowerOperations
+            .connect(bob.wallet)
+            .withdrawMUSD(maxFeePercentage, amount, bob.wallet, bob.wallet),
+        ).to.be.revertedWith(
+          "BorrowerOps: Operation must leave trove with ICR >= CCR",
+        )
+      })
+    })
+
+    /**
+     *
+     * Emitted Events
+     *
+     */
+
+    context("Emitted Events", () => {})
+
+    /**
+     *
+     * System State Changes
+     *
+     */
+
+    context("System State Changes", () => {})
+
+    /**
+     *
+     * Individual Troves
+     *
+     */
+
+    context("Individual Troves", () => {})
+
+    /**
+     *
+     *  Balance changes
+     *
+     */
+
+    context("Balance changes", () => {})
+
+    /**
+     *
+     * Fees
+     *
+     */
+
+    context("Fees", () => {})
+
+    /**
+     *
+     * State change in other contracts
+     *
+     */
+
+    context("State change in other contracts", () => {})
+  })
 })


### PR DESCRIPTION
Note that the withdrawMUSD call on BorrowerOperations makes use of the _adjustTrove call. As a result no smart contract changes where required for this PR. 

A trove for Carol is opened with a CR of 500% so that withdrawing will work as Alice and Bob's troves are both opened at 150%.

Withdrawing extra MUSD against Alice or Bob without opening another trove would cause the TCR for fall below the CCR.