### PR TITLE
Porting repayMUSD tests

### DIFF
--- a/solidity/contracts/v1/BorrowerOperations.sol
+++ b/solidity/contracts/v1/BorrowerOperations.sol
@@ -276,7 +276,18 @@ contract BorrowerOperations is
         uint256 _amount,
         address _upperHint,
         address _lowerHint
-    ) external override {}
+    ) external override {
+        _adjustTrove(
+            msg.sender,
+            0,
+            _amount,
+            false,
+            0,
+            _upperHint,
+            _lowerHint,
+            0
+        );
+    }
 
     function closeTrove() external override {
         ITroveManager troveManagerCached = troveManager;

--- a/solidity/test/helpers/functions.ts
+++ b/solidity/test/helpers/functions.ts
@@ -79,6 +79,7 @@ export async function updateContractsSnapshot(
   state[pool].btc[checkPoint] = await ethers.provider.getBalance(
     addresses[pool],
   )
+  state[pool].debt[checkPoint] = await contracts[pool].getMUSDDebt()
 }
 
 export async function updatePendingSnapshot(

--- a/solidity/test/v1/recovery/BorrowerOperations.test.ts
+++ b/solidity/test/v1/recovery/BorrowerOperations.test.ts
@@ -588,4 +588,86 @@ describe("BorrowerOperations in Recovery Mode", () => {
 
     context("State change in other contracts", () => {})
   })
+
+  describe("repayMUSD", () => {
+    /**
+     *
+     * Expected Reverts
+     *
+     */
+
+    context("Expected Reverts", () => {})
+
+    /**
+     *
+     * Emitted Events
+     *
+     */
+
+    context("Emitted Events", () => {})
+
+    /**
+     *
+     * System State Changes
+     *
+     */
+
+    context("System State Changes", () => {})
+
+    /**
+     *
+     * Individual Troves
+     *
+     */
+
+    context("Individual Troves", () => {
+      it("repayTHUSD(): can repay debt in Recovery Mode", async () => {
+        const amount = to1e18("1,000")
+        await updateTroveSnapshot(contracts, bob, "before")
+        await contracts.borrowerOperations
+          .connect(bob.wallet)
+          .repayMUSD(amount, bob.wallet, bob.wallet)
+        await updateTroveSnapshot(contracts, bob, "after")
+
+        expect(bob.trove.debt.after).to.equal(bob.trove.debt.before - amount)
+      })
+
+      it("repayTHUSD(): no mintlist, can repay debt in Recovery Mode", async () => {
+        await removeMintlist(contracts, deployer.wallet)
+
+        const amount = to1e18("1,000")
+        await updateTroveSnapshot(contracts, bob, "before")
+        await contracts.borrowerOperations
+          .connect(bob.wallet)
+          .repayMUSD(amount, bob.wallet, bob.wallet)
+        await updateTroveSnapshot(contracts, bob, "after")
+
+        expect(bob.trove.debt.after).to.equal(bob.trove.debt.before - amount)
+      })
+    })
+
+    /**
+     *
+     *  Balance changes
+     *
+     */
+
+    context("Balance changes", () => {})
+
+    /**
+     *
+     * Fees
+     *
+     */
+
+    context("Fees", () => {})
+
+    /**
+     *
+     * State change in other contracts
+     *
+     */
+
+    context("State change in other contracts", () => {})
+  })
 })


### PR DESCRIPTION
Note that the repayMUSD call on BorrowerOperations makes use of the _adjustTrove call. As a result only a small smart contract change is required for this PR.
