### PR TITLE
Skip Rounding Error Tests

### DIFF
--- a/solidity/test/v1/normal/StabilityPool.test.ts
+++ b/solidity/test/v1/normal/StabilityPool.test.ts
@@ -1168,4 +1168,13 @@ describe("StabilityPool in Normal Mode", () => {
      */
     context("State change in other contracts", () => {})
   })
+
+  describe("Rounding Errors", () => {
+    it.skip("100 deposits of $100 into SP, then 200 liquidations of $49", () => {
+      // https://github.com/Threshold-USD/dev/blob/develop/packages/contracts/test/StabilityPool_RoundingErrors.js#L38C12-L38C95
+      // Tried to get it to work for a couple of days, seems to rely on a bunch of assumptions that we don't make,
+      // like having no minimum trove amount (we can't open a $49 trove). Also, as written, the original test looks broken.
+      // ... And horribly slow.
+    })
+  })
 })


### PR DESCRIPTION
I gave this a shot for a couple of days: https://discord.com/channels/1079490158639976609/1277695865636524184 but didn't get there and I'm punting for now.

Ryan suggested that whenever this happens we include it and mark it as `skip` in the code base for completion's sake; I like the idea.

Tagging @rwatts07 and @benthesis for review