### PR TITLE
Trove manager top up

### DIFF
--- a/solidity/test/v1/normal/TroveManager.test.ts
+++ b/solidity/test/v1/normal/TroveManager.test.ts
@@ -40,7 +40,6 @@ import {
   User,
 } from "../../helpers"
 import { to1e18 } from "../../utils"
-import { TroveManagerTester } from "../../../typechain"
 
 describe("TroveManager in Normal Mode", () => {
   let addresses: TestingAddresses


### PR DESCRIPTION
Small PR to close some gaps in TroveManager tests since we'll be touching that with the interest rates work.

Specifically:
- Modified one of the existing tests to use `getRedemptionFeeWithDecay` as in the original test.  This is the only test in thUSD that touches that function so even though it's not a perfect test at least it's something. 
- Fix a `skip`ed test in the recovery mode tests to hit an additional branch.
- Added a few of the `batchLiquidateTroves` tests from https://github.com/Threshold-USD/dev/blob/develop/packages/contracts/test/TroveManager_RecoveryMode_Batch_Liqudation_Test.js.  Most of this logic is already covered by the other tests but I added the cases I don't think we have yet.