### PR TITLE
Remove updateCollateralBalance and related checks

### DIFF
--- a/solidity/contracts/v1/ActivePool.sol
+++ b/solidity/contracts/v1/ActivePool.sol
@@ -124,29 +124,7 @@ contract ActivePool is Ownable, CheckContract, SendCollateral, IActivePool {
         collateral -= _amount;
         emit ActivePoolCollateralBalanceUpdated(collateral);
         emit CollateralSent(_account, _amount);
-
         sendCollateral(IERC20(collateralAddress), _account, _amount);
-        if (collateralAddress == address(0)) {
-            return;
-        }
-        if (_account == defaultPoolAddress) {
-            IDefaultPool(_account).updateCollateralBalance(_amount);
-        } else if (_account == collSurplusPoolAddress) {
-            ICollSurplusPool(_account).updateCollateralBalance(_amount);
-        } else if (_account == stabilityPoolAddress) {
-            IStabilityPool(_account).updateCollateralBalance(_amount);
-        }
-    }
-
-    // When ERC20 token collateral is received this function needs to be called
-    function updateCollateralBalance(uint256 _amount) external override {
-        _requireCallerIsBorrowerOperationsOrDefaultPool();
-        require(
-            collateralAddress != address(0),
-            "ActivePool: BTC collateral needed, not ERC20"
-        );
-        collateral += _amount;
-        emit ActivePoolCollateralBalanceUpdated(collateral);
     }
 
     /*

--- a/solidity/contracts/v1/BorrowerOperations.sol
+++ b/solidity/contracts/v1/BorrowerOperations.sol
@@ -705,11 +705,6 @@ contract BorrowerOperations is
             address(_activePool),
             _amount
         );
-
-        if (collateralAddress == address(0)) {
-            return;
-        }
-        _activePool.updateCollateralBalance(_amount);
     }
 
     // Update trove's coll and debt based on whether they increase or decrease

--- a/solidity/contracts/v1/CollSurplusPool.sol
+++ b/solidity/contracts/v1/CollSurplusPool.sol
@@ -115,17 +115,6 @@ contract CollSurplusPool is
         sendCollateral(IERC20(collateralAddress), _account, claimableColl);
     }
 
-    // When ERC20 token collateral is received this function needs to be called
-    function updateCollateralBalance(uint256 _amount) external override {
-        _requireCallerIsActivePool();
-        require(
-            collateralAddress != address(0),
-            "CollSurplusPool: BTC collateral needed, not ERC20"
-        );
-        // slither-disable-next-line events-maths
-        collateral += _amount;
-    }
-
     function getCollateral(
         address _account
     ) external view override returns (uint) {

--- a/solidity/contracts/v1/DefaultPool.sol
+++ b/solidity/contracts/v1/DefaultPool.sol
@@ -89,21 +89,6 @@ contract DefaultPool is Ownable, CheckContract, SendCollateral, IDefaultPool {
         emit CollateralSent(activePool, _amount);
 
         sendCollateral(IERC20(collateralAddress), activePool, _amount);
-        if (collateralAddress == address(0)) {
-            return;
-        }
-        IActivePool(activePool).updateCollateralBalance(_amount);
-    }
-
-    // When ERC20 token collateral is received this function needs to be called
-    function updateCollateralBalance(uint256 _amount) external override {
-        _requireCallerIsActivePool();
-        require(
-            collateralAddress != address(0),
-            "DefaultPool: BTC collateral needed, not ERC20"
-        );
-        collateral += _amount;
-        emit DefaultPoolCollateralBalanceUpdated(collateral);
     }
 
     function getCollateralBalance() external view override returns (uint) {

--- a/solidity/contracts/v1/StabilityPool.sol
+++ b/solidity/contracts/v1/StabilityPool.sol
@@ -286,13 +286,6 @@ contract StabilityPool is
         _moveOffsetCollAndDebt(_collToAdd, _debtToOffset);
     }
 
-    // When ERC20 token collateral is received this function needs to be called
-    function updateCollateralBalance(uint256 _amount) external override {
-        _requireCallerIsActivePool();
-        collateral += _amount;
-        emit StabilityPoolCollateralBalanceUpdated(collateral);
-    }
-
     // --- Getters for public variables. Required by IPool interface ---
 
     function getCollateralBalance() external view override returns (uint) {

--- a/solidity/contracts/v1/interfaces/IActivePool.sol
+++ b/solidity/contracts/v1/interfaces/IActivePool.sol
@@ -18,7 +18,5 @@ interface IActivePool is IPool {
     // --- Functions ---
     function sendCollateral(address _account, uint256 _amount) external;
 
-    function updateCollateralBalance(uint256 _amount) external;
-
     function collateralAddress() external view returns (address);
 }

--- a/solidity/contracts/v1/interfaces/ICollSurplusPool.sol
+++ b/solidity/contracts/v1/interfaces/ICollSurplusPool.sol
@@ -28,8 +28,6 @@ interface ICollSurplusPool {
 
     function claimColl(address _account) external;
 
-    function updateCollateralBalance(uint256 _amount) external;
-
     function collateralAddress() external view returns (address);
 
     function getCollateralBalance() external view returns (uint);

--- a/solidity/contracts/v1/interfaces/IDefaultPool.sol
+++ b/solidity/contracts/v1/interfaces/IDefaultPool.sol
@@ -14,7 +14,5 @@ interface IDefaultPool is IPool {
     // --- Functions ---
     function sendCollateralToActivePool(uint256 _amount) external;
 
-    function updateCollateralBalance(uint256 _amount) external;
-
     function collateralAddress() external view returns (address);
 }

--- a/solidity/contracts/v1/interfaces/IStabilityPool.sol
+++ b/solidity/contracts/v1/interfaces/IStabilityPool.sol
@@ -120,11 +120,6 @@ interface IStabilityPool {
     function offset(uint256 _debt, uint256 _coll) external;
 
     /*
-     * Only callable by Active Pool, updates ERC20 tokens recieved
-     */
-    function updateCollateralBalance(uint256 _amount) external;
-
-    /*
      * Returns the total amount of collateral held by the pool, accounted in an internal variable instead of `balance`,
      * to exclude edge cases like collateral received from a self-destruct.
      */

--- a/solidity/contracts/v2/ActivePoolV2.sol
+++ b/solidity/contracts/v2/ActivePoolV2.sol
@@ -132,27 +132,6 @@ contract ActivePoolV2 is
         emit CollateralSent(_account, _amount);
 
         sendCollateral(IERC20(collateralAddress), _account, _amount);
-        if (collateralAddress == address(0)) {
-            return;
-        }
-        if (_account == defaultPoolAddress) {
-            IDefaultPoolV2(_account).updateCollateralBalance(_amount);
-        } else if (_account == collSurplusPoolAddress) {
-            ICollSurplusPoolV2(_account).updateCollateralBalance(_amount);
-        } else if (_account == stabilityPoolAddress) {
-            IStabilityPoolV2(_account).updateCollateralBalance(_amount);
-        }
-    }
-
-    // When ERC20 token collateral is received this function needs to be called
-    function updateCollateralBalance(uint256 _amount) external override {
-        _requireCallerIsBorrowerOperationsOrDefaultPool();
-        require(
-            collateralAddress != address(0),
-            "ActivePool: BTC collateral needed, not ERC20"
-        );
-        collateral += _amount;
-        emit ActivePoolCollateralBalanceUpdated(collateral);
     }
 
     /*

--- a/solidity/contracts/v2/BorrowerOperationsV2.sol
+++ b/solidity/contracts/v2/BorrowerOperationsV2.sol
@@ -710,11 +710,6 @@ contract BorrowerOperationsV2 is
             address(_activePool),
             _amount
         );
-
-        if (collateralAddress == address(0)) {
-            return;
-        }
-        _activePool.updateCollateralBalance(_amount);
     }
 
     // Update trove's coll and debt based on whether they increase or decrease

--- a/solidity/contracts/v2/CollSurplusPoolV2.sol
+++ b/solidity/contracts/v2/CollSurplusPoolV2.sol
@@ -115,17 +115,6 @@ contract CollSurplusPoolV2 is
         sendCollateral(IERC20(collateralAddress), _account, claimableColl);
     }
 
-    // When ERC20 token collateral is received this function needs to be called
-    function updateCollateralBalance(uint256 _amount) external override {
-        _requireCallerIsActivePool();
-        require(
-            collateralAddress != address(0),
-            "CollSurplusPool: BTC collateral needed, not ERC20"
-        );
-        // slither-disable-next-line events-maths
-        collateral += _amount;
-    }
-
     function getCollateral(
         address _account
     ) external view override returns (uint) {

--- a/solidity/contracts/v2/DefaultPoolV2.sol
+++ b/solidity/contracts/v2/DefaultPoolV2.sol
@@ -94,21 +94,6 @@ contract DefaultPoolV2 is
         emit CollateralSent(activePool, _amount);
 
         sendCollateral(IERC20(collateralAddress), activePool, _amount);
-        if (collateralAddress == address(0)) {
-            return;
-        }
-        IActivePoolV2(activePool).updateCollateralBalance(_amount);
-    }
-
-    // When ERC20 token collateral is received this function needs to be called
-    function updateCollateralBalance(uint256 _amount) external override {
-        _requireCallerIsActivePool();
-        require(
-            collateralAddress != address(0),
-            "DefaultPool: BTC collateral needed, not ERC20"
-        );
-        collateral += _amount;
-        emit DefaultPoolCollateralBalanceUpdated(collateral);
     }
 
     function getCollateralBalance() external view override returns (uint) {

--- a/solidity/contracts/v2/StabilityPoolV2.sol
+++ b/solidity/contracts/v2/StabilityPoolV2.sol
@@ -286,13 +286,6 @@ contract StabilityPoolV2 is
         _moveOffsetCollAndDebt(_collToAdd, _debtToOffset);
     }
 
-    // When ERC20 token collateral is received this function needs to be called
-    function updateCollateralBalance(uint256 _amount) external override {
-        _requireCallerIsActivePool();
-        collateral += _amount;
-        emit StabilityPoolCollateralBalanceUpdated(collateral);
-    }
-
     // --- Getters for public variables. Required by IPool interface ---
 
     function getCollateralBalance() external view override returns (uint) {

--- a/solidity/contracts/v2/interfaces/IActivePoolV2.sol
+++ b/solidity/contracts/v2/interfaces/IActivePoolV2.sol
@@ -18,7 +18,5 @@ interface IActivePoolV2 is IPoolV2 {
     // --- Functions ---
     function sendCollateral(address _account, uint256 _amount) external;
 
-    function updateCollateralBalance(uint256 _amount) external;
-
     function collateralAddress() external view returns (address);
 }

--- a/solidity/contracts/v2/interfaces/ICollSurplusPoolV2.sol
+++ b/solidity/contracts/v2/interfaces/ICollSurplusPoolV2.sol
@@ -28,8 +28,6 @@ interface ICollSurplusPoolV2 {
 
     function claimColl(address _account) external;
 
-    function updateCollateralBalance(uint256 _amount) external;
-
     function collateralAddress() external view returns (address);
 
     function getCollateralBalance() external view returns (uint);

--- a/solidity/contracts/v2/interfaces/IDefaultPoolV2.sol
+++ b/solidity/contracts/v2/interfaces/IDefaultPoolV2.sol
@@ -14,7 +14,5 @@ interface IDefaultPoolV2 is IPoolV2 {
     // --- Functions ---
     function sendCollateralToActivePool(uint256 _amount) external;
 
-    function updateCollateralBalance(uint256 _amount) external;
-
     function collateralAddress() external view returns (address);
 }

--- a/solidity/contracts/v2/interfaces/IStabilityPoolV2.sol
+++ b/solidity/contracts/v2/interfaces/IStabilityPoolV2.sol
@@ -120,11 +120,6 @@ interface IStabilityPoolV2 {
     function offset(uint256 _debt, uint256 _coll) external;
 
     /*
-     * Only callable by Active Pool, updates ERC20 tokens recieved
-     */
-    function updateCollateralBalance(uint256 _amount) external;
-
-    /*
      * Returns the total amount of collateral held by the pool, accounted in an internal variable instead of `balance`,
      * to exclude edge cases like collateral received from a self-destruct.
      */

--- a/solidity/test/v1/normal/DefaultPool.test.ts
+++ b/solidity/test/v1/normal/DefaultPool.test.ts
@@ -22,7 +22,6 @@ describe("DefaultPool", () => {
   let state: ContractsState
   let testSetup: TestSetup
 
-  let activePoolSigner: HardhatEthersSigner
   let troveManagerSigner: HardhatEthersSigner
 
   beforeEach(async () => {
@@ -44,7 +43,6 @@ describe("DefaultPool", () => {
       params: [addresses.activePool],
     })
 
-    activePoolSigner = await ethers.getSigner(addresses.activePool)
     troveManagerSigner = await ethers.getSigner(addresses.troveManager)
   })
 
@@ -54,14 +52,6 @@ describe("DefaultPool", () => {
    *
    */
   context("Expected Reverts", () => {
-    it("updateCollateralBalance(): fails if pool receives token", async () => {
-      await expect(
-        contracts.defaultPool
-          .connect(activePoolSigner)
-          .updateCollateralBalance(0, NO_GAS),
-      ).to.be.revertedWith("DefaultPool: BTC collateral needed, not ERC20")
-    })
-
     it.skip("sendCollateralToActivePool(): fails if receiver cannot receive collateral", async () => {
       // TODO This requires the active pool to be a nonpayable address.  Skipping for now because the extra setup doesn't seem worth it.
       // THUSD Test link: https://github.com/Threshold-USD/dev/blob/develop/packages/contracts/test/DefaultPoolTest.js#L64

--- a/solidity/test/v2/normal/DefaultPool.test.ts
+++ b/solidity/test/v2/normal/DefaultPool.test.ts
@@ -22,7 +22,6 @@ describe("DefaultPoolV2", () => {
   let state: ContractsState
   let testSetup: TestSetup
 
-  let activePoolSigner: HardhatEthersSigner
   let troveManagerSigner: HardhatEthersSigner
 
   beforeEach(async () => {
@@ -44,7 +43,6 @@ describe("DefaultPoolV2", () => {
       params: [addresses.activePool],
     })
 
-    activePoolSigner = await ethers.getSigner(addresses.activePool)
     troveManagerSigner = await ethers.getSigner(addresses.troveManager)
   })
 
@@ -54,14 +52,6 @@ describe("DefaultPoolV2", () => {
    *
    */
   context("Expected Reverts", () => {
-    it("updateCollateralBalance(): fails if pool receives token", async () => {
-      await expect(
-        contracts.defaultPool
-          .connect(activePoolSigner)
-          .updateCollateralBalance(0, NO_GAS),
-      ).to.be.revertedWith("DefaultPool: BTC collateral needed, not ERC20")
-    })
-
     it.skip("sendCollateralToActivePool(): fails if receiver cannot receive collateral", async () => {
       // TODO This requires the active pool to be a nonpayable address.  Skipping for now because the extra setup doesn't seem worth it.
       // THUSD Test link: https://github.com/Threshold-USD/dev/blob/develop/packages/contracts/test/DefaultPoolTest.js#L64


### PR DESCRIPTION
Removes `updateCollateralBalance` and related logic since we are not accepting ERC20 tokens as collateral.  There is some more that *could* be removed (like making `collateralAddress` a constant `address(0)` across contracts but that seemed like potentially more trouble than it is worth.