### PR TITLE
WIP - Refactoring to use global debt index

### DIFF
--- a/solidity/contracts/BorrowerOperations.sol
+++ b/solidity/contracts/BorrowerOperations.sol
@@ -181,15 +181,8 @@ contract BorrowerOperations is
             vars.compositeDebt
         );
 
-        contractsCache.troveManager.setTroveInterestRate(
-            msg.sender,
-            contractsCache.troveManager.interestRate()
-        );
-        // solhint-disable-next-line not-rely-on-time
-        contractsCache.troveManager.setTroveLastInterestUpdateTime(
-            msg.sender,
-            block.timestamp
-        );
+        contractsCache.troveManager.setTroveDebtIndex(msg.sender);
+
         contractsCache.troveManager.updateTroveRewardSnapshots(msg.sender);
         vars.stake = contractsCache.troveManager.updateStakeAndTotalStakes(
             msg.sender

--- a/solidity/contracts/interfaces/ITroveManager.sol
+++ b/solidity/contracts/interfaces/ITroveManager.sol
@@ -16,7 +16,7 @@ interface ITroveManager {
     }
 
     struct InterestRateChange {
-        uint16 interestRate;
+        uint256 interestRate;
         uint256 blockNumber;
     }
 
@@ -145,18 +145,13 @@ interface ITroveManager {
         uint256 _debtDecrease
     ) external returns (uint);
 
-    function setTroveInterestRate(address _borrower, uint16 _rate) external;
-
-    function setTroveLastInterestUpdateTime(
-        address _borrower,
-        uint256 _timestamp
-    ) external;
+    function setTroveDebtIndex(address _borrower) external;
 
     function approveInterestRate() external;
 
-    function proposeInterestRate(uint16 _newProposedInterestRate) external;
+    function proposeInterestRate(uint256 _newProposedInterestRate) external;
 
-    function setMaxInterestRate(uint16 _newMaxInterestRate) external;
+    function setMaxInterestRate(uint256 _newMaxInterestRate) external;
 
     function stabilityPool() external view returns (IStabilityPool);
 
@@ -221,21 +216,11 @@ interface ITroveManager {
 
     function getTroveDebt(address _borrower) external view returns (uint);
 
-    function getTroveInterestRate(
-        address _borrower
-    ) external view returns (uint16);
-
-    function getTroveLastInterestUpdateTime(
-        address _borrower
-    ) external view returns (uint);
-
     function getTroveColl(address _borrower) external view returns (uint);
 
     function getTCR(uint256 _price) external view returns (uint);
 
     function checkRecoveryMode(uint256 _price) external view returns (bool);
-
-    function interestRate() external view returns (uint16);
 
     function getInterestRateHistory()
         external

--- a/solidity/test/normal/BorrowerOperations.test.ts
+++ b/solidity/test/normal/BorrowerOperations.test.ts
@@ -631,38 +631,18 @@ describe("BorrowerOperations in Normal Mode", () => {
         )
       })
 
-      it("openTrove(): opens a new Trove with the current interest rate and sets the lastInterestUpdatedTime", async () => {
-        // set the current interest rate to 100 bps
-        await contracts.troveManager
-          .connect(council.wallet)
-          .proposeInterestRate(100)
-        const timeToIncrease = 7 * 24 * 60 * 60 // 7 days in seconds
-        await fastForwardTime(timeToIncrease)
-        await contracts.troveManager
-          .connect(council.wallet)
-          .approveInterestRate()
-
+      it("openTrove(): opens a new Trove and sets the lastUpdatedDebtIndex", async () => {
         // open a new trove
         await openTrove(contracts, {
           musdAmount: "100,000",
           sender: dennis.wallet,
         })
 
-        // check that the interest rate on the trove is the current interest rate
-        const interestRate = await contracts.troveManager.getTroveInterestRate(
-          dennis.wallet,
+        const troveDebtIndex =
+          await contracts.troveManager.getTroveInterestRate(dennis.wallet)
+        expect(troveDebtIndex).is.equal(
+          await contracts.troveManager.globalDebtIndex(),
         )
-        expect(interestRate).is.equal(100)
-
-        // check that the lastInterestUpdatedTime on the Trove is the current time
-        const lastInterestUpdatedTime =
-          await contracts.troveManager.getTroveLastInterestUpdateTime(
-            dennis.wallet,
-          )
-
-        const currentTime = await getLatestBlockTimestamp()
-
-        expect(lastInterestUpdatedTime).is.equal(currentTime)
       })
     })
 


### PR DESCRIPTION
Still a work in progress but wanted to get some feedback on the global debt index approach.  There is still work to be done to make everything work together but the interest calculation itself could use some eyes.

Some points I could use feedback on:
- Storing the annual interest rate in basis points.  This makes sense at face value but converting between basis points, fixed point, and 1e18 precision add up to create a decent bit of cognitive overhead.
- The global debt index now compounds on a daily basis independent of when troves are opened.  This seems reasonable to me but wanted to get some thoughts on it.
- There is some approximation going on when calculating compound interest and honestly I've been going in circles trying to track down the source of the error.  It feels like we should be able to get a more precise result but we are limited by integer math and the fact that solidity does not support fractional exponents.  I've tried a few different methods, but there may be another one that will get us closer.  Open to suggestions on this one.