### PR TITLE
Re-enable `pre-commit` hooks

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -7,6 +7,8 @@ solidity/external/
 solidity/typechain/
 solidity/typechain-types/
 solidity/artifacts/
+solidity/coverage
+solidity/coverage.json
 
 # Auto-generated files.
 pnpm-lock.yaml

--- a/solidity/.eslintignore
+++ b/solidity/.eslintignore
@@ -1,5 +1,7 @@
 build/
 cache/
+coverage/
+coverage.json
 deployments/
 export.json
 export/


### PR DESCRIPTION
closes ENG-275

These have been broken for a while (and so I've been running `git commit -n` for everything).

[As it turns out](https://github.com/eslint/eslint/issues/10239#issuecomment-389288730), the culprit is the code coverage report files. Adding these to the ignore list for prettier and eslint gets everything in ship shape.

Tagging @rwatts07 for review

To test, pull this branch down, make a change in a typescript file, and try to commit. It should work! Likewise, it should not work in main (with pre-commit installed).