### PR TITLE
Restructure Test Formatting

### DIFF
--- a/solidity/test/MUSD.test.ts
+++ b/solidity/test/MUSD.test.ts
@@ -45,20 +45,26 @@ describe("MUSD", () => {
     await contracts.musd.unprotectedMint(carol.wallet, to1e18(50))
   })
 
-  describe("Initial State", () => {
-    it("name(): returns the token's name", async () => {
+  describe("name()", () => {
+    it("returns the token's name", async () => {
       expect(await contracts.musd.name()).to.equal("Mezo USD")
     })
+  })
 
-    it("symbol(): returns the token's symbol", async () => {
+  describe("symbol()", () => {
+    it("returns the token's symbol", async () => {
       expect(await contracts.musd.symbol()).to.equal("MUSD")
     })
+  })
 
-    it("decimals(): returns the token's decimals", async () => {
+  describe("decimals()", () => {
+    it("returns the token's decimals", async () => {
       expect(await contracts.musd.decimals()).to.equal("18")
     })
+  })
 
-    it("balanceOf(): gets the balance of the account", async () => {
+  describe("balanceOf()", () => {
+    it("gets the balance of the account", async () => {
       let balance = await contracts.musd.balanceOf(alice.wallet)
       expect(balance).to.be.eq(to1e18(150))
 
@@ -71,12 +77,16 @@ describe("MUSD", () => {
       balance = await contracts.musd.balanceOf(dennis.wallet)
       expect(balance).to.be.eq(to1e18(0))
     })
+  })
 
-    it("totalSupply(): gets the total supply", async () => {
+  describe("totalSupply()", () => {
+    it("gets the total supply", async () => {
       const total = await contracts.musd.totalSupply()
       expect(total).to.be.eq(to1e18(300))
     })
+  })
 
+  describe("burnList()", () => {
     it("Initial set of contracts was set correctly", async () => {
       expect(await contracts.musd.burnList(addresses.troveManager)).to.equal(
         true,
@@ -94,8 +104,8 @@ describe("MUSD", () => {
     })
   })
 
-  describe("Approving MUSD", () => {
-    it("allowance(): returns an account's spending allowance for another account's balance", async () => {
+  describe("allowance()", () => {
+    it("returns an account's spending allowance for another account's balance", async () => {
       await contracts.musd
         .connect(bob.wallet)
         .approve(alice.wallet, to1e18(100))
@@ -112,8 +122,10 @@ describe("MUSD", () => {
       expect(allowanceA).to.be.eq(to1e18(100))
       expect(allowanceD).to.be.eq(to1e18(0))
     })
+  })
 
-    it("approve(): approves an account to spend the specified amount", async () => {
+  describe("approve()", () => {
+    it("approves an account to spend the specified amount", async () => {
       const allowanceABefore = await contracts.musd.allowance(
         bob.wallet,
         alice.wallet,
@@ -131,27 +143,29 @@ describe("MUSD", () => {
       expect(allowanceAAfter).to.be.eq(to1e18(100))
     })
 
-    it("approve(): reverts when spender param is address(0)", async () => {
+    it("reverts when spender param is address(0)", async () => {
       await expect(
         contracts.musd.connect(bob.wallet).approve(ZERO_ADDRESS, to1e18(100)),
       ).to.be.reverted
     })
 
-    it("approve(): reverts when owner param is address(0)", async () => {
-      if ("callInternalApprove" in contracts.musd) {
-        await expect(
-          contracts.musd
-            .connect(bob.wallet)
-            .callInternalApprove(ZERO_ADDRESS, alice.wallet, to1e18(1000)),
-        ).to.be.reverted
-      } else {
-        assert.fail("MUSDTester not loaded in contracts.musd")
-      }
+    context("Expected Reverts", () => {
+      it("reverts when owner param is address(0)", async () => {
+        if ("callInternalApprove" in contracts.musd) {
+          await expect(
+            contracts.musd
+              .connect(bob.wallet)
+              .callInternalApprove(ZERO_ADDRESS, alice.wallet, to1e18(1000)),
+          ).to.be.reverted
+        } else {
+          assert.fail("MUSDTester not loaded in contracts.musd")
+        }
+      })
     })
   })
 
-  describe("Transferring MUSD", () => {
-    it("transferFrom(): successfully transfers from an account which is it approved to transfer from", async () => {
+  describe("transferFrom()", () => {
+    it("successfully transfers from an account which is it approved to transfer from", async () => {
       const allowanceA0 = await contracts.musd.allowance(
         bob.wallet,
         alice.wallet,
@@ -192,8 +206,10 @@ describe("MUSD", () => {
           .transferFrom(bob.wallet, carol.wallet, to1e18(50)),
       ).to.be.reverted
     })
+  })
 
-    it("transfer(): increases the recipient's balance by the correct amount", async () => {
+  describe("transfer()", () => {
+    it("increases the recipient's balance by the correct amount", async () => {
       expect(await contracts.musd.balanceOf(alice.wallet)).to.be.eq(to1e18(150))
 
       await contracts.musd
@@ -203,28 +219,34 @@ describe("MUSD", () => {
       expect(await contracts.musd.balanceOf(alice.wallet)).to.be.eq(to1e18(187))
     })
 
-    it("transfer(): reverts if amount exceeds sender's balance", async () => {
-      expect(await contracts.musd.balanceOf(bob.wallet)).to.be.eq(to1e18(100))
-      await expect(
-        contracts.musd.connect(bob.wallet).transfer(alice.wallet, to1e18(101)),
-      ).to.be.reverted
-    })
+    context("Expected Reverts", () => {
+      it("reverts if amount exceeds sender's balance", async () => {
+        expect(await contracts.musd.balanceOf(bob.wallet)).to.be.eq(to1e18(100))
+        await expect(
+          contracts.musd
+            .connect(bob.wallet)
+            .transfer(alice.wallet, to1e18(101)),
+        ).to.be.reverted
+      })
 
-    it("transfer(): transferring to a blacklisted address reverts", async () => {
-      await expect(
-        contracts.musd
-          .connect(alice.wallet)
-          .transfer(addresses.musd, to1e18(1)),
-      ).to.be.reverted
+      it("reverts when transferring to a blacklisted address", async () => {
+        await expect(
+          contracts.musd
+            .connect(alice.wallet)
+            .transfer(addresses.musd, to1e18(1)),
+        ).to.be.reverted
 
-      await expect(
-        contracts.musd.connect(alice.wallet).transfer(ZERO_ADDRESS, to1e18(1)),
-      ).to.be.reverted
+        await expect(
+          contracts.musd
+            .connect(alice.wallet)
+            .transfer(ZERO_ADDRESS, to1e18(1)),
+        ).to.be.reverted
+      })
     })
   })
 
-  describe("Minting and Burning MUSD", () => {
-    it("mint(): issues correct amount of tokens to the given address", async () => {
+  describe("mint()", () => {
+    it("issues correct amount of tokens to the given address", async () => {
       alice.musd.before = await contracts.musd.balanceOf(alice.wallet)
       expect(alice.musd.before).to.be.eq(to1e18(150))
 
@@ -233,8 +255,10 @@ describe("MUSD", () => {
       alice.musd.after = await contracts.musd.balanceOf(alice.wallet)
       await expect(alice.musd.after).to.be.eq(to1e18(250))
     })
+  })
 
-    it("burn(): burns correct amount of tokens from the given address", async () => {
+  describe("burn()", () => {
+    it("burns correct amount of tokens from the given address", async () => {
       alice.musd.before = await contracts.musd.balanceOf(alice.wallet)
       expect(alice.musd.before).to.be.eq(to1e18(150))
 
@@ -249,9 +273,43 @@ describe("MUSD", () => {
     })
   })
 
-  describe("Role based access", () => {
-    context("Adding New Collateral", () => {
-      it("startAddContracts(): reverts when caller is not owner", async () => {
+  describe("startAddContracts()", () => {
+    it("puts new set of contracts to pending list", async () => {
+      await contracts.musd
+        .connect(deployer.wallet)
+        .startAddContracts(
+          await newTroveManager.getAddress(),
+          await newStabilityPool.getAddress(),
+          await newBorrowerOperations.getAddress(),
+        )
+      const timeNow = await getLatestBlockTimestamp()
+      expect(await contracts.musd.pendingTroveManager()).to.be.eq(
+        await newTroveManager.getAddress(),
+      )
+      expect(await contracts.musd.pendingStabilityPool()).to.be.eq(
+        await newStabilityPool.getAddress(),
+      )
+      expect(await contracts.musd.pendingBorrowerOperations()).to.be.eq(
+        await newBorrowerOperations.getAddress(),
+      )
+      expect(await contracts.musd.addContractsInitiated()).to.be.eq(timeNow)
+
+      expect(
+        await contracts.musd.burnList(await newTroveManager.getAddress()),
+      ).to.equal(false)
+      expect(
+        await contracts.musd.burnList(await newStabilityPool.getAddress()),
+      ).to.equal(false)
+      expect(
+        await contracts.musd.burnList(await newBorrowerOperations.getAddress()),
+      ).to.equal(false)
+      expect(
+        await contracts.musd.mintList(await newBorrowerOperations.getAddress()),
+      ).to.equal(false)
+    })
+
+    context("Expected Reverts", () => {
+      it("reverts when caller is not owner", async () => {
         await expect(
           contracts.musd
             .connect(alice.wallet)
@@ -266,7 +324,7 @@ describe("MUSD", () => {
         )
       })
 
-      it("startAddContracts(): reverts when provided addresses are not contracts", async () => {
+      it("reverts when provided addresses are not contracts", async () => {
         await expect(
           contracts.musd
             .connect(deployer.wallet)
@@ -327,46 +385,44 @@ describe("MUSD", () => {
             ),
         ).to.be.revertedWith("Account cannot be zero address")
       })
+    })
+  })
 
-      it("startAddContracts(): puts new set of contracts to pending list", async () => {
-        await contracts.musd
-          .connect(deployer.wallet)
-          .startAddContracts(
-            await newTroveManager.getAddress(),
-            await newStabilityPool.getAddress(),
-            await newBorrowerOperations.getAddress(),
-          )
-        const timeNow = await getLatestBlockTimestamp()
-        expect(await contracts.musd.pendingTroveManager()).to.be.eq(
+  describe("cancelAddContracts()", () => {
+    it("cancels adding system contracts", async () => {
+      await contracts.musd
+        .connect(deployer.wallet)
+        .startAddContracts(
           await newTroveManager.getAddress(),
-        )
-        expect(await contracts.musd.pendingStabilityPool()).to.be.eq(
           await newStabilityPool.getAddress(),
-        )
-        expect(await contracts.musd.pendingBorrowerOperations()).to.be.eq(
           await newBorrowerOperations.getAddress(),
         )
-        expect(await contracts.musd.addContractsInitiated()).to.be.eq(timeNow)
 
-        expect(
-          await contracts.musd.burnList(await newTroveManager.getAddress()),
-        ).to.equal(false)
-        expect(
-          await contracts.musd.burnList(await newStabilityPool.getAddress()),
-        ).to.equal(false)
-        expect(
-          await contracts.musd.burnList(
-            await newBorrowerOperations.getAddress(),
-          ),
-        ).to.equal(false)
-        expect(
-          await contracts.musd.mintList(
-            await newBorrowerOperations.getAddress(),
-          ),
-        ).to.equal(false)
-      })
+      await contracts.musd.connect(deployer.wallet).cancelAddContracts()
 
-      it("cancelAddContracts(): reverts when caller is not owner", async () => {
+      expect(await contracts.musd.pendingTroveManager()).to.be.eq(ZERO_ADDRESS)
+      expect(await contracts.musd.pendingStabilityPool()).to.be.eq(ZERO_ADDRESS)
+      expect(await contracts.musd.pendingBorrowerOperations()).to.be.eq(
+        ZERO_ADDRESS,
+      )
+      expect(await contracts.musd.addContractsInitiated()).to.be.eq(0)
+
+      expect(
+        await contracts.musd.burnList(await newTroveManager.getAddress()),
+      ).to.equal(false)
+      expect(
+        await contracts.musd.burnList(await newStabilityPool.getAddress()),
+      ).equal(false)
+      expect(
+        await contracts.musd.burnList(await newBorrowerOperations.getAddress()),
+      ).to.equal(false)
+      expect(
+        await contracts.musd.mintList(await newBorrowerOperations.getAddress()),
+      ).to.equal(false)
+    })
+
+    context("Expected Reverts", () => {
+      it("reverts when caller is not owner", async () => {
         await expect(
           contracts.musd.connect(alice.wallet).cancelAddContracts(),
         ).to.be.revertedWithCustomError(
@@ -380,48 +436,63 @@ describe("MUSD", () => {
           contracts.musd.connect(deployer.wallet).cancelAddContracts(),
         ).to.be.revertedWith("Adding contracts is not started")
       })
+    })
+  })
 
-      it("cancelAddContracts(): cancels adding system contracts", async () => {
-        await contracts.musd
-          .connect(deployer.wallet)
-          .startAddContracts(
-            await newTroveManager.getAddress(),
-            await newStabilityPool.getAddress(),
-            await newBorrowerOperations.getAddress(),
-          )
-
-        await contracts.musd.connect(deployer.wallet).cancelAddContracts()
-
-        expect(await contracts.musd.pendingTroveManager()).to.be.eq(
-          ZERO_ADDRESS,
+  describe("finalizeAddContracts()", () => {
+    it("enables new system contracts roles", async () => {
+      await contracts.musd
+        .connect(deployer.wallet)
+        .startAddContracts(
+          await newTroveManager.getAddress(),
+          await newStabilityPool.getAddress(),
+          await newBorrowerOperations.getAddress(),
         )
-        expect(await contracts.musd.pendingStabilityPool()).to.be.eq(
-          ZERO_ADDRESS,
-        )
-        expect(await contracts.musd.pendingBorrowerOperations()).to.be.eq(
-          ZERO_ADDRESS,
-        )
-        expect(await contracts.musd.addContractsInitiated()).to.be.eq(0)
+      await fastForwardTime(GOVERNANCE_TIME_DELAY + 1)
 
-        expect(
-          await contracts.musd.burnList(await newTroveManager.getAddress()),
-        ).to.equal(false)
-        expect(
-          await contracts.musd.burnList(await newStabilityPool.getAddress()),
-        ).equal(false)
-        expect(
-          await contracts.musd.burnList(
-            await newBorrowerOperations.getAddress(),
-          ),
-        ).to.equal(false)
-        expect(
-          await contracts.musd.mintList(
-            await newBorrowerOperations.getAddress(),
-          ),
-        ).to.equal(false)
-      })
+      const tx = await contracts.musd
+        .connect(deployer.wallet)
+        .finalizeAddContracts()
 
-      it("finalizeAddContracts(): reverts when caller is not owner", async () => {
+      expect(await contracts.musd.pendingTroveManager()).to.be.eq(ZERO_ADDRESS)
+      expect(await contracts.musd.pendingStabilityPool()).to.be.eq(ZERO_ADDRESS)
+      expect(await contracts.musd.pendingBorrowerOperations()).to.be.eq(
+        ZERO_ADDRESS,
+      )
+      expect(await contracts.musd.addContractsInitiated()).to.be.eq(0)
+
+      expect(await contracts.musd.burnList(addresses.troveManager)).to.equal(
+        true,
+      )
+      expect(
+        await contracts.musd.burnList(await newTroveManager.getAddress()),
+      ).to.equal(true)
+      expect(await contracts.musd.burnList(addresses.stabilityPool)).to.equal(
+        true,
+      )
+      expect(
+        await contracts.musd.burnList(await newStabilityPool.getAddress()),
+      ).to.equal(true)
+      expect(
+        await contracts.musd.burnList(await newBorrowerOperations.getAddress()),
+      ).to.equal(true)
+      expect(
+        await contracts.musd.burnList(addresses.borrowerOperations),
+      ).to.equal(true)
+
+      await expect(tx)
+        .to.emit(contracts.musd, "TroveManagerAddressAdded")
+        .withArgs(await newTroveManager.getAddress())
+      await expect(tx)
+        .to.emit(contracts.musd, "StabilityPoolAddressAdded")
+        .withArgs(await newStabilityPool.getAddress())
+      await expect(tx)
+        .to.emit(contracts.musd, "BorrowerOperationsAddressAdded")
+        .withArgs(await newBorrowerOperations.getAddress())
+    })
+
+    context("Expected Reverts", () => {
+      it("reverts when caller is not owner", async () => {
         await expect(
           contracts.musd.connect(alice.wallet).finalizeAddContracts(),
         ).to.be.revertedWithCustomError(
@@ -430,13 +501,13 @@ describe("MUSD", () => {
         )
       })
 
-      it("finalizeAddContracts(): reverts when change is not initiated", async () => {
+      it("reverts when change is not initiated", async () => {
         await expect(
           contracts.musd.connect(deployer.wallet).finalizeAddContracts(),
         ).to.be.revertedWith("Change not initiated")
       })
 
-      it("finalizeAddContracts(): reverts when not enough time has passed", async () => {
+      it("reverts when not enough time has passed", async () => {
         await contracts.musd
           .connect(deployer.wallet)
           .startAddContracts(
@@ -449,67 +520,29 @@ describe("MUSD", () => {
           contracts.musd.connect(deployer.wallet).finalizeAddContracts(),
         ).to.be.revertedWith("Governance delay has not elapsed")
       })
+    })
+  })
 
-      it("finalizeAddContracts(): enables new system contracts roles", async () => {
-        await contracts.musd
-          .connect(deployer.wallet)
-          .startAddContracts(
-            await newTroveManager.getAddress(),
-            await newStabilityPool.getAddress(),
-            await newBorrowerOperations.getAddress(),
-          )
-        await fastForwardTime(GOVERNANCE_TIME_DELAY + 1)
+  describe("startRevokeMintList()", () => {
+    it("puts account to pending list", async () => {
+      await contracts.musd
+        .connect(deployer.wallet)
+        .startRevokeMintList(addresses.borrowerOperations)
 
-        const tx = await contracts.musd
-          .connect(deployer.wallet)
-          .finalizeAddContracts()
-
-        expect(await contracts.musd.pendingTroveManager()).to.be.eq(
-          ZERO_ADDRESS,
-        )
-        expect(await contracts.musd.pendingStabilityPool()).to.be.eq(
-          ZERO_ADDRESS,
-        )
-        expect(await contracts.musd.pendingBorrowerOperations()).to.be.eq(
-          ZERO_ADDRESS,
-        )
-        expect(await contracts.musd.addContractsInitiated()).to.be.eq(0)
-
-        expect(await contracts.musd.burnList(addresses.troveManager)).to.equal(
-          true,
-        )
-        expect(
-          await contracts.musd.burnList(await newTroveManager.getAddress()),
-        ).to.equal(true)
-        expect(await contracts.musd.burnList(addresses.stabilityPool)).to.equal(
-          true,
-        )
-        expect(
-          await contracts.musd.burnList(await newStabilityPool.getAddress()),
-        ).to.equal(true)
-        expect(
-          await contracts.musd.burnList(
-            await newBorrowerOperations.getAddress(),
-          ),
-        ).to.equal(true)
-        expect(
-          await contracts.musd.burnList(addresses.borrowerOperations),
-        ).to.equal(true)
-
-        await expect(tx)
-          .to.emit(contracts.musd, "TroveManagerAddressAdded")
-          .withArgs(await newTroveManager.getAddress())
-        await expect(tx)
-          .to.emit(contracts.musd, "StabilityPoolAddressAdded")
-          .withArgs(await newStabilityPool.getAddress())
-        await expect(tx)
-          .to.emit(contracts.musd, "BorrowerOperationsAddressAdded")
-          .withArgs(await newBorrowerOperations.getAddress())
-      })
+      const timeNow = await getLatestBlockTimestamp()
+      expect(await contracts.musd.pendingRevokedMintAddress()).to.be.equal(
+        addresses.borrowerOperations,
+      )
+      expect(await contracts.musd.revokeMintListInitiated()).to.be.equal(
+        timeNow,
+      )
+      expect(
+        await contracts.musd.mintList(addresses.borrowerOperations),
+      ).to.equal(true)
     })
 
-    context("Removing Mint Permissions", () => {
-      it("startRevokeMintList(): reverts when caller is not owner", async () => {
+    context("Expected Reverts", () => {
+      it("reverts when caller is not owner", async () => {
         await expect(
           contracts.musd
             .connect(alice.wallet)
@@ -520,32 +553,34 @@ describe("MUSD", () => {
         )
       })
 
-      it("startRevokeMintList(): reverts when account has no minting role", async () => {
+      it("reverts when account has no minting role", async () => {
         await expect(
           contracts.musd
             .connect(deployer.wallet)
             .startRevokeMintList(alice.wallet),
         ).to.be.revertedWith("Incorrect address to revoke")
       })
+    })
+  })
 
-      it("startRevokeMintList(): puts account to pending list", async () => {
-        await contracts.musd
-          .connect(deployer.wallet)
-          .startRevokeMintList(addresses.borrowerOperations)
+  describe("cancelRevokeMintList()", () => {
+    it("cancels revoking from mint list", async () => {
+      await contracts.musd
+        .connect(deployer.wallet)
+        .startRevokeMintList(addresses.borrowerOperations)
+      await contracts.musd.connect(deployer.wallet).cancelRevokeMintList()
 
-        const timeNow = await getLatestBlockTimestamp()
-        expect(await contracts.musd.pendingRevokedMintAddress()).to.be.equal(
-          addresses.borrowerOperations,
-        )
-        expect(await contracts.musd.revokeMintListInitiated()).to.be.equal(
-          timeNow,
-        )
-        expect(
-          await contracts.musd.mintList(addresses.borrowerOperations),
-        ).to.equal(true)
-      })
+      expect(await contracts.musd.pendingRevokedMintAddress()).to.be.equal(
+        ZERO_ADDRESS,
+      )
+      expect(await contracts.musd.revokeMintListInitiated()).to.be.equal(0)
+      expect(
+        await contracts.musd.mintList(addresses.borrowerOperations),
+      ).to.equal(true)
+    })
 
-      it("cancelRevokeMintList(): reverts when caller is not owner", async () => {
+    context("Expected Reverts", () => {
+      it("reverts when caller is not owner", async () => {
         await expect(
           contracts.musd.connect(alice.wallet).cancelRevokeMintList(),
         ).to.be.revertedWithCustomError(
@@ -554,28 +589,34 @@ describe("MUSD", () => {
         )
       })
 
-      it("cancelRevokeMintList(): reverts when change is not initiated", async () => {
+      it("reverts when change is not initiated", async () => {
         await expect(
           contracts.musd.connect(deployer.wallet).cancelRevokeMintList(),
         ).to.be.revertedWith("Revoking from mint list is not started")
       })
+    })
+  })
 
-      it("cancelRevokeMintList(): cancels revoking from mint list", async () => {
-        await contracts.musd
-          .connect(deployer.wallet)
-          .startRevokeMintList(addresses.borrowerOperations)
-        await contracts.musd.connect(deployer.wallet).cancelRevokeMintList()
+  describe("finalizeRevokeMintList()", () => {
+    it("removes account from minting list", async () => {
+      await contracts.musd
+        .connect(deployer.wallet)
+        .startRevokeMintList(addresses.borrowerOperations)
+      await fastForwardTime(GOVERNANCE_TIME_DELAY + 1)
 
-        expect(await contracts.musd.pendingRevokedMintAddress()).to.be.equal(
-          ZERO_ADDRESS,
-        )
-        expect(await contracts.musd.revokeMintListInitiated()).to.be.equal(0)
-        expect(
-          await contracts.musd.mintList(addresses.borrowerOperations),
-        ).to.equal(true)
-      })
+      await contracts.musd.connect(deployer.wallet).finalizeRevokeMintList()
 
-      it("finalizeRevokeMintList(): reverts when caller is not owner", async () => {
+      expect(await contracts.musd.pendingRevokedMintAddress()).to.be.equal(
+        ZERO_ADDRESS,
+      )
+      expect(await contracts.musd.revokeMintListInitiated()).to.be.equal(0)
+      expect(
+        await contracts.musd.mintList(addresses.borrowerOperations),
+      ).to.equal(false)
+    })
+
+    context("Expected Reverts", () => {
+      it("reverts when caller is not owner", async () => {
         await expect(
           contracts.musd.connect(alice.wallet).finalizeRevokeMintList(),
         ).to.be.revertedWithCustomError(
@@ -584,13 +625,13 @@ describe("MUSD", () => {
         )
       })
 
-      it("finalizeRevokeMintList(): reverts when change is not initiated", async () => {
+      it("reverts when change is not initiated", async () => {
         await expect(
           contracts.musd.connect(deployer.wallet).finalizeRevokeMintList(),
         ).to.be.revertedWith("Change not initiated")
       })
 
-      it("finalizeRevokeMintList(): reverts when passed not enough time", async () => {
+      it("reverts when passed not enough time", async () => {
         await contracts.musd
           .connect(deployer.wallet)
           .startRevokeMintList(addresses.borrowerOperations)
@@ -598,27 +639,25 @@ describe("MUSD", () => {
           contracts.musd.connect(deployer.wallet).finalizeRevokeMintList(),
         ).to.be.revertedWith("Governance delay has not elapsed")
       })
+    })
+  })
 
-      it("finalizeRevokeMintList(): removes account from minting list", async () => {
-        await contracts.musd
-          .connect(deployer.wallet)
-          .startRevokeMintList(addresses.borrowerOperations)
-        await fastForwardTime(GOVERNANCE_TIME_DELAY + 1)
+  describe("startAddMintList()", () => {
+    it("puts account to pending list", async () => {
+      await contracts.musd
+        .connect(deployer.wallet)
+        .startAddMintList(alice.wallet)
 
-        await contracts.musd.connect(deployer.wallet).finalizeRevokeMintList()
-
-        expect(await contracts.musd.pendingRevokedMintAddress()).to.be.equal(
-          ZERO_ADDRESS,
-        )
-        expect(await contracts.musd.revokeMintListInitiated()).to.be.equal(0)
-        expect(
-          await contracts.musd.mintList(addresses.borrowerOperations),
-        ).to.equal(false)
-      })
+      const timeNow = await getLatestBlockTimestamp()
+      expect(await contracts.musd.pendingAddedMintAddress()).to.be.equal(
+        alice.wallet,
+      )
+      expect(await contracts.musd.addMintListInitiated()).to.be.equal(timeNow)
+      expect(await contracts.musd.mintList(alice.wallet)).to.equal(false)
     })
 
-    context("Mintlist Changes", () => {
-      it("startAddMintList(): reverts when caller is not owner", async () => {
+    context("Expected Reverts", () => {
+      it("reverts when caller is not owner", async () => {
         await expect(
           contracts.musd.connect(alice.wallet).startAddMintList(alice.wallet),
         ).to.be.revertedWithCustomError(
@@ -627,56 +666,57 @@ describe("MUSD", () => {
         )
       })
 
-      it("startAddMintList(): reverts when account already has minting role", async () => {
+      it("reverts when account already has minting role", async () => {
         await expect(
           contracts.musd
             .connect(deployer.wallet)
             .startAddMintList(addresses.borrowerOperations),
         ).to.be.revertedWith("Incorrect address to add")
       })
+    })
+  })
 
-      it("startAddMintList(): puts account to pending list", async () => {
-        await contracts.musd
-          .connect(deployer.wallet)
-          .startAddMintList(alice.wallet)
+  describe("cancelAddMintList()", () => {
+    it("cancels adding to mint list", async () => {
+      await contracts.musd
+        .connect(deployer.wallet)
+        .startAddMintList(alice.wallet)
+      await contracts.musd.connect(deployer.wallet).cancelAddMintList()
 
-        const timeNow = await getLatestBlockTimestamp()
-        expect(await contracts.musd.pendingAddedMintAddress()).to.be.equal(
-          alice.wallet,
-        )
-        expect(await contracts.musd.addMintListInitiated()).to.be.equal(timeNow)
-        expect(await contracts.musd.mintList(alice.wallet)).to.equal(false)
-      })
+      expect(await contracts.musd.pendingAddedMintAddress()).to.be.equal(
+        ZERO_ADDRESS,
+      )
+      expect(await contracts.musd.addMintListInitiated()).to.be.equal(0)
+      expect(await contracts.musd.mintList(alice.wallet)).to.equal(false)
+    })
 
-      it("cancelAddMintList(): reverts when caller is not owner", async () => {
-        await expect(
-          contracts.musd.connect(alice.wallet).cancelAddMintList(),
-        ).to.be.revertedWithCustomError(
-          contracts.musd,
-          "OwnableUnauthorizedAccount",
-        )
-      })
-
-      it("cancelAddMintList(): reverts when change is not initiated", async () => {
+    context("Expected Reverts", () => {
+      it("reverts when change is not initiated", async () => {
         await expect(
           contracts.musd.connect(deployer.wallet).cancelAddMintList(),
         ).to.be.revertedWith("Adding to mint list is not started")
       })
+    })
+  })
 
-      it("cancelAddMintList(): cancels adding to mint list", async () => {
-        await contracts.musd
-          .connect(deployer.wallet)
-          .startAddMintList(alice.wallet)
-        await contracts.musd.connect(deployer.wallet).cancelAddMintList()
+  describe("finalizeAddMintList()", () => {
+    it("adds account to minting list", async () => {
+      await contracts.musd
+        .connect(deployer.wallet)
+        .startAddMintList(alice.wallet)
+      await fastForwardTime(GOVERNANCE_TIME_DELAY + 1)
 
-        expect(await contracts.musd.pendingAddedMintAddress()).to.be.equal(
-          ZERO_ADDRESS,
-        )
-        expect(await contracts.musd.addMintListInitiated()).to.be.equal(0)
-        expect(await contracts.musd.mintList(alice.wallet)).to.equal(false)
-      })
+      await contracts.musd.connect(deployer.wallet).finalizeAddMintList()
 
-      it("finalizeAddMintList(): reverts when caller is not owner", async () => {
+      expect(await contracts.musd.pendingAddedMintAddress()).to.be.equal(
+        ZERO_ADDRESS,
+      )
+      expect(await contracts.musd.addMintListInitiated()).to.be.equal(0)
+      expect(await contracts.musd.mintList(alice.wallet)).to.equal(true)
+    })
+
+    context("Expected Reverts", () => {
+      it("reverts when caller is not owner", async () => {
         await expect(
           contracts.musd.connect(alice.wallet).finalizeAddMintList(),
         ).to.be.revertedWithCustomError(
@@ -685,13 +725,13 @@ describe("MUSD", () => {
         )
       })
 
-      it("finalizeAddMintList(): reverts when change is not initiated", async () => {
+      it("reverts when change is not initiated", async () => {
         await expect(
           contracts.musd.connect(deployer.wallet).finalizeAddMintList(),
         ).to.be.revertedWith("Change not initiated")
       })
 
-      it("finalizeAddMintList(): reverts when passed not enough time", async () => {
+      it("reverts when passed not enough time", async () => {
         await contracts.musd
           .connect(deployer.wallet)
           .startAddMintList(alice.wallet)
@@ -699,25 +739,30 @@ describe("MUSD", () => {
           contracts.musd.connect(deployer.wallet).finalizeAddMintList(),
         ).to.be.revertedWith("Governance delay has not elapsed")
       })
+    })
+  })
 
-      it("finalizeAddMintList(): adds account to minting list", async () => {
-        await contracts.musd
-          .connect(deployer.wallet)
-          .startAddMintList(alice.wallet)
-        await fastForwardTime(GOVERNANCE_TIME_DELAY + 1)
+  describe("startRevokeBurnList()", () => {
+    it("puts account to pending list", async () => {
+      await contracts.musd
+        .connect(deployer.wallet)
+        .startRevokeBurnList(addresses.borrowerOperations)
 
-        await contracts.musd.connect(deployer.wallet).finalizeAddMintList()
+      const timeNow = await getLatestBlockTimestamp()
+      expect(await contracts.musd.pendingRevokedBurnAddress()).to.be.equal(
+        addresses.borrowerOperations,
+      )
+      expect(await contracts.musd.revokeBurnListInitiated()).to.be.equal(
+        timeNow,
+      )
 
-        expect(await contracts.musd.pendingAddedMintAddress()).to.be.equal(
-          ZERO_ADDRESS,
-        )
-        expect(await contracts.musd.addMintListInitiated()).to.be.equal(0)
-        expect(await contracts.musd.mintList(alice.wallet)).to.equal(true)
-      })
+      expect(
+        await contracts.musd.burnList(addresses.borrowerOperations),
+      ).to.equal(true)
     })
 
-    context("Burnlist Changes", () => {
-      it("startRevokeBurnList(): reverts when caller is not owner", async () => {
+    context("Expected Reverts", () => {
+      it("reverts when caller is not owner", async () => {
         await expect(
           contracts.musd
             .connect(alice.wallet)
@@ -728,33 +773,35 @@ describe("MUSD", () => {
         )
       })
 
-      it("startRevokeBurnList(): reverts when account has no burning role", async () => {
+      it("reverts when account has no burning role", async () => {
         await expect(
           contracts.musd
             .connect(deployer.wallet)
             .startRevokeBurnList(alice.wallet),
         ).to.be.revertedWith("Incorrect address to revoke")
       })
+    })
+  })
 
-      it("startRevokeBurnList(): puts account to pending list", async () => {
-        await contracts.musd
-          .connect(deployer.wallet)
-          .startRevokeBurnList(addresses.borrowerOperations)
+  describe("cancelRevokeBurnList()", () => {
+    it("cancels revoking from burn list", async () => {
+      await contracts.musd
+        .connect(deployer.wallet)
+        .startRevokeBurnList(addresses.borrowerOperations)
+      await contracts.musd.connect(deployer.wallet).cancelRevokeBurnList()
 
-        const timeNow = await getLatestBlockTimestamp()
-        expect(await contracts.musd.pendingRevokedBurnAddress()).to.be.equal(
-          addresses.borrowerOperations,
-        )
-        expect(await contracts.musd.revokeBurnListInitiated()).to.be.equal(
-          timeNow,
-        )
+      expect(await contracts.musd.pendingRevokedBurnAddress()).to.be.equal(
+        ZERO_ADDRESS,
+      )
+      expect(await contracts.musd.revokeBurnListInitiated()).to.be.equal(0)
 
-        expect(
-          await contracts.musd.burnList(addresses.borrowerOperations),
-        ).to.equal(true)
-      })
+      expect(
+        await contracts.musd.burnList(addresses.borrowerOperations),
+      ).to.equal(true)
+    })
 
-      it("cancelRevokeBurnList(): reverts when caller is not owner", async () => {
+    context("Expected Reverts", () => {
+      it("reverts when caller is not owner", async () => {
         await expect(
           contracts.musd.connect(alice.wallet).cancelRevokeBurnList(),
         ).to.be.revertedWithCustomError(
@@ -763,29 +810,35 @@ describe("MUSD", () => {
         )
       })
 
-      it("cancelRevokeBurnList(): reverts when change is not initiated", async () => {
+      it("reverts when change is not initiated", async () => {
         await expect(
           contracts.musd.connect(deployer.wallet).cancelRevokeBurnList(),
         ).to.be.revertedWith("Revoking from burn list is not started")
       })
+    })
+  })
 
-      it("cancelRevokeBurnList(): cancels revoking from burn list", async () => {
-        await contracts.musd
-          .connect(deployer.wallet)
-          .startRevokeBurnList(addresses.borrowerOperations)
-        await contracts.musd.connect(deployer.wallet).cancelRevokeBurnList()
+  describe("finalizeRevokeBurnList()", () => {
+    it("removes account from minting list", async () => {
+      await contracts.musd
+        .connect(deployer.wallet)
+        .startRevokeBurnList(addresses.borrowerOperations)
+      await fastForwardTime(GOVERNANCE_TIME_DELAY + 1)
 
-        expect(await contracts.musd.pendingRevokedBurnAddress()).to.be.equal(
-          ZERO_ADDRESS,
-        )
-        expect(await contracts.musd.revokeBurnListInitiated()).to.be.equal(0)
+      await contracts.musd.connect(deployer.wallet).finalizeRevokeBurnList()
 
-        expect(
-          await contracts.musd.burnList(addresses.borrowerOperations),
-        ).to.equal(true)
-      })
+      expect(await contracts.musd.pendingRevokedBurnAddress()).to.be.equal(
+        ZERO_ADDRESS,
+      )
+      expect(await contracts.musd.revokeBurnListInitiated()).to.be.equal(0)
 
-      it("finalizeRevokeBurnList(): reverts when caller is not owner", async () => {
+      expect(
+        await contracts.musd.burnList(addresses.borrowerOperations),
+      ).to.equal(false)
+    })
+
+    context("Expected Reverts", () => {
+      it("reverts when caller is not owner", async () => {
         await expect(
           contracts.musd.connect(alice.wallet).finalizeRevokeBurnList(),
         ).to.be.revertedWithCustomError(
@@ -794,37 +847,19 @@ describe("MUSD", () => {
         )
       })
 
-      it("finalizeRevokeBurnList(): reverts when change is not initiated", async () => {
+      it("reverts when change is not initiated", async () => {
         await expect(
           contracts.musd.connect(deployer.wallet).finalizeRevokeBurnList(),
         ).to.be.revertedWith("Change not initiated")
       })
 
-      it("finalizeRevokeBurnList(): reverts when passed not enough time", async () => {
+      it("reverts when passed not enough time", async () => {
         await contracts.musd
           .connect(deployer.wallet)
           .startRevokeBurnList(addresses.borrowerOperations)
         await expect(
           contracts.musd.connect(deployer.wallet).finalizeRevokeBurnList(),
         ).to.be.revertedWith("Governance delay has not elapsed")
-      })
-
-      it("finalizeRevokeBurnList(): removes account from minting list", async () => {
-        await contracts.musd
-          .connect(deployer.wallet)
-          .startRevokeBurnList(addresses.borrowerOperations)
-        await fastForwardTime(GOVERNANCE_TIME_DELAY + 1)
-
-        await contracts.musd.connect(deployer.wallet).finalizeRevokeBurnList()
-
-        expect(await contracts.musd.pendingRevokedBurnAddress()).to.be.equal(
-          ZERO_ADDRESS,
-        )
-        expect(await contracts.musd.revokeBurnListInitiated()).to.be.equal(0)
-
-        expect(
-          await contracts.musd.burnList(addresses.borrowerOperations),
-        ).to.equal(false)
       })
     })
   })

--- a/solidity/test/normal/ActivePool.test.ts
+++ b/solidity/test/normal/ActivePool.test.ts
@@ -31,49 +31,20 @@ describe("ActivePool", () => {
     )
   })
 
-  /**
-   *
-   * Expected Reverts
-   *
-   */
-  context("Expected Reverts", () => {})
-
-  /**
-   *
-   * Emitted Events
-   *
-   */
-  context("Emitted Events", () => {})
-
-  /**
-   *
-   * System State Changes
-   *
-   */
-  context("System State Changes", () => {})
-
-  /**
-   *
-   * Individual Troves
-   *
-   */
-  context("Individual Troves", () => {})
-
-  /**
-   *
-   * Balance changes
-   *
-   */
-  context("Balance changes", () => {
-    it("getCollateralBalance(): gets the recorded collateral balance", async () => {
+  describe("getCollateralBalance()", () => {
+    it("gets the recorded collateral balance", async () => {
       expect(await contracts.activePool.getCollateralBalance()).to.equal(0)
     })
+  })
 
-    it("getMUSDDebt(): gets the recorded MUSD balance", async () => {
+  describe("getMUSDDebt()", () => {
+    it("gets the recorded MUSD balance", async () => {
       expect(await contracts.activePool.getMUSDDebt()).to.equal(0)
     })
+  })
 
-    it("increaseMUSDDebt(): increases the recorded MUSD balance by the correct amount", async () => {
+  describe("increaseMUSDDebt()", () => {
+    it("increases the recorded MUSD balance by the correct amount", async () => {
       await updateContractsSnapshot(
         contracts,
         state,
@@ -99,8 +70,10 @@ describe("ActivePool", () => {
         state.activePool.debt.after - state.activePool.debt.before,
       ).to.equal(amount)
     })
+  })
 
-    it("decreaseMUSDDebt(): decreases the recorded MUSD balance by the correct amount", async () => {
+  describe("decreaseMUSDDebt()", () => {
+    it("decreases the recorded MUSD balance by the correct amount", async () => {
       const initialAmount = to1e18("100")
 
       await contracts.activePool
@@ -134,18 +107,4 @@ describe("ActivePool", () => {
       )
     })
   })
-
-  /**
-   *
-   * Fees
-   *
-   */
-  context("Fees", () => {})
-
-  /**
-   *
-   * State change in other contracts
-   *
-   */
-  context("State change in other contracts", () => {})
 })

--- a/solidity/test/normal/BorrowerOperations.test.ts
+++ b/solidity/test/normal/BorrowerOperations.test.ts
@@ -142,16 +142,16 @@ describe("BorrowerOperations in Normal Mode", () => {
     await defaultTrovesSetup()
   })
 
-  describe("Initial State", () => {
-    it("name(): Returns the contract's name", async () => {
+  describe("name()", () => {
+    it("Returns the contract's name", async () => {
       expect(await contracts.borrowerOperations.name()).to.equal(
         "BorrowerOperations",
       )
     })
   })
 
-  describe("Helper functions", () => {
-    it("setNewRate(): Changes the base", async () => {
+  describe("setNewRate()", () => {
+    it("Changes the base", async () => {
       const baseRateBefore = await contracts.troveManager.baseRate()
       const newRate = to1e18(5) / 100n
       await setNewRate(newRate)
@@ -163,14 +163,585 @@ describe("BorrowerOperations in Normal Mode", () => {
   })
 
   describe("openTrove()", () => {
-    /**
-     *
-     * Expected Reverts
-     *
-     */
+    it("Decays a non-zero base rate", async () => {
+      // setup
+      const newRate = to1e18(5) / 100n
+      await setNewRate(newRate)
+
+      // Check baseRate is now non-zero
+      const baseRate1 = await contracts.troveManager.baseRate()
+      expect(baseRate1).is.equal(newRate)
+
+      // 2 hours pass
+      await fastForwardTime(7200)
+
+      // Dennis opens trove
+      await openTrove(contracts, {
+        musdAmount: "2,037",
+        sender: dennis.wallet,
+      })
+
+      // Check baseRate has decreased
+      const baseRate2 = await contracts.troveManager.baseRate()
+      expect(baseRate2).is.lessThan(baseRate1)
+
+      // 1 hour passes
+      await fastForwardTime(3600)
+
+      // Eric opens trove
+      await openTrove(contracts, {
+        musdAmount: "2,012",
+        sender: eric.wallet,
+      })
+
+      const baseRate3 = await contracts.troveManager.baseRate()
+      expect(baseRate3).is.lessThan(baseRate2)
+    })
+
+    it("Doesn't change base rate if it is already zero", async () => {
+      // Check baseRate is zero
+      expect(await contracts.troveManager.baseRate()).to.equal(0)
+
+      // 2 hours pass
+      await fastForwardTime(7200)
+
+      // Dennis opens trove
+      await openTrove(contracts, {
+        musdAmount: "2,000",
+        sender: dennis.wallet,
+      })
+
+      // Check baseRate is still 0
+      expect(await contracts.troveManager.baseRate()).to.equal(0)
+
+      // 1 hour passes
+      await fastForwardTime(3600)
+
+      // Eric opens trove
+      await openTrove(contracts, {
+        musdAmount: "2,000",
+        sender: eric.wallet,
+      })
+
+      expect(await contracts.troveManager.baseRate()).to.equal(0)
+    })
+
+    it("Doesn't update lastFeeOpTime if less time than decay interval has passed since the last fee operation", async () => {
+      const newRate = to1e18(5) / 100n
+      await setNewRate(newRate)
+      const lastFeeOpTime1 = await contracts.troveManager.lastFeeOperationTime()
+
+      // Dennis triggers a fee
+      await openTrove(contracts, {
+        musdAmount: "2,000",
+        sender: dennis.wallet,
+      })
+      const lastFeeOpTime2 = await contracts.troveManager.lastFeeOperationTime()
+
+      // Check that the last fee operation time did not update, as borrower D's debt issuance occured
+      // since before minimum interval had passed
+      expect(lastFeeOpTime2).to.equal(lastFeeOpTime1)
+
+      // 1 minute passes
+      await fastForwardTime(60)
+
+      // Check that now, at least one minute has passed since lastFeeOpTime_1
+      const timeNow = await getLatestBlockTimestamp()
+      expect(BigInt(timeNow)).to.be.oneOf([
+        lastFeeOpTime1 + 60n,
+        lastFeeOpTime1 + 61n,
+        lastFeeOpTime1 + 62n,
+      ])
+
+      // Eric triggers a fee
+      await openTrove(contracts, {
+        musdAmount: "2,000",
+        sender: eric.wallet,
+      })
+      const lastFeeOpTime3 = await contracts.troveManager.lastFeeOperationTime()
+
+      // Check that the last fee operation time DID update, as borrower's debt issuance occured
+      // after minimum interval had passed
+      expect(lastFeeOpTime3).to.greaterThan(lastFeeOpTime1)
+    })
+
+    it("Borrower can't grief the baseRate and stop it decaying by issuing debt at higher frequency than the decay granularity", async () => {
+      const newRate = to1e18(5) / 100n
+      await setNewRate(newRate)
+
+      // 59 minutes pass
+      fastForwardTime(3540)
+
+      // Borrower triggers a fee, before 60 minute decay interval has passed
+      await openTrove(contracts, {
+        musdAmount: "20,000",
+        sender: dennis.wallet,
+      })
+
+      // 1 minute pass
+      fastForwardTime(60)
+
+      // Borrower triggers another fee
+      await openTrove(contracts, {
+        musdAmount: "20,000",
+        sender: eric.wallet,
+      })
+
+      // Check base rate has decreased even though Borrower tried to stop it decaying
+      expect(await contracts.troveManager.baseRate()).is.lessThan(newRate)
+    })
+
+    it("Opens a trove with net debt >= minimum net debt", async () => {
+      await openTrove(contracts, {
+        musdAmount: MIN_NET_DEBT,
+        sender: carol.wallet,
+      })
+
+      expect(await contracts.sortedTroves.contains(carol.wallet)).to.equal(true)
+
+      await openTrove(contracts, {
+        musdAmount: "477,898,980",
+        sender: eric.wallet,
+      })
+      expect(await contracts.sortedTroves.contains(eric.address)).to.equal(true)
+    })
+
+    it("Succeeds when fee is less than max fee percentage", async () => {
+      // setup
+      const newRate = to1e18(5) / 100n
+      await setNewRate(newRate)
+
+      // Attempt with maxFee > 5%
+      await openTrove(contracts, {
+        musdAmount: "10,000",
+        sender: dennis.wallet,
+        maxFeePercentage: "5.0000000000000001",
+      })
+      expect(await contracts.musd.balanceOf(dennis.wallet)).to.equal(
+        to1e18("10,000"),
+      )
+
+      // Attempt with maxFee 100%
+      await openTrove(contracts, {
+        musdAmount: "20,000",
+        sender: eric.wallet,
+        maxFeePercentage: "100",
+      })
+      expect(await contracts.musd.balanceOf(eric.wallet)).to.equal(
+        to1e18("20,000"),
+      )
+    })
+
+    it("Borrowing at non-zero base records the (drawn debt + fee  + liq. reserve) on the Trove struct", async () => {
+      const abi = [
+        // Add your contract ABI here
+        "event MUSDBorrowingFeePaid(address indexed _borrower, uint256 _MUSDFee)",
+      ]
+
+      const musdAmount = to1e18("20,000")
+      const newRate = to1e18(5) / 100n
+      await setNewRate(newRate)
+
+      fastForwardTime(7200)
+
+      const { tx } = await openTrove(contracts, {
+        musdAmount,
+        sender: dennis.wallet,
+      })
+
+      const emittedFee = await getEventArgByName(
+        tx,
+        abi,
+        "MUSDBorrowingFeePaid",
+        1,
+      )
+      expect(emittedFee).to.greaterThan(0)
+
+      await updateTroveSnapshot(contracts, dennis, "after")
+
+      // Check debt on Trove struct equals drawn debt plus emitted fee
+      expect(dennis.trove.debt.after).is.equal(
+        emittedFee + MUSD_GAS_COMPENSATION + musdAmount,
+      )
+    })
+
+    it("Creates a new Trove and assigns the correct collateral and debt amount", async () => {
+      await updateTroveSnapshot(contracts, carol, "before")
+
+      expect(carol.trove.debt.before).is.equal(0)
+      expect(carol.trove.collateral.before).is.equal(0)
+      expect(carol.trove.status.before).is.equal(0)
+
+      await openTrove(contracts, {
+        musdAmount: MIN_NET_DEBT,
+        sender: carol.wallet,
+      })
+
+      // Get the expected debt based on the MUSD request (adding fee and liq. reserve on top)
+      const expectedDebt =
+        MIN_NET_DEBT +
+        (await contracts.troveManager.getBorrowingFee(MIN_NET_DEBT)) +
+        MUSD_GAS_COMPENSATION
+
+      await updateTroveSnapshot(contracts, carol, "after")
+
+      expect(carol.trove.collateral.after).is.greaterThan(
+        carol.trove.collateral.before,
+      )
+      expect(carol.trove.debt.after).is.greaterThan(carol.trove.debt.before)
+      expect(carol.trove.debt.after).is.equal(expectedDebt)
+      expect(carol.trove.status.after).is.equal(1n)
+    })
+
+    it("Allows a user to open a Trove, then close it, then re-open it", async () => {
+      // Send MUSD to Alice so she has sufficent funds to close the trove
+      await contracts.musd
+        .connect(bob.wallet)
+        .transfer(alice.address, to1e18("10,000"))
+
+      // Repay and close Trove
+      await contracts.borrowerOperations.connect(alice.wallet).closeTrove()
+      await updateTroveSnapshot(contracts, alice, "before")
+
+      // Check Alices trove is closed
+      expect(alice.trove.status.before).is.equal(2)
+      expect(await contracts.sortedTroves.contains(alice.address)).to.equal(
+        false,
+      )
+
+      // Re-open Trove
+      await openTrove(contracts, {
+        musdAmount: "5,000",
+        sender: alice.wallet,
+      })
+
+      await updateTroveSnapshot(contracts, alice, "after")
+      expect(alice.trove.status.after).is.equal(1)
+      expect(await contracts.sortedTroves.contains(alice.address)).to.equal(
+        true,
+      )
+    })
+
+    it("opens a new Trove with the current interest rate and sets the lastInterestUpdatedTime", async () => {
+      // set the current interest rate to 100 bps
+      await contracts.troveManager
+        .connect(council.wallet)
+        .proposeInterestRate(100)
+      const timeToIncrease = 7 * 24 * 60 * 60 // 7 days in seconds
+      await fastForwardTime(timeToIncrease)
+      await contracts.troveManager.connect(council.wallet).approveInterestRate()
+
+      // open a new trove
+      await openTrove(contracts, {
+        musdAmount: "100,000",
+        sender: dennis.wallet,
+      })
+
+      // check that the interest rate on the trove is the current interest rate
+      const interestRate = await contracts.troveManager.getTroveInterestRate(
+        dennis.wallet,
+      )
+      expect(interestRate).is.equal(100)
+
+      // check that the lastInterestUpdatedTime on the Trove is the current time
+      const lastInterestUpdatedTime =
+        await contracts.troveManager.getTroveLastInterestUpdateTime(
+          dennis.wallet,
+        )
+
+      const currentTime = await getLatestBlockTimestamp()
+
+      expect(lastInterestUpdatedTime).is.equal(currentTime)
+    })
+
+    it("Increases user MUSD balance by correct amount", async () => {
+      expect(await contracts.musd.balanceOf(carol.wallet)).to.equal(0)
+
+      const musdAmount = to1e18("100,000")
+      await openTrove(contracts, {
+        musdAmount,
+        sender: carol.wallet,
+      })
+
+      expect(await contracts.musd.balanceOf(carol.wallet)).to.equal(musdAmount)
+    })
+
+    it("Increases the Trove's MUSD debt by the correct amount", async () => {
+      const abi = [
+        // Add your contract ABI here
+        "event MUSDBorrowingFeePaid(address indexed _borrower, uint256 _MUSDFee)",
+      ]
+
+      await updateTroveSnapshot(contracts, dennis, "before")
+      expect(dennis.trove.debt.before).to.equal(0n)
+
+      const { tx } = await openTrove(contracts, {
+        musdAmount: MIN_NET_DEBT,
+        sender: dennis.wallet,
+      })
+
+      const emittedFee = await getEventArgByName(
+        tx,
+        abi,
+        "MUSDBorrowingFeePaid",
+        1,
+      )
+      await updateTroveSnapshot(contracts, dennis, "after")
+      expect(dennis.trove.debt.after).to.equal(
+        MIN_NET_DEBT + MUSD_GAS_COMPENSATION + emittedFee,
+      )
+    })
+
+    it("Increases MUSD debt in ActivePool by the debt of the trove", async () => {
+      const debtBefore = await contracts.activePool.getMUSDDebt()
+
+      await openTrove(contracts, {
+        musdAmount: MIN_NET_DEBT,
+        sender: carol.wallet,
+      })
+
+      await updateTroveSnapshot(contracts, carol, "after")
+      expect(await contracts.activePool.getMUSDDebt()).to.equal(
+        carol.trove.debt.after + debtBefore,
+      )
+
+      await openTrove(contracts, {
+        musdAmount: MIN_NET_DEBT,
+        sender: dennis.wallet,
+      })
+
+      await updateTroveSnapshot(contracts, dennis, "after")
+      expect(await contracts.activePool.getMUSDDebt()).to.equal(
+        dennis.trove.debt.after + carol.trove.debt.after + debtBefore,
+      )
+    })
+
+    it("Sets the maximum borrowing capacity on a trove when it is opened", async () => {
+      // Open a large trove for Alice with high ICR so we don't go into recovery mode
+      await openTrove(contracts, {
+        musdAmount: "100,000",
+        ICR: "500",
+        sender: eric.wallet,
+      })
+
+      await openTrove(contracts, {
+        musdAmount: "5,000",
+        ICR: "110",
+        sender: dennis.wallet,
+      })
+      await updateTroveSnapshot(contracts, dennis, "before")
+
+      // Dennis borrowed the maximum amount so his debt should equal his borrowing capacity
+      expect(dennis.trove.maxBorrowingCapacity.before).is.equal(
+        dennis.trove.debt.before,
+      )
+    })
+
+    it("Sets the maximum borrowing capacity on a trove when it is opened at higher than 110% ICR", async () => {
+      // Open a large trove for Alice with high ICR so we don't go into recovery mode
+      await openTrove(contracts, {
+        musdAmount: "100,000",
+        ICR: "500",
+        sender: eric.wallet,
+      })
+
+      const { collateral } = await openTrove(contracts, {
+        musdAmount: "5,000",
+        ICR: "200",
+        sender: dennis.wallet,
+      })
+
+      const price = await contracts.priceFeed.fetchPrice()
+
+      const expectedBorrowingCapacity =
+        (collateral * price * 100n) / to1e18(110)
+
+      await updateTroveSnapshot(contracts, dennis, "before")
+
+      // Dennis borrowed the maximum amount so his debt should equal his borrowing capacity
+      expect(dennis.trove.maxBorrowingCapacity.before).is.equal(
+        expectedBorrowingCapacity,
+      )
+    })
+
+    it("Adds the trove's principal to the principal for its interest rate", async () => {
+      const principalBefore = (await contracts.troveManager.interestRateData(0))
+        .principal
+
+      await openTrove(contracts, {
+        musdAmount: "5,000",
+        ICR: "400",
+        sender: dennis.wallet,
+      })
+
+      const principalAfter = (await contracts.troveManager.interestRateData(0))
+        .principal
+
+      await updateTroveSnapshot(contracts, dennis, "before")
+      expect(principalAfter - principalBefore).to.equal(
+        dennis.trove.debt.before,
+      )
+    })
+
+    it("Borrowing at non-zero base rate sends MUSD fee to PCV contract", async () => {
+      state.pcv.musd.before = await contracts.musd.balanceOf(addresses.pcv)
+
+      const newRate = to1e18(5) / 100n
+      await setNewRate(newRate)
+
+      await fastForwardTime(7200)
+
+      await openTrove(contracts, {
+        musdAmount: "40,000",
+        sender: dennis.wallet,
+      })
+
+      state.pcv.musd.after = await contracts.musd.balanceOf(addresses.pcv)
+      expect(state.pcv.musd.after).is.greaterThan(state.pcv.musd.before)
+    })
+
+    it("Borrowing at non-zero base rate sends requested amount to the user", async () => {
+      dennis.musd.before = await contracts.musd.balanceOf(dennis.address)
+      expect(dennis.musd.before).to.equal(0)
+
+      const musdAmount = to1e18("40,000")
+      const newRate = to1e18(5) / 100n
+      await setNewRate(newRate)
+
+      fastForwardTime(7200)
+
+      // Dennis opens trove
+      await openTrove(contracts, {
+        musdAmount,
+        sender: dennis.wallet,
+      })
+
+      dennis.musd.after = await contracts.musd.balanceOf(dennis.address)
+      expect(dennis.musd.after).to.equal(musdAmount)
+    })
+
+    it("Borrowing at zero base rate changes the PCV contract MUSD fees collected", async () => {
+      state.troveManager.baseRate.before =
+        await contracts.troveManager.baseRate()
+      expect(state.troveManager.baseRate.before).to.be.equal(0)
+      state.pcv.musd.before = await contracts.musd.balanceOf(addresses.pcv)
+
+      await openTrove(contracts, {
+        musdAmount: "100,000",
+        sender: carol.wallet,
+      })
+
+      state.pcv.musd.after = await contracts.musd.balanceOf(addresses.pcv)
+      expect(state.pcv.musd.after).to.be.equal(
+        to1e18(500) + state.pcv.musd.before,
+      )
+    })
+
+    it("Borrowing at zero base rate charges minimum fee", async () => {
+      const abi = [
+        // Add your contract ABI here
+        "event MUSDBorrowingFeePaid(address indexed sender, uint256 fee)",
+      ]
+
+      const { tx } = await openTrove(contracts, {
+        musdAmount: MIN_NET_DEBT,
+        sender: carol.wallet,
+      })
+
+      const emittedFee = await getEventArgByName(
+        tx,
+        abi,
+        "MUSDBorrowingFeePaid",
+        1,
+      )
+
+      const BORROWING_FEE_FLOOR =
+        await contracts.borrowerOperations.BORROWING_FEE_FLOOR()
+      const expectedFee =
+        (BORROWING_FEE_FLOOR * MIN_NET_DEBT) / 1000000000000000000n
+      expect(expectedFee).to.equal(emittedFee)
+    })
+
+    it("Adds Trove owner to TroveOwners array", async () => {
+      state.troveManager.troves.before =
+        await contracts.troveManager.getTroveOwnersCount()
+      expect(state.troveManager.troves.before).to.equal(2n)
+
+      await openTrove(contracts, {
+        musdAmount: MIN_NET_DEBT,
+        sender: carol.wallet,
+      })
+
+      state.troveManager.troves.after =
+        await contracts.troveManager.getTroveOwnersCount()
+      expect(state.troveManager.troves.after).to.equal(3n)
+    })
+
+    it("Creates a stake and adds it to total stakes", async () => {
+      state.troveManager.stakes.before =
+        await contracts.troveManager.totalStakes()
+
+      await openTrove(contracts, {
+        musdAmount: MIN_NET_DEBT,
+        sender: carol.wallet,
+      })
+
+      await updateTroveSnapshot(contracts, carol, "after")
+
+      state.troveManager.stakes.after =
+        await contracts.troveManager.totalStakes()
+      expect(state.troveManager.stakes.after).to.equal(
+        carol.trove.stake.after + state.troveManager.stakes.before,
+      )
+    })
+
+    it("Inserts Trove to Sorted Troves list", async () => {
+      expect(await contracts.sortedTroves.contains(carol.address)).to.equal(
+        false,
+      )
+
+      await openTrove(contracts, {
+        musdAmount: MIN_NET_DEBT,
+        sender: carol.wallet,
+      })
+
+      expect(await contracts.sortedTroves.contains(carol.address)).to.equal(
+        true,
+      )
+    })
+
+    it("Increases the activePool collateral and raw collateral balance by correct amount", async () => {
+      state.activePool.collateral.before =
+        await contracts.activePool.getCollateralBalance()
+      state.activePool.btc.before = await ethers.provider.getBalance(
+        addresses.activePool,
+      )
+
+      expect(state.activePool.btc.before).to.equal(
+        state.activePool.collateral.before,
+      )
+
+      await openTrove(contracts, {
+        musdAmount: MIN_NET_DEBT,
+        sender: carol.wallet,
+      })
+
+      await updateTroveSnapshot(contracts, carol, "after")
+
+      const expectedCollateral =
+        carol.trove.collateral.after + state.activePool.collateral.before
+      state.activePool.collateral.after =
+        await contracts.activePool.getCollateralBalance()
+      state.activePool.btc.after = await ethers.provider.getBalance(
+        addresses.activePool,
+      )
+
+      expect(state.activePool.collateral.after).to.equal(expectedCollateral)
+      expect(state.activePool.btc.after).to.equal(expectedCollateral)
+    })
 
     context("Expected Reverts", () => {
-      it("openTrove(): Reverts when BorrowerOperations address is not in mintlist", async () => {
+      it("Reverts when BorrowerOperations address is not in mintlist", async () => {
         // remove mintlist
         await removeMintlist(contracts, deployer.wallet)
         await expect(
@@ -181,7 +752,7 @@ describe("BorrowerOperations in Normal Mode", () => {
         ).to.be.revertedWith("MUSD: Caller not allowed to mint")
       })
 
-      it("openTrove(): Reverts if amount to borrow is zero", async () => {
+      it("Reverts if amount to borrow is zero", async () => {
         await expect(
           openTrove(contracts, {
             musdAmount: "0",
@@ -190,7 +761,7 @@ describe("BorrowerOperations in Normal Mode", () => {
         ).to.be.revertedWithPanic()
       })
 
-      it("openTrove(): Reverts if net debt < minimum net debt", async () => {
+      it("Reverts if net debt < minimum net debt", async () => {
         const amount =
           (await contracts.borrowerOperations.MIN_NET_DEBT()) -
           (await contracts.borrowerOperations.MUSD_GAS_COMPENSATION()) -
@@ -205,7 +776,7 @@ describe("BorrowerOperations in Normal Mode", () => {
         )
       })
 
-      it("openTrove(): Reverts if max fee > 100%", async () => {
+      it("Reverts if max fee > 100%", async () => {
         await expect(
           openTrove(contracts, {
             musdAmount: "10,000",
@@ -215,7 +786,7 @@ describe("BorrowerOperations in Normal Mode", () => {
         ).to.be.revertedWith("Max fee percentage must be between 0.5% and 100%")
       })
 
-      it("openTrove(): Reverts if max fee < 0.5% in Normal mode", async () => {
+      it("Reverts if max fee < 0.5% in Normal mode", async () => {
         await expect(
           openTrove(contracts, {
             musdAmount: "10,000",
@@ -233,7 +804,7 @@ describe("BorrowerOperations in Normal Mode", () => {
         ).to.be.revertedWith("Max fee percentage must be between 0.5% and 100%")
       })
 
-      it("openTrove(): Reverts if fee exceeds max fee percentage", async () => {
+      it("Reverts if fee exceeds max fee percentage", async () => {
         // setup
         const newRate = to1e18(5) / 100n
         await setNewRate(newRate)
@@ -250,7 +821,7 @@ describe("BorrowerOperations in Normal Mode", () => {
         ).to.be.revertedWith("Fee exceeded provided maximum")
       })
 
-      it("openTrove(): Reverts when opening the trove would cause the TCR of the system to fall below the CCR", async () => {
+      it("Reverts when opening the trove would cause the TCR of the system to fall below the CCR", async () => {
         const TCR = await getTCR(contracts)
         assert.equal(TCR, to1e18(150) / 100n)
 
@@ -267,7 +838,7 @@ describe("BorrowerOperations in Normal Mode", () => {
         )
       })
 
-      it("openTrove(): Reverts if trove is already active", async () => {
+      it("Reverts if trove is already active", async () => {
         await expect(
           openTrove(contracts, {
             musdAmount: "10,000",
@@ -276,7 +847,7 @@ describe("BorrowerOperations in Normal Mode", () => {
         ).to.be.revertedWith("BorrowerOps: Trove is active")
       })
 
-      it("openTrove(): Reverts when trove ICR < MCR", async () => {
+      it("Reverts when trove ICR < MCR", async () => {
         await expect(
           openTrove(contracts, {
             musdAmount: "10,000",
@@ -289,14 +860,8 @@ describe("BorrowerOperations in Normal Mode", () => {
       })
     })
 
-    /**
-     *
-     * Emitted Events
-     *
-     */
-
     context("Emitted Events", () => {
-      it("openTrove(): Emits a TroveUpdated event with the correct collateral and debt", async () => {
+      it("Emits a TroveUpdated event with the correct collateral and debt", async () => {
         const abi = [
           // Add your contract ABI here
           "event TroveUpdated(address indexed borrower, uint256 debt, uint256 coll, uint256 stake, uint8 operation)",
@@ -313,7 +878,7 @@ describe("BorrowerOperations in Normal Mode", () => {
         await checkOpenTroveEvents(transactions, abi)
       })
 
-      it("openTrove(): Emits a TroveUpdated event with the correct collateral and debt after changed baseRate", async () => {
+      it("Emits a TroveUpdated event with the correct collateral and debt after changed baseRate", async () => {
         const abi = [
           // Add your contract ABI here
           "event TroveUpdated(address indexed borrower, uint256 debt, uint256 coll, uint256 stake, uint8 operation)",
@@ -337,645 +902,207 @@ describe("BorrowerOperations in Normal Mode", () => {
         await checkOpenTroveEvents(transactions, abi)
       })
     })
-
-    /**
-     *
-     * System State Changes
-     *
-     */
-
-    context("System State Changes", () => {
-      it("openTrove(): Decays a non-zero base rate", async () => {
-        // setup
-        const newRate = to1e18(5) / 100n
-        await setNewRate(newRate)
-
-        // Check baseRate is now non-zero
-        const baseRate1 = await contracts.troveManager.baseRate()
-        expect(baseRate1).is.equal(newRate)
-
-        // 2 hours pass
-        await fastForwardTime(7200)
-
-        // Dennis opens trove
-        await openTrove(contracts, {
-          musdAmount: "2,037",
-          sender: dennis.wallet,
-        })
-
-        // Check baseRate has decreased
-        const baseRate2 = await contracts.troveManager.baseRate()
-        expect(baseRate2).is.lessThan(baseRate1)
-
-        // 1 hour passes
-        await fastForwardTime(3600)
-
-        // Eric opens trove
-        await openTrove(contracts, {
-          musdAmount: "2,012",
-          sender: eric.wallet,
-        })
-
-        const baseRate3 = await contracts.troveManager.baseRate()
-        expect(baseRate3).is.lessThan(baseRate2)
-      })
-
-      it("openTrove(): Doesn't change base rate if it is already zero", async () => {
-        // Check baseRate is zero
-        expect(await contracts.troveManager.baseRate()).to.equal(0)
-
-        // 2 hours pass
-        await fastForwardTime(7200)
-
-        // Dennis opens trove
-        await openTrove(contracts, {
-          musdAmount: "2,000",
-          sender: dennis.wallet,
-        })
-
-        // Check baseRate is still 0
-        expect(await contracts.troveManager.baseRate()).to.equal(0)
-
-        // 1 hour passes
-        await fastForwardTime(3600)
-
-        // Eric opens trove
-        await openTrove(contracts, {
-          musdAmount: "2,000",
-          sender: eric.wallet,
-        })
-
-        expect(await contracts.troveManager.baseRate()).to.equal(0)
-      })
-
-      it("openTrove(): Doesn't update lastFeeOpTime if less time than decay interval has passed since the last fee operation", async () => {
-        const newRate = to1e18(5) / 100n
-        await setNewRate(newRate)
-        const lastFeeOpTime1 =
-          await contracts.troveManager.lastFeeOperationTime()
-
-        // Dennis triggers a fee
-        await openTrove(contracts, {
-          musdAmount: "2,000",
-          sender: dennis.wallet,
-        })
-        const lastFeeOpTime2 =
-          await contracts.troveManager.lastFeeOperationTime()
-
-        // Check that the last fee operation time did not update, as borrower D's debt issuance occured
-        // since before minimum interval had passed
-        expect(lastFeeOpTime2).to.equal(lastFeeOpTime1)
-
-        // 1 minute passes
-        await fastForwardTime(60)
-
-        // Check that now, at least one minute has passed since lastFeeOpTime_1
-        const timeNow = await getLatestBlockTimestamp()
-        expect(BigInt(timeNow)).to.be.oneOf([
-          lastFeeOpTime1 + 60n,
-          lastFeeOpTime1 + 61n,
-          lastFeeOpTime1 + 62n,
-        ])
-
-        // Eric triggers a fee
-        await openTrove(contracts, {
-          musdAmount: "2,000",
-          sender: eric.wallet,
-        })
-        const lastFeeOpTime3 =
-          await contracts.troveManager.lastFeeOperationTime()
-
-        // Check that the last fee operation time DID update, as borrower's debt issuance occured
-        // after minimum interval had passed
-        expect(lastFeeOpTime3).to.greaterThan(lastFeeOpTime1)
-      })
-
-      it("openTrove(): Borrower can't grief the baseRate and stop it decaying by issuing debt at higher frequency than the decay granularity", async () => {
-        const newRate = to1e18(5) / 100n
-        await setNewRate(newRate)
-
-        // 59 minutes pass
-        fastForwardTime(3540)
-
-        // Borrower triggers a fee, before 60 minute decay interval has passed
-        await openTrove(contracts, {
-          musdAmount: "20,000",
-          sender: dennis.wallet,
-        })
-
-        // 1 minute pass
-        fastForwardTime(60)
-
-        // Borrower triggers another fee
-        await openTrove(contracts, {
-          musdAmount: "20,000",
-          sender: eric.wallet,
-        })
-
-        // Check base rate has decreased even though Borrower tried to stop it decaying
-        expect(await contracts.troveManager.baseRate()).is.lessThan(newRate)
-      })
-    })
-
-    /**
-     *
-     * Individual Troves
-     *
-     */
-
-    context("Individual Troves", () => {
-      it("openTrove(): Opens a trove with net debt >= minimum net debt", async () => {
-        await openTrove(contracts, {
-          musdAmount: MIN_NET_DEBT,
-          sender: carol.wallet,
-        })
-
-        expect(await contracts.sortedTroves.contains(carol.wallet)).to.equal(
-          true,
-        )
-
-        await openTrove(contracts, {
-          musdAmount: "477,898,980",
-          sender: eric.wallet,
-        })
-        expect(await contracts.sortedTroves.contains(eric.address)).to.equal(
-          true,
-        )
-      })
-
-      it("openTrove(): Succeeds when fee is less than max fee percentage", async () => {
-        // setup
-        const newRate = to1e18(5) / 100n
-        await setNewRate(newRate)
-
-        // Attempt with maxFee > 5%
-        await openTrove(contracts, {
-          musdAmount: "10,000",
-          sender: dennis.wallet,
-          maxFeePercentage: "5.0000000000000001",
-        })
-        expect(await contracts.musd.balanceOf(dennis.wallet)).to.equal(
-          to1e18("10,000"),
-        )
-
-        // Attempt with maxFee 100%
-        await openTrove(contracts, {
-          musdAmount: "20,000",
-          sender: eric.wallet,
-          maxFeePercentage: "100",
-        })
-        expect(await contracts.musd.balanceOf(eric.wallet)).to.equal(
-          to1e18("20,000"),
-        )
-      })
-
-      it("openTrove(): Borrowing at non-zero base records the (drawn debt + fee  + liq. reserve) on the Trove struct", async () => {
-        const abi = [
-          // Add your contract ABI here
-          "event MUSDBorrowingFeePaid(address indexed _borrower, uint256 _MUSDFee)",
-        ]
-
-        const musdAmount = to1e18("20,000")
-        const newRate = to1e18(5) / 100n
-        await setNewRate(newRate)
-
-        fastForwardTime(7200)
-
-        const { tx } = await openTrove(contracts, {
-          musdAmount,
-          sender: dennis.wallet,
-        })
-
-        const emittedFee = await getEventArgByName(
-          tx,
-          abi,
-          "MUSDBorrowingFeePaid",
-          1,
-        )
-        expect(emittedFee).to.greaterThan(0)
-
-        await updateTroveSnapshot(contracts, dennis, "after")
-
-        // Check debt on Trove struct equals drawn debt plus emitted fee
-        expect(dennis.trove.debt.after).is.equal(
-          emittedFee + MUSD_GAS_COMPENSATION + musdAmount,
-        )
-      })
-
-      it("openTrove(): Creates a new Trove and assigns the correct collateral and debt amount", async () => {
-        await updateTroveSnapshot(contracts, carol, "before")
-
-        expect(carol.trove.debt.before).is.equal(0)
-        expect(carol.trove.collateral.before).is.equal(0)
-        expect(carol.trove.status.before).is.equal(0)
-
-        await openTrove(contracts, {
-          musdAmount: MIN_NET_DEBT,
-          sender: carol.wallet,
-        })
-
-        // Get the expected debt based on the MUSD request (adding fee and liq. reserve on top)
-        const expectedDebt =
-          MIN_NET_DEBT +
-          (await contracts.troveManager.getBorrowingFee(MIN_NET_DEBT)) +
-          MUSD_GAS_COMPENSATION
-
-        await updateTroveSnapshot(contracts, carol, "after")
-
-        expect(carol.trove.collateral.after).is.greaterThan(
-          carol.trove.collateral.before,
-        )
-        expect(carol.trove.debt.after).is.greaterThan(carol.trove.debt.before)
-        expect(carol.trove.debt.after).is.equal(expectedDebt)
-        expect(carol.trove.status.after).is.equal(1n)
-      })
-
-      it("openTrove(): Allows a user to open a Trove, then close it, then re-open it", async () => {
-        // Send MUSD to Alice so she has sufficent funds to close the trove
-        await contracts.musd
-          .connect(bob.wallet)
-          .transfer(alice.address, to1e18("10,000"))
-
-        // Repay and close Trove
-        await contracts.borrowerOperations.connect(alice.wallet).closeTrove()
-        await updateTroveSnapshot(contracts, alice, "before")
-
-        // Check Alices trove is closed
-        expect(alice.trove.status.before).is.equal(2)
-        expect(await contracts.sortedTroves.contains(alice.address)).to.equal(
-          false,
-        )
-
-        // Re-open Trove
-        await openTrove(contracts, {
-          musdAmount: "5,000",
-          sender: alice.wallet,
-        })
-
-        await updateTroveSnapshot(contracts, alice, "after")
-        expect(alice.trove.status.after).is.equal(1)
-        expect(await contracts.sortedTroves.contains(alice.address)).to.equal(
-          true,
-        )
-      })
-
-      it("openTrove(): opens a new Trove with the current interest rate and sets the lastInterestUpdatedTime", async () => {
-        // set the current interest rate to 100 bps
-        await contracts.troveManager
-          .connect(council.wallet)
-          .proposeInterestRate(100)
-        const timeToIncrease = 7 * 24 * 60 * 60 // 7 days in seconds
-        await fastForwardTime(timeToIncrease)
-        await contracts.troveManager
-          .connect(council.wallet)
-          .approveInterestRate()
-
-        // open a new trove
-        await openTrove(contracts, {
-          musdAmount: "100,000",
-          sender: dennis.wallet,
-        })
-
-        // check that the interest rate on the trove is the current interest rate
-        const interestRate = await contracts.troveManager.getTroveInterestRate(
-          dennis.wallet,
-        )
-        expect(interestRate).is.equal(100)
-
-        // check that the lastInterestUpdatedTime on the Trove is the current time
-        const lastInterestUpdatedTime =
-          await contracts.troveManager.getTroveLastInterestUpdateTime(
-            dennis.wallet,
-          )
-
-        const currentTime = await getLatestBlockTimestamp()
-
-        expect(lastInterestUpdatedTime).is.equal(currentTime)
-      })
-    })
-
-    /**
-     * Balance changes
-     */
-
-    context("Balance changes", () => {
-      it("openTrove(): Increases user MUSD balance by correct amount", async () => {
-        expect(await contracts.musd.balanceOf(carol.wallet)).to.equal(0)
-
-        const musdAmount = to1e18("100,000")
-        await openTrove(contracts, {
-          musdAmount,
-          sender: carol.wallet,
-        })
-
-        expect(await contracts.musd.balanceOf(carol.wallet)).to.equal(
-          musdAmount,
-        )
-      })
-
-      it("openTrove(): Increases the Trove's MUSD debt by the correct amount", async () => {
-        const abi = [
-          // Add your contract ABI here
-          "event MUSDBorrowingFeePaid(address indexed _borrower, uint256 _MUSDFee)",
-        ]
-
-        await updateTroveSnapshot(contracts, dennis, "before")
-        expect(dennis.trove.debt.before).to.equal(0n)
-
-        const { tx } = await openTrove(contracts, {
-          musdAmount: MIN_NET_DEBT,
-          sender: dennis.wallet,
-        })
-
-        const emittedFee = await getEventArgByName(
-          tx,
-          abi,
-          "MUSDBorrowingFeePaid",
-          1,
-        )
-        await updateTroveSnapshot(contracts, dennis, "after")
-        expect(dennis.trove.debt.after).to.equal(
-          MIN_NET_DEBT + MUSD_GAS_COMPENSATION + emittedFee,
-        )
-      })
-
-      it("openTrove(): Increases MUSD debt in ActivePool by the debt of the trove", async () => {
-        const debtBefore = await contracts.activePool.getMUSDDebt()
-
-        await openTrove(contracts, {
-          musdAmount: MIN_NET_DEBT,
-          sender: carol.wallet,
-        })
-
-        await updateTroveSnapshot(contracts, carol, "after")
-        expect(await contracts.activePool.getMUSDDebt()).to.equal(
-          carol.trove.debt.after + debtBefore,
-        )
-
-        await openTrove(contracts, {
-          musdAmount: MIN_NET_DEBT,
-          sender: dennis.wallet,
-        })
-
-        await updateTroveSnapshot(contracts, dennis, "after")
-        expect(await contracts.activePool.getMUSDDebt()).to.equal(
-          dennis.trove.debt.after + carol.trove.debt.after + debtBefore,
-        )
-      })
-
-      it("openTrove(): Sets the maximum borrowing capacity on a trove when it is opened", async () => {
-        // Open a large trove for Alice with high ICR so we don't go into recovery mode
-        await openTrove(contracts, {
-          musdAmount: "100,000",
-          ICR: "500",
-          sender: eric.wallet,
-        })
-
-        await openTrove(contracts, {
-          musdAmount: "5,000",
-          ICR: "110",
-          sender: dennis.wallet,
-        })
-        await updateTroveSnapshot(contracts, dennis, "before")
-
-        // Dennis borrowed the maximum amount so his debt should equal his borrowing capacity
-        expect(dennis.trove.maxBorrowingCapacity.before).is.equal(
-          dennis.trove.debt.before,
-        )
-      })
-
-      it("openTrove(): Sets the maximum borrowing capacity on a trove when it is opened at higher than 110% ICR", async () => {
-        // Open a large trove for Alice with high ICR so we don't go into recovery mode
-        await openTrove(contracts, {
-          musdAmount: "100,000",
-          ICR: "500",
-          sender: eric.wallet,
-        })
-
-        const { collateral } = await openTrove(contracts, {
-          musdAmount: "5,000",
-          ICR: "200",
-          sender: dennis.wallet,
-        })
-
-        const price = await contracts.priceFeed.fetchPrice()
-
-        const expectedBorrowingCapacity =
-          (collateral * price * 100n) / to1e18(110)
-
-        await updateTroveSnapshot(contracts, dennis, "before")
-
-        // Dennis borrowed the maximum amount so his debt should equal his borrowing capacity
-        expect(dennis.trove.maxBorrowingCapacity.before).is.equal(
-          expectedBorrowingCapacity,
-        )
-      })
-
-      it("openTrove(): Adds the trove's principal to the principal for its interest rate", async () => {
-        const principalBefore = (
-          await contracts.troveManager.interestRateData(0)
-        ).principal
-
-        await openTrove(contracts, {
-          musdAmount: "5,000",
-          ICR: "400",
-          sender: dennis.wallet,
-        })
-
-        const principalAfter = (
-          await contracts.troveManager.interestRateData(0)
-        ).principal
-
-        await updateTroveSnapshot(contracts, dennis, "before")
-        expect(principalAfter - principalBefore).to.equal(
-          dennis.trove.debt.before,
-        )
-      })
-    })
-
-    /**
-     *
-     * Fees
-     *
-     */
-
-    context("Fees", () => {
-      it("openTrove(): Borrowing at non-zero base rate sends MUSD fee to PCV contract", async () => {
-        state.pcv.musd.before = await contracts.musd.balanceOf(addresses.pcv)
-
-        const newRate = to1e18(5) / 100n
-        await setNewRate(newRate)
-
-        await fastForwardTime(7200)
-
-        await openTrove(contracts, {
-          musdAmount: "40,000",
-          sender: dennis.wallet,
-        })
-
-        state.pcv.musd.after = await contracts.musd.balanceOf(addresses.pcv)
-        expect(state.pcv.musd.after).is.greaterThan(state.pcv.musd.before)
-      })
-
-      it("openTrove(): Borrowing at non-zero base rate sends requested amount to the user", async () => {
-        dennis.musd.before = await contracts.musd.balanceOf(dennis.address)
-        expect(dennis.musd.before).to.equal(0)
-
-        const musdAmount = to1e18("40,000")
-        const newRate = to1e18(5) / 100n
-        await setNewRate(newRate)
-
-        fastForwardTime(7200)
-
-        // Dennis opens trove
-        await openTrove(contracts, {
-          musdAmount,
-          sender: dennis.wallet,
-        })
-
-        dennis.musd.after = await contracts.musd.balanceOf(dennis.address)
-        expect(dennis.musd.after).to.equal(musdAmount)
-      })
-
-      it("openTrove(): Borrowing at zero base rate changes the PCV contract MUSD fees collected", async () => {
-        state.troveManager.baseRate.before =
-          await contracts.troveManager.baseRate()
-        expect(state.troveManager.baseRate.before).to.be.equal(0)
-        state.pcv.musd.before = await contracts.musd.balanceOf(addresses.pcv)
-
-        await openTrove(contracts, {
-          musdAmount: "100,000",
-          sender: carol.wallet,
-        })
-
-        state.pcv.musd.after = await contracts.musd.balanceOf(addresses.pcv)
-        expect(state.pcv.musd.after).to.be.equal(
-          to1e18(500) + state.pcv.musd.before,
-        )
-      })
-
-      it("openTrove(): Borrowing at zero base rate charges minimum fee", async () => {
-        const abi = [
-          // Add your contract ABI here
-          "event MUSDBorrowingFeePaid(address indexed sender, uint256 fee)",
-        ]
-
-        const { tx } = await openTrove(contracts, {
-          musdAmount: MIN_NET_DEBT,
-          sender: carol.wallet,
-        })
-
-        const emittedFee = await getEventArgByName(
-          tx,
-          abi,
-          "MUSDBorrowingFeePaid",
-          1,
-        )
-
-        const BORROWING_FEE_FLOOR =
-          await contracts.borrowerOperations.BORROWING_FEE_FLOOR()
-        const expectedFee =
-          (BORROWING_FEE_FLOOR * MIN_NET_DEBT) / 1000000000000000000n
-        expect(expectedFee).to.equal(emittedFee)
-      })
-    })
-
-    /**
-     *
-     * State change in other contracts
-     *
-     */
-
-    context("State change in other contracts", () => {
-      it("openTrove(): Adds Trove owner to TroveOwners array", async () => {
-        state.troveManager.troves.before =
-          await contracts.troveManager.getTroveOwnersCount()
-        expect(state.troveManager.troves.before).to.equal(2n)
-
-        await openTrove(contracts, {
-          musdAmount: MIN_NET_DEBT,
-          sender: carol.wallet,
-        })
-
-        state.troveManager.troves.after =
-          await contracts.troveManager.getTroveOwnersCount()
-        expect(state.troveManager.troves.after).to.equal(3n)
-      })
-
-      it("openTrove(): Creates a stake and adds it to total stakes", async () => {
-        state.troveManager.stakes.before =
-          await contracts.troveManager.totalStakes()
-
-        await openTrove(contracts, {
-          musdAmount: MIN_NET_DEBT,
-          sender: carol.wallet,
-        })
-
-        await updateTroveSnapshot(contracts, carol, "after")
-
-        state.troveManager.stakes.after =
-          await contracts.troveManager.totalStakes()
-        expect(state.troveManager.stakes.after).to.equal(
-          carol.trove.stake.after + state.troveManager.stakes.before,
-        )
-      })
-
-      it("openTrove(): Inserts Trove to Sorted Troves list", async () => {
-        expect(await contracts.sortedTroves.contains(carol.address)).to.equal(
-          false,
-        )
-
-        await openTrove(contracts, {
-          musdAmount: MIN_NET_DEBT,
-          sender: carol.wallet,
-        })
-
-        expect(await contracts.sortedTroves.contains(carol.address)).to.equal(
-          true,
-        )
-      })
-
-      it("openTrove(): Increases the activePool collateral and raw collateral balance by correct amount", async () => {
-        state.activePool.collateral.before =
-          await contracts.activePool.getCollateralBalance()
-        state.activePool.btc.before = await ethers.provider.getBalance(
-          addresses.activePool,
-        )
-
-        expect(state.activePool.btc.before).to.equal(
-          state.activePool.collateral.before,
-        )
-
-        await openTrove(contracts, {
-          musdAmount: MIN_NET_DEBT,
-          sender: carol.wallet,
-        })
-
-        await updateTroveSnapshot(contracts, carol, "after")
-
-        const expectedCollateral =
-          carol.trove.collateral.after + state.activePool.collateral.before
-        state.activePool.collateral.after =
-          await contracts.activePool.getCollateralBalance()
-        state.activePool.btc.after = await ethers.provider.getBalance(
-          addresses.activePool,
-        )
-
-        expect(state.activePool.collateral.after).to.equal(expectedCollateral)
-        expect(state.activePool.btc.after).to.equal(expectedCollateral)
-      })
-    })
   })
 
   describe("closeTrove", () => {
-    /**
-     *
-     * Expected Reverts
-     *
-     */
+    it("no mintlist, succeeds when it would lower the TCR below CCR", async () => {
+      await openTrove(contracts, {
+        musdAmount: "30,000",
+        ICR: "300",
+        sender: carol.wallet,
+      })
+
+      await removeMintlist(contracts, deployer.wallet)
+
+      const price = to1e18("33,500")
+      const amount = to1e18("10,000")
+      // transfer
+      await contracts.musd.connect(bob.wallet).transfer(carol.wallet, amount)
+      await contracts.mockAggregator.setPrice(price)
+
+      expect(await contracts.troveManager.checkRecoveryMode(price)).to.equal(
+        false,
+      )
+      await contracts.borrowerOperations.connect(carol.wallet).closeTrove()
+    })
+
+    it("reduces a Trove's collateral to zero", async () => {
+      const amount = to1e18("10,000")
+      await contracts.musd.connect(bob.wallet).transfer(alice.wallet, amount)
+      await contracts.borrowerOperations.connect(alice.wallet).closeTrove()
+
+      await updateTroveSnapshot(contracts, alice, "after")
+      expect(alice.trove.collateral.after).to.equal(0)
+    })
+
+    it("reduces a Trove's debt to zero", async () => {
+      const amount = to1e18("10,000")
+      await contracts.musd.connect(bob.wallet).transfer(alice.wallet, amount)
+      await contracts.borrowerOperations.connect(alice.wallet).closeTrove()
+
+      await updateTroveSnapshot(contracts, alice, "after")
+      expect(alice.trove.debt.after).to.equal(0)
+    })
+
+    it("sets Trove's stake to zero", async () => {
+      const amount = to1e18("10,000")
+      await contracts.musd.connect(bob.wallet).transfer(alice.wallet, amount)
+      await contracts.borrowerOperations.connect(alice.wallet).closeTrove()
+
+      await updateTroveSnapshot(contracts, alice, "after")
+      expect(alice.trove.stake.after).to.equal(0)
+    })
+
+    it("sends the correct amount of collateral to the user", async () => {
+      await updateTroveSnapshot(contracts, alice, "before")
+      await updateContractsSnapshot(
+        contracts,
+        state,
+        "activePool",
+        "before",
+        addresses,
+      )
+
+      const amount = to1e18("10,000")
+      await contracts.musd.connect(bob.wallet).transfer(alice.wallet, amount)
+      await contracts.borrowerOperations.connect(alice.wallet).closeTrove()
+
+      await updateContractsSnapshot(
+        contracts,
+        state,
+        "activePool",
+        "after",
+        addresses,
+      )
+
+      expect(state.activePool.collateral.after).to.equal(
+        state.activePool.collateral.before - alice.trove.collateral.before,
+      )
+    })
+
+    it("subtracts the debt of the closed Trove from the Borrower's MUSDToken balance", async () => {
+      await updateTroveSnapshot(contracts, alice, "before")
+
+      const amount = to1e18("10,000")
+      await contracts.musd.connect(bob.wallet).transfer(alice.wallet, amount)
+      alice.musd.before = await contracts.musd.balanceOf(alice.wallet)
+      await contracts.borrowerOperations.connect(alice.wallet).closeTrove()
+      alice.musd.after = await contracts.musd.balanceOf(alice.wallet)
+
+      expect(alice.musd.after).to.equal(
+        alice.musd.before - alice.trove.debt.before + MUSD_GAS_COMPENSATION,
+      )
+    })
+
+    it("zero's the troves reward snapshots", async () => {
+      await setupCarolsTrove()
+
+      const amount = to1e18("10,000")
+      await contracts.musd.connect(bob.wallet).transfer(alice.wallet, amount)
+
+      await createLiquidationEvent(contracts)
+
+      // do a transaction that will update Alice's reward snapshot values
+      await contracts.borrowerOperations.withdrawMUSD(
+        to1e18(1),
+        1n,
+        alice.wallet,
+        alice.wallet,
+      )
+      await updateRewardSnapshot(contracts, alice, "before")
+      await contracts.borrowerOperations.connect(alice.wallet).closeTrove()
+      await updateRewardSnapshot(contracts, alice, "after")
+
+      expect(alice.rewardSnapshot.collateral.before).to.be.greaterThan(0)
+      expect(alice.rewardSnapshot.debt.before).to.be.greaterThan(0)
+      expect(alice.rewardSnapshot.collateral.after).to.be.equal(0)
+      expect(alice.rewardSnapshot.debt.after).to.be.equal(0)
+    })
+
+    it("sets trove's status to closed and removes it from sorted troves list", async () => {
+      const amount = to1e18("10,000")
+      await contracts.musd.connect(bob.wallet).transfer(alice.wallet, amount)
+      await contracts.borrowerOperations.connect(alice.wallet).closeTrove()
+
+      await updateTroveSnapshot(contracts, alice, "after")
+      expect(alice.trove.status.after).to.equal(2)
+      expect(await contracts.sortedTroves.contains(alice.wallet)).to.equal(
+        false,
+      )
+    })
+
+    it("reduces ActivePool collateral and raw collateral by correct amount", async () => {
+      await updateContractsSnapshot(
+        contracts,
+        state,
+        "activePool",
+        "before",
+        addresses,
+      )
+      await updateTroveSnapshot(contracts, alice, "before")
+
+      const amount = to1e18("10,000")
+      await contracts.musd.connect(bob.wallet).transfer(alice.wallet, amount)
+      await contracts.borrowerOperations.connect(alice.wallet).closeTrove()
+      await updateContractsSnapshot(
+        contracts,
+        state,
+        "activePool",
+        "after",
+        addresses,
+      )
+
+      expect(state.activePool.collateral.after).to.equal(
+        state.activePool.collateral.before - alice.trove.collateral.before,
+      )
+      expect(state.activePool.btc.after).to.equal(
+        state.activePool.btc.before - alice.trove.collateral.before,
+      )
+    })
+
+    it("reduces ActivePool debt by correct amount", async () => {
+      await updateContractsSnapshot(
+        contracts,
+        state,
+        "activePool",
+        "before",
+        addresses,
+      )
+      await updateTroveSnapshot(contracts, alice, "before")
+
+      const amount = to1e18("10,000")
+      await contracts.musd.connect(bob.wallet).transfer(alice.wallet, amount)
+      await contracts.borrowerOperations.connect(alice.wallet).closeTrove()
+      await updateContractsSnapshot(
+        contracts,
+        state,
+        "activePool",
+        "after",
+        addresses,
+      )
+
+      expect(state.activePool.debt.after).to.equal(
+        state.activePool.debt.before - alice.trove.debt.before,
+      )
+    })
+
+    it("updates the the total stakes", async () => {
+      await updateTroveSnapshot(contracts, alice, "before")
+      await updateTroveManagerSnapshot(contracts, state, "before")
+
+      const amount = to1e18("10,000")
+      await contracts.musd.connect(bob.wallet).transfer(alice.wallet, amount)
+      await contracts.borrowerOperations.connect(alice.wallet).closeTrove()
+      await updateTroveManagerSnapshot(contracts, state, "after")
+
+      expect(state.troveManager.stakes.after).to.equal(
+        state.troveManager.stakes.before - alice.trove.stake.before,
+      )
+      expect(alice.trove.stake.before).to.be.greaterThan(0)
+    })
 
     context("Expected Reverts", () => {
-      it("closeTrove(): reverts when it would lower the TCR below CCR", async () => {
+      it("reverts when it would lower the TCR below CCR", async () => {
         await openTrove(contracts, {
           musdAmount: "30,000",
           ICR: "300",
@@ -999,13 +1126,13 @@ describe("BorrowerOperations in Normal Mode", () => {
         )
       })
 
-      it("closeTrove(): reverts when calling address does not have active trove", async () => {
+      it(" calling address does not have active trove", async () => {
         await expect(
           contracts.borrowerOperations.connect(carol.wallet).closeTrove(),
         ).to.be.revertedWith("BorrowerOps: Trove does not exist or is closed")
       })
 
-      it("closeTrove(): reverts when trove is the only one in the system", async () => {
+      it("reverts when trove is the only one in the system", async () => {
         // Artificially mint to Alice and Bob have enough to close their troves
         await contracts.musd.unprotectedMint(alice.wallet, to1e18("1,000"))
         await contracts.musd.unprotectedMint(bob.wallet, to1e18("1,000"))
@@ -1016,7 +1143,7 @@ describe("BorrowerOperations in Normal Mode", () => {
         ).to.be.revertedWith("TroveManager: Only one trove in the system")
       })
 
-      it("closeTrove(): reverts if borrower has insufficient MUSD balance to repay his entire debt", async () => {
+      it("reverts if borrower has insufficient MUSD balance to repay his entire debt", async () => {
         await expect(
           contracts.borrowerOperations.connect(bob.wallet).closeTrove(),
         ).to.be.revertedWith(
@@ -1024,261 +1151,110 @@ describe("BorrowerOperations in Normal Mode", () => {
         )
       })
     })
-
-    /**
-     *
-     * Emitted Events
-     *
-     */
-
-    context("Emitted Events", () => {})
-
-    /**
-     *
-     * System State Changes
-     *
-     */
-
-    context("System State Changes", () => {})
-
-    /**
-     *
-     * Individual Troves
-     *
-     */
-
-    context("Individual Troves", () => {
-      it("closeTrove(): no mintlist, succeeds when it would lower the TCR below CCR", async () => {
-        await openTrove(contracts, {
-          musdAmount: "30,000",
-          ICR: "300",
-          sender: carol.wallet,
-        })
-
-        await removeMintlist(contracts, deployer.wallet)
-
-        const price = to1e18("33,500")
-        const amount = to1e18("10,000")
-        // transfer
-        await contracts.musd.connect(bob.wallet).transfer(carol.wallet, amount)
-        await contracts.mockAggregator.setPrice(price)
-
-        expect(await contracts.troveManager.checkRecoveryMode(price)).to.equal(
-          false,
-        )
-        await contracts.borrowerOperations.connect(carol.wallet).closeTrove()
-      })
-
-      it("closeTrove(): reduces a Trove's collateral to zero", async () => {
-        const amount = to1e18("10,000")
-        await contracts.musd.connect(bob.wallet).transfer(alice.wallet, amount)
-        await contracts.borrowerOperations.connect(alice.wallet).closeTrove()
-
-        await updateTroveSnapshot(contracts, alice, "after")
-        expect(alice.trove.collateral.after).to.equal(0)
-      })
-
-      it("closeTrove(): reduces a Trove's debt to zero", async () => {
-        const amount = to1e18("10,000")
-        await contracts.musd.connect(bob.wallet).transfer(alice.wallet, amount)
-        await contracts.borrowerOperations.connect(alice.wallet).closeTrove()
-
-        await updateTroveSnapshot(contracts, alice, "after")
-        expect(alice.trove.debt.after).to.equal(0)
-      })
-
-      it("closeTrove(): sets Trove's stake to zero", async () => {
-        const amount = to1e18("10,000")
-        await contracts.musd.connect(bob.wallet).transfer(alice.wallet, amount)
-        await contracts.borrowerOperations.connect(alice.wallet).closeTrove()
-
-        await updateTroveSnapshot(contracts, alice, "after")
-        expect(alice.trove.stake.after).to.equal(0)
-      })
-    })
-
-    /**
-     *
-     *  Balance changes
-     *
-     */
-
-    context("Balance changes", () => {
-      it("closeTrove(): sends the correct amount of collateral to the user", async () => {
-        await updateTroveSnapshot(contracts, alice, "before")
-        await updateContractsSnapshot(
-          contracts,
-          state,
-          "activePool",
-          "before",
-          addresses,
-        )
-
-        const amount = to1e18("10,000")
-        await contracts.musd.connect(bob.wallet).transfer(alice.wallet, amount)
-        await contracts.borrowerOperations.connect(alice.wallet).closeTrove()
-
-        await updateContractsSnapshot(
-          contracts,
-          state,
-          "activePool",
-          "after",
-          addresses,
-        )
-
-        expect(state.activePool.collateral.after).to.equal(
-          state.activePool.collateral.before - alice.trove.collateral.before,
-        )
-      })
-
-      it("closeTrove(): subtracts the debt of the closed Trove from the Borrower's MUSDToken balance", async () => {
-        await updateTroveSnapshot(contracts, alice, "before")
-
-        const amount = to1e18("10,000")
-        await contracts.musd.connect(bob.wallet).transfer(alice.wallet, amount)
-        alice.musd.before = await contracts.musd.balanceOf(alice.wallet)
-        await contracts.borrowerOperations.connect(alice.wallet).closeTrove()
-        alice.musd.after = await contracts.musd.balanceOf(alice.wallet)
-
-        expect(alice.musd.after).to.equal(
-          alice.musd.before - alice.trove.debt.before + MUSD_GAS_COMPENSATION,
-        )
-      })
-    })
-
-    /**
-     *
-     * Fees
-     *
-     */
-
-    context("Fees", () => {})
-
-    /**
-     *
-     * State change in other contracts
-     *
-     */
-
-    context("State change in other contracts", () => {
-      it("closeTrove(): zero's the troves reward snapshots", async () => {
-        await setupCarolsTrove()
-
-        const amount = to1e18("10,000")
-        await contracts.musd.connect(bob.wallet).transfer(alice.wallet, amount)
-
-        await createLiquidationEvent(contracts)
-
-        // do a transaction that will update Alice's reward snapshot values
-        await contracts.borrowerOperations.withdrawMUSD(
-          to1e18(1),
-          1n,
-          alice.wallet,
-          alice.wallet,
-        )
-        await updateRewardSnapshot(contracts, alice, "before")
-        await contracts.borrowerOperations.connect(alice.wallet).closeTrove()
-        await updateRewardSnapshot(contracts, alice, "after")
-
-        expect(alice.rewardSnapshot.collateral.before).to.be.greaterThan(0)
-        expect(alice.rewardSnapshot.debt.before).to.be.greaterThan(0)
-        expect(alice.rewardSnapshot.collateral.after).to.be.equal(0)
-        expect(alice.rewardSnapshot.debt.after).to.be.equal(0)
-      })
-
-      it("closeTrove(): sets trove's status to closed and removes it from sorted troves list", async () => {
-        const amount = to1e18("10,000")
-        await contracts.musd.connect(bob.wallet).transfer(alice.wallet, amount)
-        await contracts.borrowerOperations.connect(alice.wallet).closeTrove()
-
-        await updateTroveSnapshot(contracts, alice, "after")
-        expect(alice.trove.status.after).to.equal(2)
-        expect(await contracts.sortedTroves.contains(alice.wallet)).to.equal(
-          false,
-        )
-      })
-
-      it("closeTrove(): reduces ActivePool collateral and raw collateral by correct amount", async () => {
-        await updateContractsSnapshot(
-          contracts,
-          state,
-          "activePool",
-          "before",
-          addresses,
-        )
-        await updateTroveSnapshot(contracts, alice, "before")
-
-        const amount = to1e18("10,000")
-        await contracts.musd.connect(bob.wallet).transfer(alice.wallet, amount)
-        await contracts.borrowerOperations.connect(alice.wallet).closeTrove()
-        await updateContractsSnapshot(
-          contracts,
-          state,
-          "activePool",
-          "after",
-          addresses,
-        )
-
-        expect(state.activePool.collateral.after).to.equal(
-          state.activePool.collateral.before - alice.trove.collateral.before,
-        )
-        expect(state.activePool.btc.after).to.equal(
-          state.activePool.btc.before - alice.trove.collateral.before,
-        )
-      })
-
-      it("closeTrove(): reduces ActivePool debt by correct amount", async () => {
-        await updateContractsSnapshot(
-          contracts,
-          state,
-          "activePool",
-          "before",
-          addresses,
-        )
-        await updateTroveSnapshot(contracts, alice, "before")
-
-        const amount = to1e18("10,000")
-        await contracts.musd.connect(bob.wallet).transfer(alice.wallet, amount)
-        await contracts.borrowerOperations.connect(alice.wallet).closeTrove()
-        await updateContractsSnapshot(
-          contracts,
-          state,
-          "activePool",
-          "after",
-          addresses,
-        )
-
-        expect(state.activePool.debt.after).to.equal(
-          state.activePool.debt.before - alice.trove.debt.before,
-        )
-      })
-
-      it("closeTrove(): updates the the total stakes", async () => {
-        await updateTroveSnapshot(contracts, alice, "before")
-        await updateTroveManagerSnapshot(contracts, state, "before")
-
-        const amount = to1e18("10,000")
-        await contracts.musd.connect(bob.wallet).transfer(alice.wallet, amount)
-        await contracts.borrowerOperations.connect(alice.wallet).closeTrove()
-        await updateTroveManagerSnapshot(contracts, state, "after")
-
-        expect(state.troveManager.stakes.after).to.equal(
-          state.troveManager.stakes.before - alice.trove.stake.before,
-        )
-        expect(alice.trove.stake.before).to.be.greaterThan(0)
-      })
-    })
   })
 
   describe("addColl()", () => {
-    /**
-     *
-     * Expected Reverts
-     *
-     */
+    it("active Trove: adds the correct collateral amount to the Trove", async () => {
+      await updateTroveSnapshot(contracts, alice, "before")
+      expect(alice.trove.status.before).to.equal(1) // status
+
+      const collateralTopUp = to1e18(1)
+      await addColl(contracts, {
+        amount: collateralTopUp,
+        sender: alice.wallet,
+      })
+
+      await updateTroveSnapshot(contracts, alice, "after")
+      expect(alice.trove.status.after).to.equal(1) // status
+      expect(alice.trove.collateral.after).to.equal(
+        alice.trove.collateral.before + collateralTopUp,
+      )
+    })
+
+    it("active Trove: Trove is in sortedList before and after", async () => {
+      expect(await contracts.sortedTroves.contains(alice.address)).to.equal(
+        true,
+      )
+      expect(await contracts.sortedTroves.isEmpty()).to.equal(false)
+
+      const collateralTopUp = to1e18(1)
+      await addColl(contracts, {
+        amount: collateralTopUp,
+        sender: alice.wallet,
+      })
+
+      expect(await contracts.sortedTroves.contains(alice.address)).to.equal(
+        true,
+      )
+      expect(await contracts.sortedTroves.isEmpty()).to.equal(false)
+    })
+
+    it("active Trove: updates the stake and updates the total stakes", async () => {
+      await updateTroveSnapshot(contracts, alice, "before")
+      state.troveManager.stakes.before =
+        await contracts.troveManager.totalStakes()
+
+      const collateralTopUp = to1e18(1)
+      await addColl(contracts, {
+        amount: collateralTopUp,
+        sender: alice.wallet,
+      })
+
+      await updateTroveSnapshot(contracts, alice, "after")
+      state.troveManager.stakes.after =
+        await contracts.troveManager.totalStakes()
+
+      expect(state.troveManager.stakes.after).is.equal(
+        state.troveManager.stakes.before +
+          alice.trove.stake.after -
+          alice.trove.stake.before,
+      )
+      expect(state.troveManager.stakes.after).to.equal(
+        state.troveManager.stakes.before + collateralTopUp,
+      )
+    })
+
+    it("no mintlist, can add collateral", async () => {
+      await updateTroveSnapshot(contracts, alice, "before")
+      await removeMintlist(contracts, deployer.wallet)
+
+      const collateralTopUp = to1e18(1)
+      await addColl(contracts, {
+        amount: collateralTopUp,
+        sender: alice.wallet,
+      })
+
+      await updateTroveSnapshot(contracts, alice, "after")
+      expect(alice.trove.collateral.after).to.equal(
+        alice.trove.collateral.before + collateralTopUp,
+      )
+    })
+
+    it("increases the activePool collateral and raw collateral balance by correct amount", async () => {
+      const beforeCollateral = await ethers.provider.getBalance(
+        addresses.activePool,
+      )
+      expect(beforeCollateral).to.equal(
+        await contracts.activePool.getCollateralBalance(),
+      )
+
+      const collateralTopUp = to1e18(1)
+      await addColl(contracts, {
+        amount: collateralTopUp,
+        sender: alice.wallet,
+      })
+
+      const afterCollateral = await ethers.provider.getBalance(
+        addresses.activePool,
+      )
+      expect(afterCollateral).to.equal(
+        await contracts.activePool.getCollateralBalance(),
+      )
+      expect(afterCollateral).to.equal(beforeCollateral + collateralTopUp)
+    })
 
     context("Expected Reverts", () => {
-      it("addColl(), reverts if trove is non-existent or closed", async () => {
+      it("reverts if trove is non-existent or closed", async () => {
         await expect(
           addColl(contracts, {
             amount: to1e18(1),
@@ -1287,164 +1263,188 @@ describe("BorrowerOperations in Normal Mode", () => {
         ).to.be.revertedWith("BorrowerOps: Trove does not exist or is closed")
       })
     })
-
-    /**
-     *
-     * Emitted Events
-     *
-     */
-
-    context("Emitted Events", () => {})
-
-    /**
-     *
-     * System State Changes
-     *
-     */
-
-    context("System State Changes", () => {})
-
-    /**
-     *
-     * Individual Troves
-     *
-     */
-
-    context("Individual Troves", () => {
-      it("addColl(), active Trove: adds the correct collateral amount to the Trove", async () => {
-        await updateTroveSnapshot(contracts, alice, "before")
-        expect(alice.trove.status.before).to.equal(1) // status
-
-        const collateralTopUp = to1e18(1)
-        await addColl(contracts, {
-          amount: collateralTopUp,
-          sender: alice.wallet,
-        })
-
-        await updateTroveSnapshot(contracts, alice, "after")
-        expect(alice.trove.status.after).to.equal(1) // status
-        expect(alice.trove.collateral.after).to.equal(
-          alice.trove.collateral.before + collateralTopUp,
-        )
-      })
-
-      it("addColl(), active Trove: Trove is in sortedList before and after", async () => {
-        expect(await contracts.sortedTroves.contains(alice.address)).to.equal(
-          true,
-        )
-        expect(await contracts.sortedTroves.isEmpty()).to.equal(false)
-
-        const collateralTopUp = to1e18(1)
-        await addColl(contracts, {
-          amount: collateralTopUp,
-          sender: alice.wallet,
-        })
-
-        expect(await contracts.sortedTroves.contains(alice.address)).to.equal(
-          true,
-        )
-        expect(await contracts.sortedTroves.isEmpty()).to.equal(false)
-      })
-
-      it("addColl(), active Trove: updates the stake and updates the total stakes", async () => {
-        await updateTroveSnapshot(contracts, alice, "before")
-        state.troveManager.stakes.before =
-          await contracts.troveManager.totalStakes()
-
-        const collateralTopUp = to1e18(1)
-        await addColl(contracts, {
-          amount: collateralTopUp,
-          sender: alice.wallet,
-        })
-
-        await updateTroveSnapshot(contracts, alice, "after")
-        state.troveManager.stakes.after =
-          await contracts.troveManager.totalStakes()
-
-        expect(state.troveManager.stakes.after).is.equal(
-          state.troveManager.stakes.before +
-            alice.trove.stake.after -
-            alice.trove.stake.before,
-        )
-        expect(state.troveManager.stakes.after).to.equal(
-          state.troveManager.stakes.before + collateralTopUp,
-        )
-      })
-    })
-
-    /**
-     *
-     *  Balance changes
-     *
-     */
-
-    context("Balance changes", () => {
-      it("addColl(): no mintlist, can add collateral", async () => {
-        await updateTroveSnapshot(contracts, alice, "before")
-        await removeMintlist(contracts, deployer.wallet)
-
-        const collateralTopUp = to1e18(1)
-        await addColl(contracts, {
-          amount: collateralTopUp,
-          sender: alice.wallet,
-        })
-
-        await updateTroveSnapshot(contracts, alice, "after")
-        expect(alice.trove.collateral.after).to.equal(
-          alice.trove.collateral.before + collateralTopUp,
-        )
-      })
-    })
-
-    /**
-     *
-     * Fees
-     *
-     */
-
-    context("Fees", () => {})
-
-    /**
-     *
-     * State change in other contracts
-     *
-     */
-
-    context("State change in other contracts", () => {
-      it("addColl(): increases the activePool collateral and raw collateral balance by correct amount", async () => {
-        const beforeCollateral = await ethers.provider.getBalance(
-          addresses.activePool,
-        )
-        expect(beforeCollateral).to.equal(
-          await contracts.activePool.getCollateralBalance(),
-        )
-
-        const collateralTopUp = to1e18(1)
-        await addColl(contracts, {
-          amount: collateralTopUp,
-          sender: alice.wallet,
-        })
-
-        const afterCollateral = await ethers.provider.getBalance(
-          addresses.activePool,
-        )
-        expect(afterCollateral).to.equal(
-          await contracts.activePool.getCollateralBalance(),
-        )
-        expect(afterCollateral).to.equal(beforeCollateral + collateralTopUp)
-      })
-    })
   })
 
   describe("withdrawColl()", () => {
-    /**
-     *
-     * Expected Reverts
-     *
-     */
+    it("updates the stake and updates the total stakes", async () => {
+      await setupCarolsTrove()
+      await updateTroveSnapshot(contracts, alice, "before")
+      await updateTroveSnapshot(contracts, bob, "before")
+      await updateTroveSnapshot(contracts, carol, "before")
+
+      state.troveManager.stakes.before =
+        await contracts.troveManager.totalStakes()
+
+      expect(carol.trove.stake.before).to.equal(carol.trove.collateral.before)
+      expect(
+        alice.trove.stake.before +
+          bob.trove.stake.before +
+          carol.trove.stake.before,
+      ).to.equal(state.troveManager.stakes.before)
+
+      const withdrawalAmount = 1n
+      await contracts.borrowerOperations
+        .connect(carol.wallet)
+        .withdrawColl(withdrawalAmount, carol.wallet, carol.wallet)
+      await updateTroveSnapshot(contracts, carol, "after")
+
+      state.troveManager.stakes.after =
+        await contracts.troveManager.totalStakes()
+      expect(
+        alice.trove.stake.before +
+          bob.trove.stake.before +
+          carol.trove.stake.after,
+      ).to.equal(state.troveManager.stakes.after)
+      expect(carol.trove.stake.after).to.equal(
+        carol.trove.stake.before - withdrawalAmount,
+      )
+      expect(carol.trove.collateral.after).to.equal(
+        carol.trove.collateral.before - withdrawalAmount,
+      )
+    })
+
+    it("leaves the Trove active when the user withdraws less than all the collateral", async () => {
+      const withdrawalAmount = 1n
+      await setupCarolsTrove()
+
+      await contracts.borrowerOperations
+        .connect(carol.wallet)
+        .withdrawColl(withdrawalAmount, carol.wallet, carol.wallet)
+
+      await updateTroveSnapshot(contracts, carol, "after")
+
+      expect(carol.trove.status.after).to.equal(1)
+      expect(await contracts.sortedTroves.contains(carol.wallet)).to.equal(true)
+    })
+
+    it("reduces the Trove's collateral by the correct amount", async () => {
+      const withdrawalAmount = 1n
+      await setupCarolsTrove()
+
+      await updateTroveSnapshot(contracts, carol, "before")
+      await contracts.borrowerOperations
+        .connect(carol.wallet)
+        .withdrawColl(withdrawalAmount, carol.wallet, carol.wallet)
+      await updateTroveSnapshot(contracts, carol, "after")
+
+      expect(carol.trove.collateral.after).to.equal(
+        carol.trove.collateral.before - withdrawalAmount,
+      )
+    })
+
+    it("sends the correct amount of collateral to the user", async () => {
+      const withdrawalAmount = to1e18("0.5")
+      await setupCarolsTrove()
+
+      carol.btc.before = await ethers.provider.getBalance(carol.address)
+      await contracts.borrowerOperations
+        .connect(carol.wallet)
+        .withdrawColl(withdrawalAmount, carol.wallet, carol.wallet, NO_GAS)
+      carol.btc.after = await ethers.provider.getBalance(carol.address)
+
+      expect(carol.btc.after).to.equal(carol.btc.before + withdrawalAmount)
+    })
+
+    it("reduces ActivePool collateral and raw collateral by correct amount", async () => {
+      const withdrawalAmount = to1e18("0.5")
+      await setupCarolsTrove()
+
+      const activePoolBalance =
+        await contracts.activePool.getCollateralBalance()
+      await contracts.borrowerOperations
+        .connect(carol.wallet)
+        .withdrawColl(withdrawalAmount, carol.wallet, carol.wallet)
+      const newActivePoolBalance =
+        await contracts.activePool.getCollateralBalance()
+
+      expect(newActivePoolBalance).to.equal(
+        activePoolBalance - withdrawalAmount,
+      )
+    })
+
+    it("applies pending rewards and updates user's L_Collateral, L_MUSDDebt snapshots", async () => {
+      await openTrove(contracts, {
+        musdAmount: "50,000",
+        ICR: "1000",
+        sender: carol.wallet,
+      })
+
+      await openTrove(contracts, {
+        musdAmount: "15,000",
+        ICR: "1000",
+        sender: dennis.wallet,
+      })
+
+      await updateTroveSnapshot(contracts, carol, "before")
+      await updateTroveSnapshot(contracts, dennis, "before")
+
+      // Make Alice subject to liquidation
+      const price = to1e18("25,000")
+      await contracts.mockAggregator.setPrice(price)
+
+      // liquidate Alice
+      await contracts.troveManager
+        .connect(deployer.wallet)
+        .liquidate(alice.wallet)
+
+      state.troveManager.liquidation.collateral.before =
+        await contracts.troveManager.L_Collateral()
+      state.troveManager.liquidation.debt.before =
+        await contracts.troveManager.L_MUSDDebt()
+
+      await updateRewardSnapshot(contracts, carol, "before")
+      await updateRewardSnapshot(contracts, dennis, "before")
+      await updatePendingSnapshot(contracts, carol, "before")
+      await updatePendingSnapshot(contracts, dennis, "before")
+
+      // Check Bob and Carol have pending rewards from the liquidation
+      expect(carol.pending.collateral.before).to.greaterThan(0n)
+      expect(dennis.pending.collateral.before).to.greaterThan(0n)
+      expect(carol.pending.debt.before).to.greaterThan(0n)
+      expect(dennis.pending.debt.before).to.greaterThan(0n)
+
+      const withdrawalAmount = 1n
+      await contracts.borrowerOperations
+        .connect(carol.wallet)
+        .withdrawColl(withdrawalAmount, carol.wallet, carol.wallet, NO_GAS)
+      await contracts.borrowerOperations
+        .connect(dennis.wallet)
+        .withdrawColl(withdrawalAmount, dennis.wallet, dennis.wallet, NO_GAS)
+
+      await updateTroveSnapshot(contracts, carol, "after")
+      await updateTroveSnapshot(contracts, dennis, "after")
+
+      // Check rewards have been applied to troves
+      expect(carol.trove.collateral.after).to.equal(
+        carol.trove.collateral.before +
+          carol.pending.collateral.before -
+          withdrawalAmount,
+      )
+      expect(dennis.trove.collateral.after).to.equal(
+        dennis.trove.collateral.before +
+          dennis.pending.collateral.before -
+          withdrawalAmount,
+      )
+
+      await updateRewardSnapshot(contracts, carol, "after")
+      await updateRewardSnapshot(contracts, dennis, "after")
+
+      expect(carol.rewardSnapshot.collateral.after).to.equal(
+        state.troveManager.liquidation.collateral.before,
+      )
+      expect(dennis.rewardSnapshot.collateral.after).to.equal(
+        state.troveManager.liquidation.collateral.before,
+      )
+      expect(carol.rewardSnapshot.debt.after).to.equal(
+        state.troveManager.liquidation.debt.before,
+      )
+      expect(dennis.rewardSnapshot.debt.after).to.equal(
+        state.troveManager.liquidation.debt.before,
+      )
+    })
 
     context("Expected Reverts", () => {
-      it("withdrawColl(): reverts when withdrawal would leave trove with ICR < MCR", async () => {
+      it("reverts when withdrawal would leave trove with ICR < MCR", async () => {
         const price = await contracts.priceFeed.fetchPrice()
         await updateTroveSnapshot(contracts, alice, "before")
         expect(
@@ -1463,7 +1463,7 @@ describe("BorrowerOperations in Normal Mode", () => {
         )
       })
 
-      it("withdrawColl(): no mintlist, reverts when withdrawal would leave trove with ICR < MCR", async () => {
+      it("no mintlist, reverts when withdrawal would leave trove with ICR < MCR", async () => {
         await removeMintlist(contracts, deployer.wallet)
 
         const price = await contracts.priceFeed.fetchPrice()
@@ -1484,8 +1484,7 @@ describe("BorrowerOperations in Normal Mode", () => {
         )
       })
 
-      // reverts when calling address does not have active trove
-      it("withdrawColl(): reverts when calling address does not have active trove", async () => {
+      it("reverts when calling address does not have active trove", async () => {
         await expect(
           contracts.borrowerOperations
             .connect(carol.wallet)
@@ -1493,7 +1492,7 @@ describe("BorrowerOperations in Normal Mode", () => {
         ).to.be.revertedWith("BorrowerOps: Trove does not exist or is closed")
       })
 
-      it("withdrawColl(): reverts when requested collateral withdrawal is > the trove's collateral", async () => {
+      it("reverts when requested collateral withdrawal is > the trove's collateral", async () => {
         await updateTroveSnapshot(contracts, alice, "before")
         await expect(
           contracts.borrowerOperations
@@ -1506,243 +1505,271 @@ describe("BorrowerOperations in Normal Mode", () => {
         ).to.be.revertedWithPanic()
       })
     })
-
-    /**
-     *
-     * Emitted Events
-     *
-     */
-
-    context("Emitted Events", () => {})
-
-    /**
-     *
-     * System State Changes
-     *
-     */
-
-    context("System State Changes", () => {
-      it("withdrawColl(): updates the stake and updates the total stakes", async () => {
-        await setupCarolsTrove()
-        await updateTroveSnapshot(contracts, alice, "before")
-        await updateTroveSnapshot(contracts, bob, "before")
-        await updateTroveSnapshot(contracts, carol, "before")
-
-        state.troveManager.stakes.before =
-          await contracts.troveManager.totalStakes()
-
-        expect(carol.trove.stake.before).to.equal(carol.trove.collateral.before)
-        expect(
-          alice.trove.stake.before +
-            bob.trove.stake.before +
-            carol.trove.stake.before,
-        ).to.equal(state.troveManager.stakes.before)
-
-        const withdrawalAmount = 1n
-        await contracts.borrowerOperations
-          .connect(carol.wallet)
-          .withdrawColl(withdrawalAmount, carol.wallet, carol.wallet)
-        await updateTroveSnapshot(contracts, carol, "after")
-
-        state.troveManager.stakes.after =
-          await contracts.troveManager.totalStakes()
-        expect(
-          alice.trove.stake.before +
-            bob.trove.stake.before +
-            carol.trove.stake.after,
-        ).to.equal(state.troveManager.stakes.after)
-        expect(carol.trove.stake.after).to.equal(
-          carol.trove.stake.before - withdrawalAmount,
-        )
-        expect(carol.trove.collateral.after).to.equal(
-          carol.trove.collateral.before - withdrawalAmount,
-        )
-      })
-    })
-
-    /**
-     *
-     * Individual Troves
-     *
-     */
-
-    context("Individual Troves", () => {
-      it("withdrawColl(): leaves the Trove active when the user withdraws less than all the collateral", async () => {
-        const withdrawalAmount = 1n
-        await setupCarolsTrove()
-
-        await contracts.borrowerOperations
-          .connect(carol.wallet)
-          .withdrawColl(withdrawalAmount, carol.wallet, carol.wallet)
-
-        await updateTroveSnapshot(contracts, carol, "after")
-
-        expect(carol.trove.status.after).to.equal(1)
-        expect(await contracts.sortedTroves.contains(carol.wallet)).to.equal(
-          true,
-        )
-      })
-
-      it("withdrawColl(): reduces the Trove's collateral by the correct amount", async () => {
-        const withdrawalAmount = 1n
-        await setupCarolsTrove()
-
-        await updateTroveSnapshot(contracts, carol, "before")
-        await contracts.borrowerOperations
-          .connect(carol.wallet)
-          .withdrawColl(withdrawalAmount, carol.wallet, carol.wallet)
-        await updateTroveSnapshot(contracts, carol, "after")
-
-        expect(carol.trove.collateral.after).to.equal(
-          carol.trove.collateral.before - withdrawalAmount,
-        )
-      })
-    })
-
-    /**
-     *
-     *  Balance changes
-     *
-     */
-
-    context("Balance changes", () => {
-      it("withdrawColl(): sends the correct amount of collateral to the user", async () => {
-        const withdrawalAmount = to1e18("0.5")
-        await setupCarolsTrove()
-
-        carol.btc.before = await ethers.provider.getBalance(carol.address)
-        await contracts.borrowerOperations
-          .connect(carol.wallet)
-          .withdrawColl(withdrawalAmount, carol.wallet, carol.wallet, NO_GAS)
-        carol.btc.after = await ethers.provider.getBalance(carol.address)
-
-        expect(carol.btc.after).to.equal(carol.btc.before + withdrawalAmount)
-      })
-    })
-
-    /**
-     *
-     * Fees
-     *
-     */
-
-    context("Fees", () => {})
-
-    /**
-     *
-     * State change in other contracts
-     *
-     */
-
-    context("State change in other contracts", () => {
-      it("withdrawColl(): reduces ActivePool collateral and raw collateral by correct amount", async () => {
-        const withdrawalAmount = to1e18("0.5")
-        await setupCarolsTrove()
-
-        const activePoolBalance =
-          await contracts.activePool.getCollateralBalance()
-        await contracts.borrowerOperations
-          .connect(carol.wallet)
-          .withdrawColl(withdrawalAmount, carol.wallet, carol.wallet)
-        const newActivePoolBalance =
-          await contracts.activePool.getCollateralBalance()
-
-        expect(newActivePoolBalance).to.equal(
-          activePoolBalance - withdrawalAmount,
-        )
-      })
-
-      it("withdrawColl(): applies pending rewards and updates user's L_Collateral, L_MUSDDebt snapshots", async () => {
-        await openTrove(contracts, {
-          musdAmount: "50,000",
-          ICR: "1000",
-          sender: carol.wallet,
-        })
-
-        await openTrove(contracts, {
-          musdAmount: "15,000",
-          ICR: "1000",
-          sender: dennis.wallet,
-        })
-
-        await updateTroveSnapshot(contracts, carol, "before")
-        await updateTroveSnapshot(contracts, dennis, "before")
-
-        // Make Alice subject to liquidation
-        const price = to1e18("25,000")
-        await contracts.mockAggregator.setPrice(price)
-
-        // liquidate Alice
-        await contracts.troveManager
-          .connect(deployer.wallet)
-          .liquidate(alice.wallet)
-
-        state.troveManager.liquidation.collateral.before =
-          await contracts.troveManager.L_Collateral()
-        state.troveManager.liquidation.debt.before =
-          await contracts.troveManager.L_MUSDDebt()
-
-        await updateRewardSnapshot(contracts, carol, "before")
-        await updateRewardSnapshot(contracts, dennis, "before")
-        await updatePendingSnapshot(contracts, carol, "before")
-        await updatePendingSnapshot(contracts, dennis, "before")
-
-        // Check Bob and Carol have pending rewards from the liquidation
-        expect(carol.pending.collateral.before).to.greaterThan(0n)
-        expect(dennis.pending.collateral.before).to.greaterThan(0n)
-        expect(carol.pending.debt.before).to.greaterThan(0n)
-        expect(dennis.pending.debt.before).to.greaterThan(0n)
-
-        const withdrawalAmount = 1n
-        await contracts.borrowerOperations
-          .connect(carol.wallet)
-          .withdrawColl(withdrawalAmount, carol.wallet, carol.wallet, NO_GAS)
-        await contracts.borrowerOperations
-          .connect(dennis.wallet)
-          .withdrawColl(withdrawalAmount, dennis.wallet, dennis.wallet, NO_GAS)
-
-        await updateTroveSnapshot(contracts, carol, "after")
-        await updateTroveSnapshot(contracts, dennis, "after")
-
-        // Check rewards have been applied to troves
-        expect(carol.trove.collateral.after).to.equal(
-          carol.trove.collateral.before +
-            carol.pending.collateral.before -
-            withdrawalAmount,
-        )
-        expect(dennis.trove.collateral.after).to.equal(
-          dennis.trove.collateral.before +
-            dennis.pending.collateral.before -
-            withdrawalAmount,
-        )
-
-        await updateRewardSnapshot(contracts, carol, "after")
-        await updateRewardSnapshot(contracts, dennis, "after")
-
-        expect(carol.rewardSnapshot.collateral.after).to.equal(
-          state.troveManager.liquidation.collateral.before,
-        )
-        expect(dennis.rewardSnapshot.collateral.after).to.equal(
-          state.troveManager.liquidation.collateral.before,
-        )
-        expect(carol.rewardSnapshot.debt.after).to.equal(
-          state.troveManager.liquidation.debt.before,
-        )
-        expect(dennis.rewardSnapshot.debt.after).to.equal(
-          state.troveManager.liquidation.debt.before,
-        )
-      })
-    })
   })
 
-  describe("withdrawMUSD", () => {
-    /**
-     *
-     * Expected Reverts
-     *
-     */
+  describe("withdrawMUSD()", () => {
+    it("decays a non-zero base rate", async () => {
+      const maxFeePercentage = to1e18(1)
+      const amount = to1e18(1)
+      const newRate = to1e18(5) / 100n
+      await setupCarolsTroveAndAdjustRate()
+
+      await fastForwardTime(7200)
+      // first withdrawal
+      await contracts.borrowerOperations
+        .connect(bob.wallet)
+        .withdrawMUSD(maxFeePercentage, amount, bob.wallet, bob.wallet)
+
+      const baseRate2 = await contracts.troveManager.baseRate()
+      expect(newRate).is.greaterThan(baseRate2)
+
+      await fastForwardTime(3600)
+      // second withdrawal
+      await contracts.borrowerOperations
+        .connect(bob.wallet)
+        .withdrawMUSD(maxFeePercentage, amount, bob.wallet, bob.wallet)
+
+      const baseRate3 = await contracts.troveManager.baseRate()
+      expect(baseRate2).is.greaterThan(baseRate3)
+    })
+
+    it("doesn't change base rate if it is already zero", async () => {
+      const maxFeePercentage = to1e18(1)
+      const amount = to1e18(1)
+      await setupCarolsTrove()
+
+      // first withdrawal
+      await contracts.borrowerOperations
+        .connect(bob.wallet)
+        .withdrawMUSD(maxFeePercentage, amount, bob.wallet, bob.wallet)
+
+      expect(await contracts.troveManager.baseRate()).is.equal(0n)
+
+      await fastForwardTime(3600)
+
+      // second withdrawal
+      await contracts.borrowerOperations
+        .connect(bob.wallet)
+        .withdrawMUSD(maxFeePercentage, amount, bob.wallet, bob.wallet)
+
+      expect(await contracts.troveManager.baseRate()).is.equal(0n)
+    })
+
+    it("lastFeeOpTime doesn't update if less time than decay interval has passed since the last fee operation", async () => {
+      const maxFeePercentage = to1e18(1)
+      const amount = to1e18(1)
+      await setupCarolsTrove()
+
+      // Artificially make baseRate 5%
+      const newRate = to1e18(5) / 100n
+      await setNewRate(newRate)
+
+      const lastFeeOpTime1 = await contracts.troveManager.lastFeeOperationTime()
+      await fastForwardTime(10)
+
+      // trigger a fee
+      await contracts.borrowerOperations
+        .connect(bob.wallet)
+        .withdrawMUSD(maxFeePercentage, amount, bob.wallet, bob.wallet)
+
+      await expect(lastFeeOpTime1).to.equal(
+        await contracts.troveManager.lastFeeOperationTime(),
+      )
+      await fastForwardTime(60)
+
+      // trigger second fee
+      await contracts.borrowerOperations
+        .connect(bob.wallet)
+        .withdrawMUSD(maxFeePercentage, amount, bob.wallet, bob.wallet)
+
+      expect(lastFeeOpTime1).to.be.lessThan(
+        await contracts.troveManager.lastFeeOperationTime(),
+      )
+    })
+
+    it("borrowing at zero base rate changes MUSD fees", async () => {
+      const maxFeePercentage = to1e18(1)
+      const amount = to1e18(1)
+      await setupCarolsTrove()
+
+      state.pcv.musd.before = await contracts.musd.balanceOf(addresses.pcv)
+      await contracts.borrowerOperations
+        .connect(bob.wallet)
+        .withdrawMUSD(maxFeePercentage, amount, bob.wallet, bob.wallet)
+      state.pcv.musd.after = await contracts.musd.balanceOf(addresses.pcv)
+
+      expect(state.pcv.musd.after).is.greaterThan(state.pcv.musd.before)
+    })
+
+    it("increases the Trove's MUSD debt by the correct amount", async () => {
+      const maxFeePercentage = to1e18(1)
+      const amount = to1e18(1)
+      const borrowingRate = await contracts.troveManager.getBorrowingRate()
+      await setupCarolsTrove()
+
+      await updateTroveSnapshot(contracts, carol, "before")
+      await contracts.borrowerOperations
+        .connect(carol.wallet)
+        .withdrawMUSD(maxFeePercentage, amount, carol.wallet, carol.wallet)
+      await updateTroveSnapshot(contracts, carol, "after")
+
+      expect(carol.trove.debt.after).to.equal(
+        carol.trove.debt.before +
+          (amount * (to1e18(1) + borrowingRate)) / to1e18(1),
+      )
+    })
+
+    it("borrowing at zero base rate sends debt request to user", async () => {
+      const maxFeePercentage = to1e18(1)
+      const amount = to1e18(1)
+      await setupCarolsTrove()
+
+      // Check baseRate is zero
+      expect(await contracts.troveManager.baseRate()).to.equal(0)
+
+      await fastForwardTime(7200)
+
+      carol.musd.before = await contracts.musd.balanceOf(carol.wallet)
+      await contracts.borrowerOperations
+        .connect(carol.wallet)
+        .withdrawMUSD(maxFeePercentage, amount, carol.wallet, carol.wallet)
+      carol.musd.after = await contracts.musd.balanceOf(carol.wallet)
+
+      expect(carol.musd.after).to.equal(carol.musd.before + amount)
+    })
+
+    it("withdrawMUSD(): borrowing at non-zero base rate sends requested amount to the user", async () => {
+      const maxFeePercentage = to1e18(1)
+      const amount = to1e18(1)
+      await setupCarolsTroveAndAdjustRate()
+
+      carol.musd.before = await contracts.musd.balanceOf(carol.wallet)
+      await contracts.borrowerOperations
+        .connect(carol.wallet)
+        .withdrawMUSD(maxFeePercentage, amount, carol.wallet, carol.wallet)
+      carol.musd.after = await contracts.musd.balanceOf(carol.wallet)
+
+      expect(carol.musd.after).to.equal(carol.musd.before + amount)
+    })
+
+    it("withdrawMUSD(): borrower can't grief the baseRate and stop it decaying by issuing debt at higher frequency than the decay granularity", async () => {
+      const maxFeePercentage = to1e18(1)
+      const amount = to1e18(1)
+
+      await openTrove(contracts, {
+        musdAmount: "20,000",
+        ICR: "500",
+        sender: carol.wallet,
+      })
+
+      const newRate = to1e18(5) / 100n
+      await setNewRate(newRate)
+
+      // 30 seconds
+      fastForwardTime(30)
+
+      // Borrower triggers a fee, before 60 minute decay interval has passed
+      await contracts.borrowerOperations
+        .connect(carol.wallet)
+        .withdrawMUSD(maxFeePercentage, amount, carol.wallet, carol.wallet)
+
+      // 1 minute pass
+      fastForwardTime(60)
+
+      // Borrower triggers another fee
+      await contracts.borrowerOperations
+        .connect(carol.wallet)
+        .withdrawMUSD(maxFeePercentage, amount, carol.wallet, carol.wallet)
+
+      // Check base rate has decreased even though Borrower tried to stop it decaying
+      expect(await contracts.troveManager.baseRate()).is.lessThan(newRate)
+    })
+
+    it("borrowing at non-zero base rate sends MUSD fee to PCV contract", async () => {
+      const maxFeePercentage = to1e18(1)
+      const amount = to1e18(1)
+      await setupCarolsTroveAndAdjustRate()
+
+      state.pcv.musd.before = await contracts.musd.balanceOf(addresses.pcv)
+      await contracts.borrowerOperations
+        .connect(carol.wallet)
+        .withdrawMUSD(maxFeePercentage, amount, carol.wallet, carol.wallet)
+      state.pcv.musd.after = await contracts.musd.balanceOf(addresses.pcv)
+      expect(state.pcv.musd.after).to.greaterThan(state.pcv.musd.before)
+    })
+
+    it("borrowing at non-zero base records the (drawn debt + fee) on the Trove struct", async () => {
+      const maxFeePercentage = to1e18(1)
+      const amount = to1e18(1)
+      const abi = [
+        // Add your contract ABI here
+        "event MUSDBorrowingFeePaid(address indexed _borrower, uint256 _MUSDFee)",
+      ]
+      await setupCarolsTroveAndAdjustRate()
+
+      await updateTroveSnapshot(contracts, carol, "before")
+      const tx = await contracts.borrowerOperations
+        .connect(carol.wallet)
+        .withdrawMUSD(maxFeePercentage, amount, carol.wallet, carol.wallet)
+
+      const emittedFee = await getEventArgByName(
+        tx,
+        abi,
+        "MUSDBorrowingFeePaid",
+        1,
+      )
+      expect(emittedFee).to.greaterThan(0)
+
+      await updateTroveSnapshot(contracts, carol, "after")
+
+      expect(carol.trove.debt.after).to.equal(
+        carol.trove.debt.before + emittedFee + amount,
+      )
+    })
+
+    it("increases MUSD debt in ActivePool by correct amount", async () => {
+      const maxFeePercentage = to1e18(1)
+      const amount = to1e18(1)
+
+      await setupCarolsTrove()
+      await updateTroveSnapshot(contracts, carol, "before")
+      await updateContractsSnapshot(
+        contracts,
+        state,
+        "activePool",
+        "before",
+        addresses,
+      )
+
+      const expectedDebt =
+        amount + (await contracts.troveManager.getBorrowingFee(amount))
+
+      await contracts.borrowerOperations
+        .connect(carol.wallet)
+        .withdrawMUSD(maxFeePercentage, amount, carol.wallet, carol.wallet)
+
+      await updateTroveSnapshot(contracts, carol, "after")
+      await updateContractsSnapshot(
+        contracts,
+        state,
+        "activePool",
+        "after",
+        addresses,
+      )
+
+      expect(state.activePool.debt.after).to.equal(
+        state.activePool.debt.before + expectedDebt,
+      )
+
+      expect(state.activePool.debt.after).to.equal(
+        state.activePool.debt.before +
+          carol.trove.debt.after -
+          carol.trove.debt.before,
+      )
+    })
+
     context("Expected Reverts", () => {
-      it("withdrawMUSD(): reverts if BorrowerOperations removed from mintlist", async () => {
+      it("reverts if BorrowerOperations removed from mintlist", async () => {
         await removeMintlist(contracts, deployer.wallet)
         await expect(
           contracts.borrowerOperations.withdrawMUSD(
@@ -1754,7 +1781,7 @@ describe("BorrowerOperations in Normal Mode", () => {
         ).to.be.revertedWith("MUSD: Caller not allowed to mint")
       })
 
-      it("withdrawMUSD(): reverts when withdrawal would leave trove with ICR < MCR", async () => {
+      it("reverts when withdrawal would leave trove with ICR < MCR", async () => {
         await setupCarolsTrove() // add extra trove so we can drop Bob's c-ratio below the MCR without putting the system into recovery mode
 
         // Price drops 50,000 --> 30,000
@@ -1777,7 +1804,7 @@ describe("BorrowerOperations in Normal Mode", () => {
         )
       })
 
-      it("withdrawMUSD(): reverts if max fee > 100%", async () => {
+      it("reverts if max fee > 100%", async () => {
         const maxFeePercentage = to1e18(1) + 1n
         const amount = 1n
         await expect(
@@ -1787,7 +1814,7 @@ describe("BorrowerOperations in Normal Mode", () => {
         ).to.be.revertedWith("Max fee percentage must be between 0.5% and 100%")
       })
 
-      it("withdrawMUSD(): reverts if max fee < 0.5% in Normal mode", async () => {
+      it("reverts if max fee < 0.5% in Normal mode", async () => {
         const maxFeePercentage = to1e18(0.005) - 1n
         const amount = 1n
         await expect(
@@ -1797,7 +1824,7 @@ describe("BorrowerOperations in Normal Mode", () => {
         ).to.be.revertedWith("Max fee percentage must be between 0.5% and 100%")
       })
 
-      it("withdrawMUSD(): reverts if fee exceeds max fee percentage", async () => {
+      it("reverts if fee exceeds max fee percentage", async () => {
         const newRate = to1e18(5) / 100n
         await setupCarolsTroveAndAdjustRate()
 
@@ -1811,7 +1838,7 @@ describe("BorrowerOperations in Normal Mode", () => {
         ).to.be.revertedWith("Fee exceeded provided maximum")
       })
 
-      it("withdrawMUSD(): reverts when calling address does not have active trove", async () => {
+      it("reverts when calling address does not have active trove", async () => {
         const maxFeePercentage = to1e18(1)
         const amount = to1e18(1)
 
@@ -1822,7 +1849,7 @@ describe("BorrowerOperations in Normal Mode", () => {
         ).to.be.revertedWith("BorrowerOps: Trove does not exist or is closed")
       })
 
-      it("withdrawMUSD(): reverts when requested withdrawal amount is zero MUSD", async () => {
+      it("reverts when requested withdrawal amount is zero MUSD", async () => {
         const maxFeePercentage = to1e18(1)
         const amount = 0
 
@@ -1835,7 +1862,7 @@ describe("BorrowerOperations in Normal Mode", () => {
         )
       })
 
-      it("withdrawMUSD(): reverts when a withdrawal would cause the TCR of the system to fall below the CCR", async () => {
+      it("reverts when a withdrawal would cause the TCR of the system to fall below the CCR", async () => {
         const price = await contracts.priceFeed.fetchPrice()
         const tcr = await contracts.troveManager.getTCR(price)
 
@@ -1854,328 +1881,70 @@ describe("BorrowerOperations in Normal Mode", () => {
         )
       })
     })
-
-    /**
-     *
-     * Emitted Events
-     *
-     */
-
-    context("Emitted Events", () => {})
-
-    /**
-     *
-     * System State Changes
-     *
-     */
-
-    context("System State Changes", () => {
-      it("withdrawMUSD(): decays a non-zero base rate", async () => {
-        const maxFeePercentage = to1e18(1)
-        const amount = to1e18(1)
-        const newRate = to1e18(5) / 100n
-        await setupCarolsTroveAndAdjustRate()
-
-        await fastForwardTime(7200)
-        // first withdrawal
-        await contracts.borrowerOperations
-          .connect(bob.wallet)
-          .withdrawMUSD(maxFeePercentage, amount, bob.wallet, bob.wallet)
-
-        const baseRate2 = await contracts.troveManager.baseRate()
-        expect(newRate).is.greaterThan(baseRate2)
-
-        await fastForwardTime(3600)
-        // second withdrawal
-        await contracts.borrowerOperations
-          .connect(bob.wallet)
-          .withdrawMUSD(maxFeePercentage, amount, bob.wallet, bob.wallet)
-
-        const baseRate3 = await contracts.troveManager.baseRate()
-        expect(baseRate2).is.greaterThan(baseRate3)
-      })
-
-      it("withdrawMUSD(): doesn't change base rate if it is already zero", async () => {
-        const maxFeePercentage = to1e18(1)
-        const amount = to1e18(1)
-        await setupCarolsTrove()
-
-        // first withdrawal
-        await contracts.borrowerOperations
-          .connect(bob.wallet)
-          .withdrawMUSD(maxFeePercentage, amount, bob.wallet, bob.wallet)
-
-        expect(await contracts.troveManager.baseRate()).is.equal(0n)
-
-        await fastForwardTime(3600)
-
-        // second withdrawal
-        await contracts.borrowerOperations
-          .connect(bob.wallet)
-          .withdrawMUSD(maxFeePercentage, amount, bob.wallet, bob.wallet)
-
-        expect(await contracts.troveManager.baseRate()).is.equal(0n)
-      })
-
-      it("withdrawMUSD(): lastFeeOpTime doesn't update if less time than decay interval has passed since the last fee operation", async () => {
-        const maxFeePercentage = to1e18(1)
-        const amount = to1e18(1)
-        await setupCarolsTrove()
-
-        // Artificially make baseRate 5%
-        const newRate = to1e18(5) / 100n
-        await setNewRate(newRate)
-
-        const lastFeeOpTime1 =
-          await contracts.troveManager.lastFeeOperationTime()
-        await fastForwardTime(10)
-
-        // trigger a fee
-        await contracts.borrowerOperations
-          .connect(bob.wallet)
-          .withdrawMUSD(maxFeePercentage, amount, bob.wallet, bob.wallet)
-
-        await expect(lastFeeOpTime1).to.equal(
-          await contracts.troveManager.lastFeeOperationTime(),
-        )
-        await fastForwardTime(60)
-
-        // trigger second fee
-        await contracts.borrowerOperations
-          .connect(bob.wallet)
-          .withdrawMUSD(maxFeePercentage, amount, bob.wallet, bob.wallet)
-
-        expect(lastFeeOpTime1).to.be.lessThan(
-          await contracts.troveManager.lastFeeOperationTime(),
-        )
-      })
-
-      it("withdrawMUSD(): borrowing at zero base rate changes MUSD fees", async () => {
-        const maxFeePercentage = to1e18(1)
-        const amount = to1e18(1)
-        await setupCarolsTrove()
-
-        state.pcv.musd.before = await contracts.musd.balanceOf(addresses.pcv)
-        await contracts.borrowerOperations
-          .connect(bob.wallet)
-          .withdrawMUSD(maxFeePercentage, amount, bob.wallet, bob.wallet)
-        state.pcv.musd.after = await contracts.musd.balanceOf(addresses.pcv)
-
-        expect(state.pcv.musd.after).is.greaterThan(state.pcv.musd.before)
-      })
-    })
-
-    /**
-     *
-     * Individual Troves
-     *
-     */
-
-    context("Individual Troves", () => {
-      // it("withdrawMUSD(): succeeds when fee is less than max fee percentage", async () => {})
-
-      it("withdrawMUSD(): increases the Trove's MUSD debt by the correct amount", async () => {
-        const maxFeePercentage = to1e18(1)
-        const amount = to1e18(1)
-        const borrowingRate = await contracts.troveManager.getBorrowingRate()
-        await setupCarolsTrove()
-
-        await updateTroveSnapshot(contracts, carol, "before")
-        await contracts.borrowerOperations
-          .connect(carol.wallet)
-          .withdrawMUSD(maxFeePercentage, amount, carol.wallet, carol.wallet)
-        await updateTroveSnapshot(contracts, carol, "after")
-
-        expect(carol.trove.debt.after).to.equal(
-          carol.trove.debt.before +
-            (amount * (to1e18(1) + borrowingRate)) / to1e18(1),
-        )
-      })
-    })
-
-    /**
-     *
-     *  Balance changes
-     *
-     */
-
-    context("Balance changes", () => {
-      it("withdrawMUSD(): borrowing at zero base rate sends debt request to user", async () => {
-        const maxFeePercentage = to1e18(1)
-        const amount = to1e18(1)
-        await setupCarolsTrove()
-
-        // Check baseRate is zero
-        expect(await contracts.troveManager.baseRate()).to.equal(0)
-
-        await fastForwardTime(7200)
-
-        carol.musd.before = await contracts.musd.balanceOf(carol.wallet)
-        await contracts.borrowerOperations
-          .connect(carol.wallet)
-          .withdrawMUSD(maxFeePercentage, amount, carol.wallet, carol.wallet)
-        carol.musd.after = await contracts.musd.balanceOf(carol.wallet)
-
-        expect(carol.musd.after).to.equal(carol.musd.before + amount)
-      })
-
-      it("withdrawMUSD(): borrowing at non-zero base rate sends requested amount to the user", async () => {
-        const maxFeePercentage = to1e18(1)
-        const amount = to1e18(1)
-        await setupCarolsTroveAndAdjustRate()
-
-        carol.musd.before = await contracts.musd.balanceOf(carol.wallet)
-        await contracts.borrowerOperations
-          .connect(carol.wallet)
-          .withdrawMUSD(maxFeePercentage, amount, carol.wallet, carol.wallet)
-        carol.musd.after = await contracts.musd.balanceOf(carol.wallet)
-
-        expect(carol.musd.after).to.equal(carol.musd.before + amount)
-      })
-    })
-
-    /**
-     *
-     * Fees
-     *
-     */
-
-    context("Fees", () => {
-      it("withdrawMUSD(): borrower can't grief the baseRate and stop it decaying by issuing debt at higher frequency than the decay granularity", async () => {
-        const maxFeePercentage = to1e18(1)
-        const amount = to1e18(1)
-
-        await openTrove(contracts, {
-          musdAmount: "20,000",
-          ICR: "500",
-          sender: carol.wallet,
-        })
-
-        const newRate = to1e18(5) / 100n
-        await setNewRate(newRate)
-
-        // 30 seconds
-        fastForwardTime(30)
-
-        // Borrower triggers a fee, before 60 minute decay interval has passed
-        await contracts.borrowerOperations
-          .connect(carol.wallet)
-          .withdrawMUSD(maxFeePercentage, amount, carol.wallet, carol.wallet)
-
-        // 1 minute pass
-        fastForwardTime(60)
-
-        // Borrower triggers another fee
-        await contracts.borrowerOperations
-          .connect(carol.wallet)
-          .withdrawMUSD(maxFeePercentage, amount, carol.wallet, carol.wallet)
-
-        // Check base rate has decreased even though Borrower tried to stop it decaying
-        expect(await contracts.troveManager.baseRate()).is.lessThan(newRate)
-      })
-
-      it("withdrawMUSD(): borrowing at non-zero base rate sends MUSD fee to PCV contract", async () => {
-        const maxFeePercentage = to1e18(1)
-        const amount = to1e18(1)
-        await setupCarolsTroveAndAdjustRate()
-
-        state.pcv.musd.before = await contracts.musd.balanceOf(addresses.pcv)
-        await contracts.borrowerOperations
-          .connect(carol.wallet)
-          .withdrawMUSD(maxFeePercentage, amount, carol.wallet, carol.wallet)
-        state.pcv.musd.after = await contracts.musd.balanceOf(addresses.pcv)
-        expect(state.pcv.musd.after).to.greaterThan(state.pcv.musd.before)
-      })
-    })
-
-    /**
-     *
-     * State change in other contracts
-     *
-     */
-
-    context("State change in other contracts", () => {
-      it("withdrawMUSD(): borrowing at non-zero base records the (drawn debt + fee) on the Trove struct", async () => {
-        const maxFeePercentage = to1e18(1)
-        const amount = to1e18(1)
-        const abi = [
-          // Add your contract ABI here
-          "event MUSDBorrowingFeePaid(address indexed _borrower, uint256 _MUSDFee)",
-        ]
-        await setupCarolsTroveAndAdjustRate()
-
-        await updateTroveSnapshot(contracts, carol, "before")
-        const tx = await contracts.borrowerOperations
-          .connect(carol.wallet)
-          .withdrawMUSD(maxFeePercentage, amount, carol.wallet, carol.wallet)
-
-        const emittedFee = await getEventArgByName(
-          tx,
-          abi,
-          "MUSDBorrowingFeePaid",
-          1,
-        )
-        expect(emittedFee).to.greaterThan(0)
-
-        await updateTroveSnapshot(contracts, carol, "after")
-
-        expect(carol.trove.debt.after).to.equal(
-          carol.trove.debt.before + emittedFee + amount,
-        )
-      })
-
-      it("withdrawMUSD(): increases MUSD debt in ActivePool by correct amount", async () => {
-        const maxFeePercentage = to1e18(1)
-        const amount = to1e18(1)
-
-        await setupCarolsTrove()
-        await updateTroveSnapshot(contracts, carol, "before")
-        await updateContractsSnapshot(
-          contracts,
-          state,
-          "activePool",
-          "before",
-          addresses,
-        )
-
-        const expectedDebt =
-          amount + (await contracts.troveManager.getBorrowingFee(amount))
-
-        await contracts.borrowerOperations
-          .connect(carol.wallet)
-          .withdrawMUSD(maxFeePercentage, amount, carol.wallet, carol.wallet)
-
-        await updateTroveSnapshot(contracts, carol, "after")
-        await updateContractsSnapshot(
-          contracts,
-          state,
-          "activePool",
-          "after",
-          addresses,
-        )
-
-        expect(state.activePool.debt.after).to.equal(
-          state.activePool.debt.before + expectedDebt,
-        )
-
-        expect(state.activePool.debt.after).to.equal(
-          state.activePool.debt.before +
-            carol.trove.debt.after -
-            carol.trove.debt.before,
-        )
-      })
-    })
   })
 
-  describe("repayMUSD", () => {
-    /**
-     *
-     * Expected Reverts
-     *
-     */
+  describe("repayMUSD()", () => {
+    it("succeeds when it would leave trove with net debt >= minimum net debt", async () => {
+      const amount = to1e18("1,000")
+      await contracts.borrowerOperations
+        .connect(bob.wallet)
+        .repayMUSD(amount, bob.wallet, bob.wallet)
+      await updateTroveSnapshot(contracts, bob, "after")
+
+      expect(bob.trove.debt.after).is.greaterThan(MIN_NET_DEBT)
+    })
+
+    it("reduces the Trove's MUSD debt by the correct amount", async () => {
+      const amount = to1e18("1,000")
+      await updateTroveSnapshot(contracts, bob, "before")
+      await contracts.borrowerOperations
+        .connect(bob.wallet)
+        .repayMUSD(amount, bob.wallet, bob.wallet)
+      await updateTroveSnapshot(contracts, bob, "after")
+
+      expect(bob.trove.debt.after).to.equal(bob.trove.debt.before - amount)
+    })
+
+    it("decreases user MUSDToken balance by correct amount", async () => {
+      bob.musd.before = await contracts.musd.balanceOf(bob.address)
+      const amount = to1e18("1,000")
+      await contracts.borrowerOperations
+        .connect(bob.wallet)
+        .repayMUSD(amount, bob.wallet, bob.wallet)
+      bob.musd.after = await contracts.musd.balanceOf(bob.address)
+
+      expect(bob.musd.after).to.equal(bob.musd.before - amount)
+    })
+
+    it("decreases MUSD debt in ActivePool by correct amount", async () => {
+      await updateContractsSnapshot(
+        contracts,
+        state,
+        "activePool",
+        "before",
+        addresses,
+      )
+
+      const amount = to1e18("1,000")
+      await contracts.borrowerOperations
+        .connect(bob.wallet)
+        .repayMUSD(amount, bob.wallet, bob.wallet)
+
+      await updateContractsSnapshot(
+        contracts,
+        state,
+        "activePool",
+        "after",
+        addresses,
+      )
+
+      expect(state.activePool.debt.after).to.equal(
+        state.activePool.debt.before - amount,
+      )
+    })
 
     context("Expected Reverts", () => {
-      it("repayMUSD(): reverts when repayment would leave trove with ICR < MCR", async () => {
+      it("reverts when repayment would leave trove with ICR < MCR", async () => {
         await setupCarolsTrove()
 
         const price = to1e18("30,000")
@@ -2209,7 +1978,7 @@ describe("BorrowerOperations in Normal Mode", () => {
         )
       })
 
-      it("repayMUSD(): reverts when it would leave trove with net debt < minimum net debt", async () => {
+      it("reverts when it would leave trove with net debt < minimum net debt", async () => {
         await setupCarolsTrove()
         const amount = to1e18("9,999")
 
@@ -2222,7 +1991,7 @@ describe("BorrowerOperations in Normal Mode", () => {
         )
       })
 
-      it("repayMUSD(): reverts when calling address does not have active trove", async () => {
+      it("reverts when calling address does not have active trove", async () => {
         const amount = to1e18(1)
         await expect(
           contracts.borrowerOperations
@@ -2231,7 +2000,7 @@ describe("BorrowerOperations in Normal Mode", () => {
         ).to.be.revertedWith("BorrowerOps: Trove does not exist or is closed")
       })
 
-      it("repayMUSD(): reverts when attempted repayment is > the debt of the trove", async () => {
+      it("reverts when attempted repayment is > the debt of the trove", async () => {
         await updateTroveSnapshot(contracts, alice, "before")
         const amount = alice.trove.debt.before + 1n
         await expect(
@@ -2241,7 +2010,7 @@ describe("BorrowerOperations in Normal Mode", () => {
         ).to.be.revertedWithPanic()
       })
 
-      it("repayMUSD(): Reverts if borrower has insufficient MUSD balance to cover his debt repayment", async () => {
+      it("Reverts if borrower has insufficient MUSD balance to cover his debt repayment", async () => {
         // bob has $20,000 of MUSD. Transfer $15,000 to Alice before trying to repay $15,000
         const amount = to1e18("15,000")
         await contracts.musd.connect(bob.wallet).transfer(alice.wallet, amount)
@@ -2255,124 +2024,824 @@ describe("BorrowerOperations in Normal Mode", () => {
         )
       })
     })
-
-    /**
-     *
-     * Emitted Events
-     *
-     */
-
-    context("Emitted Events", () => {})
-
-    /**
-     *
-     * System State Changes
-     *
-     */
-
-    context("System State Changes", () => {})
-
-    /**
-     *
-     * Individual Troves
-     *
-     */
-
-    context("Individual Troves", () => {
-      it("repayMUSD(): succeeds when it would leave trove with net debt >= minimum net debt", async () => {
-        const amount = to1e18("1,000")
-        await contracts.borrowerOperations
-          .connect(bob.wallet)
-          .repayMUSD(amount, bob.wallet, bob.wallet)
-        await updateTroveSnapshot(contracts, bob, "after")
-
-        expect(bob.trove.debt.after).is.greaterThan(MIN_NET_DEBT)
-      })
-
-      it("repayMUSD(): reduces the Trove's MUSD debt by the correct amount", async () => {
-        const amount = to1e18("1,000")
-        await updateTroveSnapshot(contracts, bob, "before")
-        await contracts.borrowerOperations
-          .connect(bob.wallet)
-          .repayMUSD(amount, bob.wallet, bob.wallet)
-        await updateTroveSnapshot(contracts, bob, "after")
-
-        expect(bob.trove.debt.after).to.equal(bob.trove.debt.before - amount)
-      })
-    })
-
-    /**
-     *
-     *  Balance changes
-     *
-     */
-
-    context("Balance changes", () => {
-      it("repayMUSD(): decreases user MUSDToken balance by correct amount", async () => {
-        bob.musd.before = await contracts.musd.balanceOf(bob.address)
-        const amount = to1e18("1,000")
-        await contracts.borrowerOperations
-          .connect(bob.wallet)
-          .repayMUSD(amount, bob.wallet, bob.wallet)
-        bob.musd.after = await contracts.musd.balanceOf(bob.address)
-
-        expect(bob.musd.after).to.equal(bob.musd.before - amount)
-      })
-    })
-
-    /**
-     *
-     * Fees
-     *
-     */
-
-    context("Fees", () => {})
-
-    /**
-     *
-     * State change in other contracts
-     *
-     */
-
-    context("State change in other contracts", () => {
-      it("repayMUSD(): decreases MUSD debt in ActivePool by correct amount", async () => {
-        await updateContractsSnapshot(
-          contracts,
-          state,
-          "activePool",
-          "before",
-          addresses,
-        )
-
-        const amount = to1e18("1,000")
-        await contracts.borrowerOperations
-          .connect(bob.wallet)
-          .repayMUSD(amount, bob.wallet, bob.wallet)
-
-        await updateContractsSnapshot(
-          contracts,
-          state,
-          "activePool",
-          "after",
-          addresses,
-        )
-
-        expect(state.activePool.debt.after).to.equal(
-          state.activePool.debt.before - amount,
-        )
-      })
-    })
   })
 
   describe("adjustTrove()", () => {
-    /**
-     *
-     * Expected Reverts
-     *
-     */
+    it("decays a non-zero base rate", async () => {
+      const maxFeePercentage = to1e18(1)
+      const amount = to1e18(1)
+      const newRate = to1e18(5) / 100n
+      await setupCarolsTroveAndAdjustRate()
+      await fastForwardTime(7200)
+
+      await contracts.borrowerOperations
+        .connect(bob.wallet)
+        .adjustTrove(
+          maxFeePercentage,
+          0,
+          amount,
+          true,
+          0,
+          bob.wallet,
+          bob.wallet,
+        )
+
+      const baseRate2 = await contracts.troveManager.baseRate()
+      expect(newRate).is.greaterThan(baseRate2)
+
+      await fastForwardTime(3600)
+      // second withdrawal
+      await contracts.borrowerOperations
+        .connect(bob.wallet)
+        .adjustTrove(to1e18(1), 0, to1e18(37), true, 0, bob.wallet, bob.wallet)
+
+      const baseRate3 = await contracts.troveManager.baseRate()
+      expect(baseRate2).is.greaterThan(baseRate3)
+    })
+
+    it("doesn't decay a non-zero base rate when user issues 0 debt", async () => {
+      const maxFeePercentage = to1e18(1)
+      const assetAmount = to1e18(1)
+
+      await setupCarolsTroveAndAdjustRate()
+      await fastForwardTime(7200)
+      await updateTroveManagerSnapshot(contracts, state, "before")
+
+      await contracts.borrowerOperations
+        .connect(bob.wallet)
+        .adjustTrove(
+          maxFeePercentage,
+          0,
+          0,
+          false,
+          assetAmount,
+          bob.wallet,
+          bob.wallet,
+          {
+            value: assetAmount,
+          },
+        )
+
+      await updateTroveManagerSnapshot(contracts, state, "after")
+      // Check baseRate has not decreased
+      expect(state.troveManager.baseRate.after).is.equal(
+        state.troveManager.baseRate.before,
+      )
+    })
+
+    it("doesn't change base rate if it is already zero", async () => {
+      const maxFeePercentage = to1e18(1)
+
+      await setupCarolsTrove()
+      await fastForwardTime(7200)
+      await updateTroveManagerSnapshot(contracts, state, "before")
+
+      await contracts.borrowerOperations
+        .connect(bob.wallet)
+        .adjustTrove(
+          maxFeePercentage,
+          0,
+          to1e18(37),
+          true,
+          0,
+          bob.wallet,
+          bob.wallet,
+        )
+
+      await updateTroveManagerSnapshot(contracts, state, "after")
+      // Check baseRate has not decreased
+      expect(state.troveManager.baseRate.after).is.equal(
+        state.troveManager.baseRate.before,
+      )
+      expect(state.troveManager.baseRate.after).is.equal(0)
+    })
+
+    it("lastFeeOpTime doesn't update if less time than decay interval has passed since the last fee operation", async () => {
+      const maxFeePercentage = to1e18(1)
+
+      await setupCarolsTroveAndAdjustRate()
+      await contracts.troveManager.setLastFeeOpTimeToNow()
+      await updateTroveManagerSnapshot(contracts, state, "before")
+
+      await fastForwardTime(10)
+
+      await contracts.borrowerOperations
+        .connect(bob.wallet)
+        .adjustTrove(
+          maxFeePercentage,
+          0,
+          to1e18(37),
+          true,
+          0,
+          bob.wallet,
+          bob.wallet,
+        )
+
+      await updateTroveManagerSnapshot(contracts, state, "after")
+
+      expect(state.troveManager.lastFeeOperationTime.before).is.equal(
+        state.troveManager.lastFeeOperationTime.after,
+      )
+      expect(state.troveManager.lastFeeOperationTime.before).is.greaterThan(0)
+    })
+
+    it("borrower can't grief the baseRate and stop it decaying by issuing debt at higher frequency than the decay granularity", async () => {
+      const maxFeePercentage = to1e18(1)
+
+      await setupCarolsTroveAndAdjustRate()
+      await updateTroveManagerSnapshot(contracts, state, "before")
+
+      await contracts.borrowerOperations
+        .connect(bob.wallet)
+        .adjustTrove(
+          maxFeePercentage,
+          0,
+          to1e18(37),
+          true,
+          0,
+          bob.wallet,
+          bob.wallet,
+        )
+
+      await fastForwardTime(60)
+
+      await contracts.borrowerOperations
+        .connect(bob.wallet)
+        .adjustTrove(
+          maxFeePercentage,
+          0,
+          to1e18(37),
+          true,
+          0,
+          bob.wallet,
+          bob.wallet,
+        )
+      await updateTroveManagerSnapshot(contracts, state, "after")
+      expect(state.troveManager.baseRate.before).to.be.greaterThan(
+        state.troveManager.baseRate.after,
+      )
+    })
+
+    it("borrowing at non-zero base records the (drawn debt + fee) on the Trove struct", async () => {
+      const maxFeePercentage = to1e18(1)
+      const amount = to1e18(37)
+      const abi = [
+        // Add your contract ABI here
+        "event MUSDBorrowingFeePaid(address indexed _borrower, uint256 _MUSDFee)",
+      ]
+
+      await setupCarolsTroveAndAdjustRate()
+
+      await updateTroveSnapshot(contracts, bob, "before")
+      await fastForwardTime(60)
+
+      const tx = await contracts.borrowerOperations
+        .connect(bob.wallet)
+        .adjustTrove(
+          maxFeePercentage,
+          0,
+          amount,
+          true,
+          0,
+          bob.wallet,
+          bob.wallet,
+        )
+
+      const emittedFee = await getEventArgByName(
+        tx,
+        abi,
+        "MUSDBorrowingFeePaid",
+        1,
+      )
+
+      await updateTroveSnapshot(contracts, bob, "after")
+
+      expect(bob.trove.debt.after).to.equal(
+        bob.trove.debt.before + amount + emittedFee,
+      )
+    })
+
+    it("Borrowing at non-zero base rate sends requested amount to the user", async () => {
+      const maxFeePercentage = to1e18(1)
+      const amount = to1e18(37)
+
+      await setupCarolsTroveAndAdjustRate()
+      await updateWalletSnapshot(contracts, carol, "before")
+      await fastForwardTime(7200)
+
+      await contracts.borrowerOperations
+        .connect(carol.wallet)
+        .adjustTrove(
+          maxFeePercentage,
+          0,
+          amount,
+          true,
+          0,
+          carol.wallet,
+          carol.wallet,
+        )
+
+      await updateWalletSnapshot(contracts, carol, "after")
+      expect(carol.musd.after).to.equal(carol.musd.before + amount)
+    })
+
+    it("Borrowing at zero base rate sends total requested MUSD to the user", async () => {
+      const maxFeePercentage = to1e18(1)
+      const amount = to1e18(37)
+
+      await setupCarolsTrove()
+      await updateWalletSnapshot(contracts, carol, "before")
+      await fastForwardTime(7200)
+
+      await contracts.borrowerOperations
+        .connect(carol.wallet)
+        .adjustTrove(
+          maxFeePercentage,
+          0,
+          amount,
+          true,
+          0,
+          carol.wallet,
+          carol.wallet,
+        )
+
+      await updateWalletSnapshot(contracts, carol, "after")
+      expect(carol.musd.after).to.equal(carol.musd.before + amount)
+    })
+
+    it("Borrowing at zero base rate changes MUSD balance of PCV contract", async () => {
+      const maxFeePercentage = to1e18(1)
+      const amount = to1e18(37)
+
+      state.pcv.musd.before = await contracts.musd.balanceOf(addresses.pcv)
+
+      await setupCarolsTrove()
+      await fastForwardTime(7200)
+      expect(await contracts.troveManager.baseRate()).is.equal(0)
+
+      await contracts.borrowerOperations
+        .connect(carol.wallet)
+        .adjustTrove(
+          maxFeePercentage,
+          0,
+          amount,
+          true,
+          0,
+          carol.wallet,
+          carol.wallet,
+        )
+
+      state.pcv.musd.after = await contracts.musd.balanceOf(addresses.pcv)
+      expect(state.pcv.musd.after).to.be.greaterThan(state.pcv.musd.before)
+    })
+
+    it("borrowing at non-zero base rate sends MUSD fee to PCV contract", async () => {
+      const maxFeePercentage = to1e18(1)
+      const amount = to1e18(37)
+
+      state.pcv.musd.before = await contracts.musd.balanceOf(addresses.pcv)
+
+      await setupCarolsTroveAndAdjustRate()
+      await fastForwardTime(7200)
+
+      await contracts.borrowerOperations
+        .connect(carol.wallet)
+        .adjustTrove(
+          maxFeePercentage,
+          0,
+          amount,
+          true,
+          0,
+          carol.wallet,
+          carol.wallet,
+        )
+
+      state.pcv.musd.after = await contracts.musd.balanceOf(addresses.pcv)
+      expect(state.pcv.musd.after).to.be.greaterThan(state.pcv.musd.before)
+    })
+
+    it("With 0 coll change, doesnt change borrower's coll or ActivePool coll", async () => {
+      const maxFeePercentage = to1e18(1)
+      const amount = to1e18(37)
+
+      await setupCarolsTrove()
+      await updateTroveSnapshot(contracts, carol, "before")
+      await updateContractsSnapshot(
+        contracts,
+        state,
+        "activePool",
+        "before",
+        addresses,
+      )
+
+      await contracts.borrowerOperations
+        .connect(carol.wallet)
+        .adjustTrove(
+          maxFeePercentage,
+          0,
+          amount,
+          true,
+          0,
+          carol.wallet,
+          carol.wallet,
+        )
+
+      await updateTroveSnapshot(contracts, carol, "after")
+      await updateContractsSnapshot(
+        contracts,
+        state,
+        "activePool",
+        "after",
+        addresses,
+      )
+
+      expect(carol.trove.collateral.after).to.be.equal(
+        carol.trove.collateral.before,
+      )
+      expect(state.activePool.collateral.after).to.be.equal(
+        state.activePool.collateral.before,
+      )
+    })
+
+    it("With 0 debt change, doesnt change borrower's debt or ActivePool debt", async () => {
+      const maxFeePercentage = to1e18(1)
+      const amount = to1e18(1)
+
+      await setupCarolsTrove()
+      await updateTroveSnapshot(contracts, carol, "before")
+      await updateContractsSnapshot(
+        contracts,
+        state,
+        "activePool",
+        "before",
+        addresses,
+      )
+
+      await contracts.borrowerOperations
+        .connect(carol.wallet)
+        .adjustTrove(
+          maxFeePercentage,
+          0,
+          0,
+          false,
+          amount,
+          carol.wallet,
+          carol.wallet,
+          {
+            value: amount,
+          },
+        )
+
+      await updateTroveSnapshot(contracts, carol, "after")
+      await updateContractsSnapshot(
+        contracts,
+        state,
+        "activePool",
+        "after",
+        addresses,
+      )
+
+      expect(carol.trove.debt.after).to.be.equal(carol.trove.debt.before)
+      expect(state.activePool.debt.after).to.be.equal(
+        state.activePool.debt.before,
+      )
+    })
+
+    it("updates borrower's debt and coll with an increase in both", async () => {
+      const abi = [
+        // Add your contract ABI here
+        "event MUSDBorrowingFeePaid(address indexed _borrower, uint256 _MUSDFee)",
+      ]
+
+      const maxFeePercentage = to1e18(1)
+      const debtChange = to1e18(50)
+      const collChange = to1e18(1)
+      await setupCarolsTrove()
+      await updateTroveSnapshot(contracts, carol, "before")
+
+      const tx = await contracts.borrowerOperations
+        .connect(carol.wallet)
+        .adjustTrove(
+          maxFeePercentage,
+          0,
+          debtChange,
+          true,
+          collChange,
+          carol.wallet,
+          carol.wallet,
+          {
+            value: collChange,
+          },
+        )
+
+      const emittedFee = await getEventArgByName(
+        tx,
+        abi,
+        "MUSDBorrowingFeePaid",
+        1,
+      )
+      await updateTroveSnapshot(contracts, carol, "after")
+
+      expect(carol.trove.collateral.after).to.be.equal(
+        carol.trove.collateral.before + collChange,
+      )
+      expect(carol.trove.debt.after).to.be.equal(
+        carol.trove.debt.before + debtChange + emittedFee,
+      )
+    })
+
+    it("updates borrower's debt and coll with a decrease in both", async () => {
+      const maxFeePercentage = to1e18(1)
+      const debtChange = to1e18(50)
+      const collChange = to1e18(1)
+      await setupCarolsTrove()
+      await updateTroveSnapshot(contracts, carol, "before")
+
+      await contracts.borrowerOperations
+        .connect(carol.wallet)
+        .adjustTrove(
+          maxFeePercentage,
+          collChange,
+          debtChange,
+          false,
+          0,
+          carol.wallet,
+          carol.wallet,
+        )
+
+      await updateTroveSnapshot(contracts, carol, "after")
+
+      expect(carol.trove.collateral.after).to.be.equal(
+        carol.trove.collateral.before - collChange,
+      )
+      expect(carol.trove.debt.after).to.be.equal(
+        carol.trove.debt.before - debtChange,
+      )
+    })
+
+    it("updates borrower's debt and coll with coll increase, debt decrease", async () => {
+      const maxFeePercentage = to1e18(1)
+      const debtChange = to1e18(50)
+      const collChange = to1e18(1)
+      await setupCarolsTrove()
+      await updateTroveSnapshot(contracts, carol, "before")
+
+      await contracts.borrowerOperations
+        .connect(carol.wallet)
+        .adjustTrove(
+          maxFeePercentage,
+          0,
+          debtChange,
+          false,
+          collChange,
+          carol.wallet,
+          carol.wallet,
+          {
+            value: collChange,
+          },
+        )
+
+      await updateTroveSnapshot(contracts, carol, "after")
+
+      expect(carol.trove.collateral.after).to.be.equal(
+        carol.trove.collateral.before + collChange,
+      )
+      expect(carol.trove.debt.after).to.be.equal(
+        carol.trove.debt.before - debtChange,
+      )
+    })
+
+    it("updates borrower's debt and coll with coll decrease, debt increase", async () => {
+      const abi = [
+        // Add your contract ABI here
+        "event MUSDBorrowingFeePaid(address indexed _borrower, uint256 _MUSDFee)",
+      ]
+
+      const maxFeePercentage = to1e18(1)
+      const debtChange = to1e18(50)
+      const collChange = to1e18(1)
+      await setupCarolsTrove()
+      await updateTroveSnapshot(contracts, carol, "before")
+
+      const tx = await contracts.borrowerOperations
+        .connect(carol.wallet)
+        .adjustTrove(
+          maxFeePercentage,
+          collChange,
+          debtChange,
+          true,
+          0,
+          carol.wallet,
+          carol.wallet,
+        )
+
+      const emittedFee = await getEventArgByName(
+        tx,
+        abi,
+        "MUSDBorrowingFeePaid",
+        1,
+      )
+      await updateTroveSnapshot(contracts, carol, "after")
+
+      expect(carol.trove.collateral.after).to.be.equal(
+        carol.trove.collateral.before - collChange,
+      )
+      expect(carol.trove.debt.after).to.be.equal(
+        carol.trove.debt.before + debtChange + emittedFee,
+      )
+    })
+
+    it("updates borrower's stake and totalStakes with a coll increase", async () => {
+      const maxFeePercentage = to1e18(1)
+      const amount = to1e18(1)
+
+      await setupCarolsTrove()
+      await updateTroveSnapshot(contracts, carol, "before")
+      await updateTroveManagerSnapshot(contracts, state, "before")
+
+      await contracts.borrowerOperations
+        .connect(carol.wallet)
+        .adjustTrove(
+          maxFeePercentage,
+          0,
+          0,
+          false,
+          amount,
+          carol.wallet,
+          carol.wallet,
+          {
+            value: amount,
+          },
+        )
+
+      await updateTroveSnapshot(contracts, carol, "after")
+      await updateTroveManagerSnapshot(contracts, state, "after")
+
+      expect(carol.trove.stake.after).to.be.equal(
+        carol.trove.stake.before + amount,
+      )
+      expect(state.troveManager.stakes.after).to.be.equal(
+        state.troveManager.stakes.before + amount,
+      )
+    })
+
+    it("updates borrower's stake and totalStakes with a coll decrease", async () => {
+      const maxFeePercentage = to1e18(1)
+      const amount = to1e18(1)
+
+      await setupCarolsTrove()
+      await updateTroveSnapshot(contracts, carol, "before")
+      await updateTroveManagerSnapshot(contracts, state, "before")
+
+      await contracts.borrowerOperations
+        .connect(carol.wallet)
+        .adjustTrove(
+          maxFeePercentage,
+          amount,
+          0,
+          false,
+          0,
+          carol.wallet,
+          carol.wallet,
+        )
+
+      await updateTroveSnapshot(contracts, carol, "after")
+      await updateTroveManagerSnapshot(contracts, state, "after")
+
+      expect(carol.trove.stake.after).to.be.equal(
+        carol.trove.stake.before - amount,
+      )
+      expect(state.troveManager.stakes.after).to.be.equal(
+        state.troveManager.stakes.before - amount,
+      )
+    })
+
+    it("changes MUSDToken balance by the requested decrease", async () => {
+      const maxFeePercentage = to1e18(1)
+      const debtChange = to1e18(50)
+      const collChange = to1e18(1)
+      await setupCarolsTrove()
+      await updateWalletSnapshot(contracts, carol, "before")
+
+      await contracts.borrowerOperations
+        .connect(carol.wallet)
+        .adjustTrove(
+          maxFeePercentage,
+          collChange,
+          debtChange,
+          false,
+          0,
+          carol.wallet,
+          carol.wallet,
+        )
+
+      await updateWalletSnapshot(contracts, carol, "after")
+      expect(carol.musd.after).to.be.equal(carol.musd.before - debtChange)
+    })
+
+    it("changes MUSDToken balance by the requested increase", async () => {
+      const maxFeePercentage = to1e18(1)
+      const debtChange = to1e18(50)
+      const collChange = to1e18(1)
+      await setupCarolsTrove()
+      await updateWalletSnapshot(contracts, carol, "before")
+
+      await contracts.borrowerOperations
+        .connect(carol.wallet)
+        .adjustTrove(
+          maxFeePercentage,
+          0,
+          debtChange,
+          true,
+          collChange,
+          carol.wallet,
+          carol.wallet,
+          {
+            value: collChange,
+          },
+        )
+
+      await updateWalletSnapshot(contracts, carol, "after")
+      expect(carol.musd.after).to.be.equal(carol.musd.before + debtChange)
+    })
+
+    it("Changes the activePool collateral and raw collateral balance by the requested decrease", async () => {
+      const maxFeePercentage = to1e18(1)
+      const debtChange = to1e18(50)
+      const collChange = to1e18(1)
+      await setupCarolsTrove()
+      await updateContractsSnapshot(
+        contracts,
+        state,
+        "activePool",
+        "before",
+        addresses,
+      )
+
+      await contracts.borrowerOperations
+        .connect(carol.wallet)
+        .adjustTrove(
+          maxFeePercentage,
+          collChange,
+          debtChange,
+          false,
+          0,
+          carol.wallet,
+          carol.wallet,
+        )
+      await updateContractsSnapshot(
+        contracts,
+        state,
+        "activePool",
+        "after",
+        addresses,
+      )
+
+      expect(state.activePool.btc.after).to.be.equal(
+        state.activePool.btc.before - collChange,
+      )
+      expect(state.activePool.collateral.after).to.be.equal(
+        state.activePool.collateral.before - collChange,
+      )
+    })
+
+    it("Changes the activePool collateral and raw collateral balance by the amount of collateral sent", async () => {
+      const maxFeePercentage = to1e18(1)
+      const debtChange = to1e18(50)
+      const collChange = to1e18(1)
+      await setupCarolsTrove()
+      await updateContractsSnapshot(
+        contracts,
+        state,
+        "activePool",
+        "before",
+        addresses,
+      )
+
+      await contracts.borrowerOperations
+        .connect(carol.wallet)
+        .adjustTrove(
+          maxFeePercentage,
+          0,
+          debtChange,
+          false,
+          collChange,
+          carol.wallet,
+          carol.wallet,
+          {
+            value: collChange,
+          },
+        )
+      await updateContractsSnapshot(
+        contracts,
+        state,
+        "activePool",
+        "after",
+        addresses,
+      )
+
+      expect(state.activePool.btc.after).to.be.equal(
+        state.activePool.btc.before + collChange,
+      )
+      expect(state.activePool.collateral.after).to.be.equal(
+        state.activePool.collateral.before + collChange,
+      )
+    })
+
+    it("Changes the MUSD debt in ActivePool by requested decrease", async () => {
+      const maxFeePercentage = to1e18(1)
+      const debtChange = to1e18(50)
+      const collChange = to1e18(1)
+      await setupCarolsTrove()
+      await updateContractsSnapshot(
+        contracts,
+        state,
+        "activePool",
+        "before",
+        addresses,
+      )
+
+      await contracts.borrowerOperations
+        .connect(carol.wallet)
+        .adjustTrove(
+          maxFeePercentage,
+          0,
+          debtChange,
+          false,
+          collChange,
+          carol.wallet,
+          carol.wallet,
+          {
+            value: collChange,
+          },
+        )
+      await updateContractsSnapshot(
+        contracts,
+        state,
+        "activePool",
+        "after",
+        addresses,
+      )
+
+      expect(state.activePool.debt.after).to.be.equal(
+        state.activePool.debt.before - debtChange,
+      )
+    })
+
+    it("Changes the MUSD debt in ActivePool by requested increase", async () => {
+      const abi = [
+        // Add your contract ABI here
+        "event MUSDBorrowingFeePaid(address indexed _borrower, uint256 _MUSDFee)",
+      ]
+
+      const maxFeePercentage = to1e18(1)
+      const debtChange = to1e18(50)
+      const collChange = to1e18(1)
+      await setupCarolsTrove()
+      await updateContractsSnapshot(
+        contracts,
+        state,
+        "activePool",
+        "before",
+        addresses,
+      )
+
+      const tx = await contracts.borrowerOperations
+        .connect(carol.wallet)
+        .adjustTrove(
+          maxFeePercentage,
+          0,
+          debtChange,
+          true,
+          collChange,
+          carol.wallet,
+          carol.wallet,
+          {
+            value: collChange,
+          },
+        )
+
+      const emittedFee = await getEventArgByName(
+        tx,
+        abi,
+        "MUSDBorrowingFeePaid",
+        1,
+      )
+      await updateContractsSnapshot(
+        contracts,
+        state,
+        "activePool",
+        "after",
+        addresses,
+      )
+
+      expect(state.activePool.debt.after).to.be.equal(
+        state.activePool.debt.before + debtChange + emittedFee,
+      )
+    })
 
     context("Expected Reverts", () => {
-      it("adjustTrove(): reverts when adjustment would leave trove with ICR < MCR", async () => {
+      it("reverts when adjustment would leave trove with ICR < MCR", async () => {
         await setupCarolsTrove()
 
         // Price drops
@@ -2406,7 +2875,7 @@ describe("BorrowerOperations in Normal Mode", () => {
         )
       })
 
-      it("adjustTrove(): no mintlist, reverts when adjustment would leave trove with ICR < MCR", async () => {
+      it("no mintlist, reverts when adjustment would leave trove with ICR < MCR", async () => {
         await setupCarolsTrove()
         await removeMintlist(contracts, deployer.wallet)
 
@@ -2441,7 +2910,7 @@ describe("BorrowerOperations in Normal Mode", () => {
         )
       })
 
-      it("adjustTrove(): reverts if max fee < 0.5% in Normal mode", async () => {
+      it("reverts if max fee < 0.5% in Normal mode", async () => {
         const collateralTopUp = to1e18(0.02)
         const debtChange = to1e18(1)
 
@@ -2486,7 +2955,7 @@ describe("BorrowerOperations in Normal Mode", () => {
         ).to.be.revertedWith("Max fee percentage must be between 0.5% and 100%")
       })
 
-      it("adjustTrove(): reverts when calling address has no active trove", async () => {
+      it("reverts when calling address has no active trove", async () => {
         const collateralTopUp = to1e18(1)
         const debtChange = to1e18(50)
 
@@ -2505,7 +2974,7 @@ describe("BorrowerOperations in Normal Mode", () => {
         ).to.be.revertedWith("BorrowerOps: Trove does not exist or is closed")
       })
 
-      it("adjustTrove(): reverts when change would cause the TCR of the system to fall below the CCR", async () => {
+      it("reverts when change would cause the TCR of the system to fall below the CCR", async () => {
         const debtChange = to1e18(50)
         await expect(
           contracts.borrowerOperations
@@ -2524,7 +2993,7 @@ describe("BorrowerOperations in Normal Mode", () => {
         )
       })
 
-      it("adjustTrove(): reverts when MUSD repaid is > debt of the trove", async () => {
+      it("reverts when MUSD repaid is > debt of the trove", async () => {
         // Alice transfers MUSD to bob to compensate borrowing fees
         await contracts.musd
           .connect(alice.wallet)
@@ -2573,7 +3042,7 @@ describe("BorrowerOperations in Normal Mode", () => {
         )
       })
 
-      it("adjustTrove(): reverts when change would cause the ICR of the trove to fall below the MCR", async () => {
+      it("reverts when change would cause the ICR of the trove to fall below the MCR", async () => {
         await setupCarolsTrove()
 
         // Price drops
@@ -2617,7 +3086,7 @@ describe("BorrowerOperations in Normal Mode", () => {
         )
       })
 
-      it("adjustTrove(): Reverts if requested debt increase and amount is zero", async () => {
+      it("Reverts if requested debt increase and amount is zero", async () => {
         await expect(
           contracts.borrowerOperations
             .connect(alice.wallet)
@@ -2627,7 +3096,7 @@ describe("BorrowerOperations in Normal Mode", () => {
         )
       })
 
-      it("adjustTrove(): Reverts if requested coll withdrawal and collateral is sent", async () => {
+      it("Reverts if requested coll withdrawal and collateral is sent", async () => {
         const assetAmount = to1e18(3)
         await expect(
           contracts.borrowerOperations
@@ -2647,7 +3116,7 @@ describe("BorrowerOperations in Normal Mode", () => {
         ).to.be.revertedWith("BorrowerOperations: Cannot withdraw and add coll")
       })
 
-      it("adjustTrove(): Reverts if it’s zero adjustment", async () => {
+      it("Reverts if it’s zero adjustment", async () => {
         await expect(
           contracts.borrowerOperations
             .connect(alice.wallet)
@@ -2657,7 +3126,7 @@ describe("BorrowerOperations in Normal Mode", () => {
         )
       })
 
-      it("adjustTrove(): Reverts if borrower has insufficient MUSD balance to cover his debt repayment", async () => {
+      it("Reverts if borrower has insufficient MUSD balance to cover his debt repayment", async () => {
         await updateTroveSnapshot(contracts, alice, "before")
         await expect(
           contracts.borrowerOperations
@@ -2672,875 +3141,6 @@ describe("BorrowerOperations in Normal Mode", () => {
               alice.wallet,
             ),
         ).to.be.revertedWithPanic() // caused by netDebtChange being greater than the debt requiring a negative number going into a uint256
-      })
-    })
-
-    /**
-     *
-     * Emitted Events
-     *
-     */
-
-    context("Emitted Events", () => {})
-
-    /**
-     *
-     * System State Changes
-     *
-     */
-
-    context("System State Changes", () => {
-      it("adjustTrove(): decays a non-zero base rate", async () => {
-        const maxFeePercentage = to1e18(1)
-        const amount = to1e18(1)
-        const newRate = to1e18(5) / 100n
-        await setupCarolsTroveAndAdjustRate()
-        await fastForwardTime(7200)
-
-        await contracts.borrowerOperations
-          .connect(bob.wallet)
-          .adjustTrove(
-            maxFeePercentage,
-            0,
-            amount,
-            true,
-            0,
-            bob.wallet,
-            bob.wallet,
-          )
-
-        const baseRate2 = await contracts.troveManager.baseRate()
-        expect(newRate).is.greaterThan(baseRate2)
-
-        await fastForwardTime(3600)
-        // second withdrawal
-        await contracts.borrowerOperations
-          .connect(bob.wallet)
-          .adjustTrove(
-            to1e18(1),
-            0,
-            to1e18(37),
-            true,
-            0,
-            bob.wallet,
-            bob.wallet,
-          )
-
-        const baseRate3 = await contracts.troveManager.baseRate()
-        expect(baseRate2).is.greaterThan(baseRate3)
-      })
-
-      it("adjustTrove(): doesn't decay a non-zero base rate when user issues 0 debt", async () => {
-        const maxFeePercentage = to1e18(1)
-        const assetAmount = to1e18(1)
-
-        await setupCarolsTroveAndAdjustRate()
-        await fastForwardTime(7200)
-        await updateTroveManagerSnapshot(contracts, state, "before")
-
-        await contracts.borrowerOperations
-          .connect(bob.wallet)
-          .adjustTrove(
-            maxFeePercentage,
-            0,
-            0,
-            false,
-            assetAmount,
-            bob.wallet,
-            bob.wallet,
-            {
-              value: assetAmount,
-            },
-          )
-
-        await updateTroveManagerSnapshot(contracts, state, "after")
-        // Check baseRate has not decreased
-        expect(state.troveManager.baseRate.after).is.equal(
-          state.troveManager.baseRate.before,
-        )
-      })
-
-      it("adjustTrove(): doesn't change base rate if it is already zero", async () => {
-        const maxFeePercentage = to1e18(1)
-
-        await setupCarolsTrove()
-        await fastForwardTime(7200)
-        await updateTroveManagerSnapshot(contracts, state, "before")
-
-        await contracts.borrowerOperations
-          .connect(bob.wallet)
-          .adjustTrove(
-            maxFeePercentage,
-            0,
-            to1e18(37),
-            true,
-            0,
-            bob.wallet,
-            bob.wallet,
-          )
-
-        await updateTroveManagerSnapshot(contracts, state, "after")
-        // Check baseRate has not decreased
-        expect(state.troveManager.baseRate.after).is.equal(
-          state.troveManager.baseRate.before,
-        )
-        expect(state.troveManager.baseRate.after).is.equal(0)
-      })
-
-      it("adjustTrove(): lastFeeOpTime doesn't update if less time than decay interval has passed since the last fee operation", async () => {
-        const maxFeePercentage = to1e18(1)
-
-        await setupCarolsTroveAndAdjustRate()
-        await contracts.troveManager.setLastFeeOpTimeToNow()
-        await updateTroveManagerSnapshot(contracts, state, "before")
-
-        await fastForwardTime(10)
-
-        await contracts.borrowerOperations
-          .connect(bob.wallet)
-          .adjustTrove(
-            maxFeePercentage,
-            0,
-            to1e18(37),
-            true,
-            0,
-            bob.wallet,
-            bob.wallet,
-          )
-
-        await updateTroveManagerSnapshot(contracts, state, "after")
-
-        expect(state.troveManager.lastFeeOperationTime.before).is.equal(
-          state.troveManager.lastFeeOperationTime.after,
-        )
-        expect(state.troveManager.lastFeeOperationTime.before).is.greaterThan(0)
-      })
-
-      it("adjustTrove(): borrower can't grief the baseRate and stop it decaying by issuing debt at higher frequency than the decay granularity", async () => {
-        const maxFeePercentage = to1e18(1)
-
-        await setupCarolsTroveAndAdjustRate()
-        await updateTroveManagerSnapshot(contracts, state, "before")
-
-        await contracts.borrowerOperations
-          .connect(bob.wallet)
-          .adjustTrove(
-            maxFeePercentage,
-            0,
-            to1e18(37),
-            true,
-            0,
-            bob.wallet,
-            bob.wallet,
-          )
-
-        await fastForwardTime(60)
-
-        await contracts.borrowerOperations
-          .connect(bob.wallet)
-          .adjustTrove(
-            maxFeePercentage,
-            0,
-            to1e18(37),
-            true,
-            0,
-            bob.wallet,
-            bob.wallet,
-          )
-        await updateTroveManagerSnapshot(contracts, state, "after")
-        expect(state.troveManager.baseRate.before).to.be.greaterThan(
-          state.troveManager.baseRate.after,
-        )
-      })
-    })
-
-    /**
-     *
-     * Individual Troves
-     *
-     */
-
-    context("Individual Troves", () => {
-      it("adjustTrove(): borrowing at non-zero base records the (drawn debt + fee) on the Trove struct", async () => {
-        const maxFeePercentage = to1e18(1)
-        const amount = to1e18(37)
-        const abi = [
-          // Add your contract ABI here
-          "event MUSDBorrowingFeePaid(address indexed _borrower, uint256 _MUSDFee)",
-        ]
-
-        await setupCarolsTroveAndAdjustRate()
-
-        await updateTroveSnapshot(contracts, bob, "before")
-        await fastForwardTime(60)
-
-        const tx = await contracts.borrowerOperations
-          .connect(bob.wallet)
-          .adjustTrove(
-            maxFeePercentage,
-            0,
-            amount,
-            true,
-            0,
-            bob.wallet,
-            bob.wallet,
-          )
-
-        const emittedFee = await getEventArgByName(
-          tx,
-          abi,
-          "MUSDBorrowingFeePaid",
-          1,
-        )
-
-        await updateTroveSnapshot(contracts, bob, "after")
-
-        expect(bob.trove.debt.after).to.equal(
-          bob.trove.debt.before + amount + emittedFee,
-        )
-      })
-    })
-
-    /**
-     *
-     *  Balance changes
-     *
-     */
-
-    context("Balance changes", () => {
-      it("adjustTrove(): Borrowing at non-zero base rate sends requested amount to the user", async () => {
-        const maxFeePercentage = to1e18(1)
-        const amount = to1e18(37)
-
-        await setupCarolsTroveAndAdjustRate()
-        await updateWalletSnapshot(contracts, carol, "before")
-        await fastForwardTime(7200)
-
-        await contracts.borrowerOperations
-          .connect(carol.wallet)
-          .adjustTrove(
-            maxFeePercentage,
-            0,
-            amount,
-            true,
-            0,
-            carol.wallet,
-            carol.wallet,
-          )
-
-        await updateWalletSnapshot(contracts, carol, "after")
-        expect(carol.musd.after).to.equal(carol.musd.before + amount)
-      })
-
-      it("adjustTrove(): Borrowing at zero base rate sends total requested MUSD to the user", async () => {
-        const maxFeePercentage = to1e18(1)
-        const amount = to1e18(37)
-
-        await setupCarolsTrove()
-        await updateWalletSnapshot(contracts, carol, "before")
-        await fastForwardTime(7200)
-
-        await contracts.borrowerOperations
-          .connect(carol.wallet)
-          .adjustTrove(
-            maxFeePercentage,
-            0,
-            amount,
-            true,
-            0,
-            carol.wallet,
-            carol.wallet,
-          )
-
-        await updateWalletSnapshot(contracts, carol, "after")
-        expect(carol.musd.after).to.equal(carol.musd.before + amount)
-      })
-    })
-
-    /**
-     *
-     * Fees
-     *
-     */
-
-    context("Fees", () => {
-      it("adjustTrove(): Borrowing at zero base rate changes MUSD balance of PCV contract", async () => {
-        const maxFeePercentage = to1e18(1)
-        const amount = to1e18(37)
-
-        state.pcv.musd.before = await contracts.musd.balanceOf(addresses.pcv)
-
-        await setupCarolsTrove()
-        await fastForwardTime(7200)
-        expect(await contracts.troveManager.baseRate()).is.equal(0)
-
-        await contracts.borrowerOperations
-          .connect(carol.wallet)
-          .adjustTrove(
-            maxFeePercentage,
-            0,
-            amount,
-            true,
-            0,
-            carol.wallet,
-            carol.wallet,
-          )
-
-        state.pcv.musd.after = await contracts.musd.balanceOf(addresses.pcv)
-        expect(state.pcv.musd.after).to.be.greaterThan(state.pcv.musd.before)
-      })
-
-      it("adjustTrove(): borrowing at non-zero base rate sends MUSD fee to PCV contract", async () => {
-        const maxFeePercentage = to1e18(1)
-        const amount = to1e18(37)
-
-        state.pcv.musd.before = await contracts.musd.balanceOf(addresses.pcv)
-
-        await setupCarolsTroveAndAdjustRate()
-        await fastForwardTime(7200)
-
-        await contracts.borrowerOperations
-          .connect(carol.wallet)
-          .adjustTrove(
-            maxFeePercentage,
-            0,
-            amount,
-            true,
-            0,
-            carol.wallet,
-            carol.wallet,
-          )
-
-        state.pcv.musd.after = await contracts.musd.balanceOf(addresses.pcv)
-        expect(state.pcv.musd.after).to.be.greaterThan(state.pcv.musd.before)
-      })
-    })
-
-    /**
-     *
-     * State change in other contracts
-     *
-     */
-
-    context("State change in other contracts", () => {
-      it("adjustTrove(): With 0 coll change, doesnt change borrower's coll or ActivePool coll", async () => {
-        const maxFeePercentage = to1e18(1)
-        const amount = to1e18(37)
-
-        await setupCarolsTrove()
-        await updateTroveSnapshot(contracts, carol, "before")
-        await updateContractsSnapshot(
-          contracts,
-          state,
-          "activePool",
-          "before",
-          addresses,
-        )
-
-        await contracts.borrowerOperations
-          .connect(carol.wallet)
-          .adjustTrove(
-            maxFeePercentage,
-            0,
-            amount,
-            true,
-            0,
-            carol.wallet,
-            carol.wallet,
-          )
-
-        await updateTroveSnapshot(contracts, carol, "after")
-        await updateContractsSnapshot(
-          contracts,
-          state,
-          "activePool",
-          "after",
-          addresses,
-        )
-
-        expect(carol.trove.collateral.after).to.be.equal(
-          carol.trove.collateral.before,
-        )
-        expect(state.activePool.collateral.after).to.be.equal(
-          state.activePool.collateral.before,
-        )
-      })
-
-      it("adjustTrove(): With 0 debt change, doesnt change borrower's debt or ActivePool debt", async () => {
-        const maxFeePercentage = to1e18(1)
-        const amount = to1e18(1)
-
-        await setupCarolsTrove()
-        await updateTroveSnapshot(contracts, carol, "before")
-        await updateContractsSnapshot(
-          contracts,
-          state,
-          "activePool",
-          "before",
-          addresses,
-        )
-
-        await contracts.borrowerOperations
-          .connect(carol.wallet)
-          .adjustTrove(
-            maxFeePercentage,
-            0,
-            0,
-            false,
-            amount,
-            carol.wallet,
-            carol.wallet,
-            {
-              value: amount,
-            },
-          )
-
-        await updateTroveSnapshot(contracts, carol, "after")
-        await updateContractsSnapshot(
-          contracts,
-          state,
-          "activePool",
-          "after",
-          addresses,
-        )
-
-        expect(carol.trove.debt.after).to.be.equal(carol.trove.debt.before)
-        expect(state.activePool.debt.after).to.be.equal(
-          state.activePool.debt.before,
-        )
-      })
-
-      it("adjustTrove(): updates borrower's debt and coll with an increase in both", async () => {
-        const abi = [
-          // Add your contract ABI here
-          "event MUSDBorrowingFeePaid(address indexed _borrower, uint256 _MUSDFee)",
-        ]
-
-        const maxFeePercentage = to1e18(1)
-        const debtChange = to1e18(50)
-        const collChange = to1e18(1)
-        await setupCarolsTrove()
-        await updateTroveSnapshot(contracts, carol, "before")
-
-        const tx = await contracts.borrowerOperations
-          .connect(carol.wallet)
-          .adjustTrove(
-            maxFeePercentage,
-            0,
-            debtChange,
-            true,
-            collChange,
-            carol.wallet,
-            carol.wallet,
-            {
-              value: collChange,
-            },
-          )
-
-        const emittedFee = await getEventArgByName(
-          tx,
-          abi,
-          "MUSDBorrowingFeePaid",
-          1,
-        )
-        await updateTroveSnapshot(contracts, carol, "after")
-
-        expect(carol.trove.collateral.after).to.be.equal(
-          carol.trove.collateral.before + collChange,
-        )
-        expect(carol.trove.debt.after).to.be.equal(
-          carol.trove.debt.before + debtChange + emittedFee,
-        )
-      })
-
-      it("adjustTrove(): updates borrower's debt and coll with a decrease in both", async () => {
-        const maxFeePercentage = to1e18(1)
-        const debtChange = to1e18(50)
-        const collChange = to1e18(1)
-        await setupCarolsTrove()
-        await updateTroveSnapshot(contracts, carol, "before")
-
-        await contracts.borrowerOperations
-          .connect(carol.wallet)
-          .adjustTrove(
-            maxFeePercentage,
-            collChange,
-            debtChange,
-            false,
-            0,
-            carol.wallet,
-            carol.wallet,
-          )
-
-        await updateTroveSnapshot(contracts, carol, "after")
-
-        expect(carol.trove.collateral.after).to.be.equal(
-          carol.trove.collateral.before - collChange,
-        )
-        expect(carol.trove.debt.after).to.be.equal(
-          carol.trove.debt.before - debtChange,
-        )
-      })
-
-      it("adjustTrove(): updates borrower's debt and coll with coll increase, debt decrease", async () => {
-        const maxFeePercentage = to1e18(1)
-        const debtChange = to1e18(50)
-        const collChange = to1e18(1)
-        await setupCarolsTrove()
-        await updateTroveSnapshot(contracts, carol, "before")
-
-        await contracts.borrowerOperations
-          .connect(carol.wallet)
-          .adjustTrove(
-            maxFeePercentage,
-            0,
-            debtChange,
-            false,
-            collChange,
-            carol.wallet,
-            carol.wallet,
-            {
-              value: collChange,
-            },
-          )
-
-        await updateTroveSnapshot(contracts, carol, "after")
-
-        expect(carol.trove.collateral.after).to.be.equal(
-          carol.trove.collateral.before + collChange,
-        )
-        expect(carol.trove.debt.after).to.be.equal(
-          carol.trove.debt.before - debtChange,
-        )
-      })
-
-      it("adjustTrove(): updates borrower's debt and coll with coll decrease, debt increase", async () => {
-        const abi = [
-          // Add your contract ABI here
-          "event MUSDBorrowingFeePaid(address indexed _borrower, uint256 _MUSDFee)",
-        ]
-
-        const maxFeePercentage = to1e18(1)
-        const debtChange = to1e18(50)
-        const collChange = to1e18(1)
-        await setupCarolsTrove()
-        await updateTroveSnapshot(contracts, carol, "before")
-
-        const tx = await contracts.borrowerOperations
-          .connect(carol.wallet)
-          .adjustTrove(
-            maxFeePercentage,
-            collChange,
-            debtChange,
-            true,
-            0,
-            carol.wallet,
-            carol.wallet,
-          )
-
-        const emittedFee = await getEventArgByName(
-          tx,
-          abi,
-          "MUSDBorrowingFeePaid",
-          1,
-        )
-        await updateTroveSnapshot(contracts, carol, "after")
-
-        expect(carol.trove.collateral.after).to.be.equal(
-          carol.trove.collateral.before - collChange,
-        )
-        expect(carol.trove.debt.after).to.be.equal(
-          carol.trove.debt.before + debtChange + emittedFee,
-        )
-      })
-
-      it("adjustTrove(): updates borrower's stake and totalStakes with a coll increase", async () => {
-        const maxFeePercentage = to1e18(1)
-        const amount = to1e18(1)
-
-        await setupCarolsTrove()
-        await updateTroveSnapshot(contracts, carol, "before")
-        await updateTroveManagerSnapshot(contracts, state, "before")
-
-        await contracts.borrowerOperations
-          .connect(carol.wallet)
-          .adjustTrove(
-            maxFeePercentage,
-            0,
-            0,
-            false,
-            amount,
-            carol.wallet,
-            carol.wallet,
-            {
-              value: amount,
-            },
-          )
-
-        await updateTroveSnapshot(contracts, carol, "after")
-        await updateTroveManagerSnapshot(contracts, state, "after")
-
-        expect(carol.trove.stake.after).to.be.equal(
-          carol.trove.stake.before + amount,
-        )
-        expect(state.troveManager.stakes.after).to.be.equal(
-          state.troveManager.stakes.before + amount,
-        )
-      })
-
-      it("adjustTrove(): updates borrower's stake and totalStakes with a coll decrease", async () => {
-        const maxFeePercentage = to1e18(1)
-        const amount = to1e18(1)
-
-        await setupCarolsTrove()
-        await updateTroveSnapshot(contracts, carol, "before")
-        await updateTroveManagerSnapshot(contracts, state, "before")
-
-        await contracts.borrowerOperations
-          .connect(carol.wallet)
-          .adjustTrove(
-            maxFeePercentage,
-            amount,
-            0,
-            false,
-            0,
-            carol.wallet,
-            carol.wallet,
-          )
-
-        await updateTroveSnapshot(contracts, carol, "after")
-        await updateTroveManagerSnapshot(contracts, state, "after")
-
-        expect(carol.trove.stake.after).to.be.equal(
-          carol.trove.stake.before - amount,
-        )
-        expect(state.troveManager.stakes.after).to.be.equal(
-          state.troveManager.stakes.before - amount,
-        )
-      })
-
-      it("adjustTrove(): changes MUSDToken balance by the requested decrease", async () => {
-        const maxFeePercentage = to1e18(1)
-        const debtChange = to1e18(50)
-        const collChange = to1e18(1)
-        await setupCarolsTrove()
-        await updateWalletSnapshot(contracts, carol, "before")
-
-        await contracts.borrowerOperations
-          .connect(carol.wallet)
-          .adjustTrove(
-            maxFeePercentage,
-            collChange,
-            debtChange,
-            false,
-            0,
-            carol.wallet,
-            carol.wallet,
-          )
-
-        await updateWalletSnapshot(contracts, carol, "after")
-        expect(carol.musd.after).to.be.equal(carol.musd.before - debtChange)
-      })
-
-      it("adjustTrove(): changes MUSDToken balance by the requested increase", async () => {
-        const maxFeePercentage = to1e18(1)
-        const debtChange = to1e18(50)
-        const collChange = to1e18(1)
-        await setupCarolsTrove()
-        await updateWalletSnapshot(contracts, carol, "before")
-
-        await contracts.borrowerOperations
-          .connect(carol.wallet)
-          .adjustTrove(
-            maxFeePercentage,
-            0,
-            debtChange,
-            true,
-            collChange,
-            carol.wallet,
-            carol.wallet,
-            {
-              value: collChange,
-            },
-          )
-
-        await updateWalletSnapshot(contracts, carol, "after")
-        expect(carol.musd.after).to.be.equal(carol.musd.before + debtChange)
-      })
-
-      it("adjustTrove(): Changes the activePool collateral and raw collateral balance by the requested decrease", async () => {
-        const maxFeePercentage = to1e18(1)
-        const debtChange = to1e18(50)
-        const collChange = to1e18(1)
-        await setupCarolsTrove()
-        await updateContractsSnapshot(
-          contracts,
-          state,
-          "activePool",
-          "before",
-          addresses,
-        )
-
-        await contracts.borrowerOperations
-          .connect(carol.wallet)
-          .adjustTrove(
-            maxFeePercentage,
-            collChange,
-            debtChange,
-            false,
-            0,
-            carol.wallet,
-            carol.wallet,
-          )
-        await updateContractsSnapshot(
-          contracts,
-          state,
-          "activePool",
-          "after",
-          addresses,
-        )
-
-        expect(state.activePool.btc.after).to.be.equal(
-          state.activePool.btc.before - collChange,
-        )
-        expect(state.activePool.collateral.after).to.be.equal(
-          state.activePool.collateral.before - collChange,
-        )
-      })
-
-      it("adjustTrove(): Changes the activePool collateral and raw collateral balance by the amount of collateral sent", async () => {
-        const maxFeePercentage = to1e18(1)
-        const debtChange = to1e18(50)
-        const collChange = to1e18(1)
-        await setupCarolsTrove()
-        await updateContractsSnapshot(
-          contracts,
-          state,
-          "activePool",
-          "before",
-          addresses,
-        )
-
-        await contracts.borrowerOperations
-          .connect(carol.wallet)
-          .adjustTrove(
-            maxFeePercentage,
-            0,
-            debtChange,
-            false,
-            collChange,
-            carol.wallet,
-            carol.wallet,
-            {
-              value: collChange,
-            },
-          )
-        await updateContractsSnapshot(
-          contracts,
-          state,
-          "activePool",
-          "after",
-          addresses,
-        )
-
-        expect(state.activePool.btc.after).to.be.equal(
-          state.activePool.btc.before + collChange,
-        )
-        expect(state.activePool.collateral.after).to.be.equal(
-          state.activePool.collateral.before + collChange,
-        )
-      })
-
-      it("adjustTrove(): Changes the MUSD debt in ActivePool by requested decrease", async () => {
-        const maxFeePercentage = to1e18(1)
-        const debtChange = to1e18(50)
-        const collChange = to1e18(1)
-        await setupCarolsTrove()
-        await updateContractsSnapshot(
-          contracts,
-          state,
-          "activePool",
-          "before",
-          addresses,
-        )
-
-        await contracts.borrowerOperations
-          .connect(carol.wallet)
-          .adjustTrove(
-            maxFeePercentage,
-            0,
-            debtChange,
-            false,
-            collChange,
-            carol.wallet,
-            carol.wallet,
-            {
-              value: collChange,
-            },
-          )
-        await updateContractsSnapshot(
-          contracts,
-          state,
-          "activePool",
-          "after",
-          addresses,
-        )
-
-        expect(state.activePool.debt.after).to.be.equal(
-          state.activePool.debt.before - debtChange,
-        )
-      })
-
-      it("adjustTrove(): Changes the MUSD debt in ActivePool by requested increase", async () => {
-        const abi = [
-          // Add your contract ABI here
-          "event MUSDBorrowingFeePaid(address indexed _borrower, uint256 _MUSDFee)",
-        ]
-
-        const maxFeePercentage = to1e18(1)
-        const debtChange = to1e18(50)
-        const collChange = to1e18(1)
-        await setupCarolsTrove()
-        await updateContractsSnapshot(
-          contracts,
-          state,
-          "activePool",
-          "before",
-          addresses,
-        )
-
-        const tx = await contracts.borrowerOperations
-          .connect(carol.wallet)
-          .adjustTrove(
-            maxFeePercentage,
-            0,
-            debtChange,
-            true,
-            collChange,
-            carol.wallet,
-            carol.wallet,
-            {
-              value: collChange,
-            },
-          )
-
-        const emittedFee = await getEventArgByName(
-          tx,
-          abi,
-          "MUSDBorrowingFeePaid",
-          1,
-        )
-        await updateContractsSnapshot(
-          contracts,
-          state,
-          "activePool",
-          "after",
-          addresses,
-        )
-
-        expect(state.activePool.debt.after).to.be.equal(
-          state.activePool.debt.before + debtChange + emittedFee,
-        )
       })
     })
   })

--- a/solidity/test/normal/CollSurplusPool.test.ts
+++ b/solidity/test/normal/CollSurplusPool.test.ts
@@ -29,13 +29,8 @@ describe("CollSurplusPool in Normal Mode", () => {
   })
 
   describe("accountSurplus()", () => {
-    /**
-     *
-     * Expected Reverts
-     *
-     */
     context("Expected Reverts", () => {
-      it("accountSurplus(): Reverts if caller is not Trove Manager", async () => {
+      it("Reverts if caller is not Trove Manager", async () => {
         await expect(
           contracts.collSurplusPool
             .connect(alice.wallet)
@@ -43,58 +38,45 @@ describe("CollSurplusPool in Normal Mode", () => {
         ).to.be.revertedWith("CollSurplusPool: Caller is not TroveManager")
       })
     })
-
-    /**
-     *
-     * Emitted Events
-     *
-     */
-    context("Emitted Events", () => {})
-
-    /**
-     *
-     * System State Changes
-     *
-     */
-    context("System State Changes", () => {})
-
-    /**
-     *
-     * Individual Troves
-     *
-     */
-    context("Individual Troves", () => {})
-
-    /**
-     *
-     * Balance changes
-     *
-     */
-    context("Balance changes", () => {})
-
-    /**
-     *
-     * Fees
-     *
-     */
-    context("Fees", () => {})
-
-    /**
-     *
-     * State change in other contracts
-     *
-     */
-    context("State change in other contracts", () => {})
   })
 
   describe("claimColl()", () => {
-    /**
-     *
-     * Expected Reverts
-     *
-     */
+    it("Allows a user to claim their collateral after their trove was redeemed", async () => {
+      await openTrove(contracts, {
+        musdAmount: "50,000",
+        ICR: "500",
+        sender: whale.wallet,
+      })
+
+      const { netDebt } = await openTrove(contracts, {
+        musdAmount: to1e18("2,000"),
+        sender: alice.wallet,
+      })
+
+      // Whale sends Bob enough MUSD to liquidate Alice
+      await contracts.musd.connect(whale.wallet).transfer(bob.wallet, netDebt)
+
+      await updateTroveSnapshot(contracts, alice, "before")
+      await updateWalletSnapshot(contracts, alice, "before")
+
+      await performRedemption(contracts, bob, alice, netDebt)
+
+      await contracts.borrowerOperations
+        .connect(alice.wallet)
+        .claimCollateral(NO_GAS)
+
+      await updateWalletSnapshot(contracts, alice, "after")
+
+      const liquidatedCollateral =
+        (netDebt * to1e18(1)) / (await contracts.priceFeed.fetchPrice())
+
+      expect(alice.btc.after - alice.btc.before).to.equal(
+        alice.trove.collateral.before - liquidatedCollateral,
+      )
+    })
+
     context("Expected Reverts", () => {
-      it("claimColl(): Reverts if caller is not Borrower Operations", async () => {
+      it("Reverts if caller is not Borrower Operations", async () => {
         await expect(
           contracts.collSurplusPool
             .connect(alice.wallet)
@@ -104,7 +86,7 @@ describe("CollSurplusPool in Normal Mode", () => {
         )
       })
 
-      it("claimColl(): Reverts if nothing to claim", async () => {
+      it("Reverts if nothing to claim", async () => {
         await expect(
           contracts.borrowerOperations.connect(alice.wallet).claimCollateral(),
         ).to.be.revertedWith(
@@ -112,86 +94,10 @@ describe("CollSurplusPool in Normal Mode", () => {
         )
       })
     })
-
-    /**
-     *
-     * Emitted Events
-     *
-     */
-    context("Emitted Events", () => {})
-
-    /**
-     *
-     * System State Changes
-     *
-     */
-    context("System State Changes", () => {})
-
-    /**
-     *
-     * Individual Troves
-     *
-     */
-    context("Individual Troves", () => {})
-
-    /**
-     *
-     * Balance changes
-     *
-     */
-    context("Balance changes", () => {
-      it("claimColl(): Allows a user to claim their collateral after their trove was redeemed", async () => {
-        await openTrove(contracts, {
-          musdAmount: "50,000",
-          ICR: "500",
-          sender: whale.wallet,
-        })
-
-        const { netDebt } = await openTrove(contracts, {
-          musdAmount: to1e18("2,000"),
-          sender: alice.wallet,
-        })
-
-        // Whale sends Bob enough MUSD to liquidate Alice
-        await contracts.musd.connect(whale.wallet).transfer(bob.wallet, netDebt)
-
-        await updateTroveSnapshot(contracts, alice, "before")
-        await updateWalletSnapshot(contracts, alice, "before")
-
-        await performRedemption(contracts, bob, alice, netDebt)
-
-        await contracts.borrowerOperations
-          .connect(alice.wallet)
-          .claimCollateral(NO_GAS)
-
-        await updateWalletSnapshot(contracts, alice, "after")
-
-        const liquidatedCollateral =
-          (netDebt * to1e18(1)) / (await contracts.priceFeed.fetchPrice())
-
-        expect(alice.btc.after - alice.btc.before).to.equal(
-          alice.trove.collateral.before - liquidatedCollateral,
-        )
-      })
-    })
-
-    /**
-     *
-     * Fees
-     *
-     */
-    context("Fees", () => {})
-
-    /**
-     *
-     * State change in other contracts
-     *
-     */
-    context("State change in other contracts", () => {})
   })
 
   it("getCollateral()", async () => {
-    it("getCollateral(): Retrieves how much collateral a user can redeem", async () => {
+    it("Retrieves how much collateral a user can redeem", async () => {
       await openTrove(contracts, {
         musdAmount: "50,000",
         ICR: "500",
@@ -220,7 +126,7 @@ describe("CollSurplusPool in Normal Mode", () => {
       )
     })
 
-    it("getCollateral(): Returns 0 for users with no redeemable collateral", async () => {
+    it("Returns 0 for users with no redeemable collateral", async () => {
       await updateCollSurplusPoolUserSnapshot(contracts, bob, "after")
 
       expect(bob.collSurplusPool.collateral.after).to.equal(0n)
@@ -228,102 +134,48 @@ describe("CollSurplusPool in Normal Mode", () => {
   })
 
   describe("getCollateralBalance()", () => {
-    /**
-     *
-     * Expected Reverts
-     *
-     */
-    context("Expected Reverts", () => {})
-
-    /**
-     *
-     * Emitted Events
-     *
-     */
-    context("Emitted Events", () => {})
-
-    /**
-     *
-     * System State Changes
-     *
-     */
-    context("System State Changes", () => {
-      it("getCollateralBalance(): Returns the collateral balance of the CollSurplusPool after redemption", async () => {
-        await openTrove(contracts, {
-          musdAmount: "50,000",
-          ICR: "500",
-          sender: whale.wallet,
-        })
-
-        const { netDebt } = await openTrove(contracts, {
-          musdAmount: to1e18("2,000"),
-          sender: alice.wallet,
-        })
-
-        // Whale sends Bob enough MUSD to liquidate Alice
-        await contracts.musd.connect(whale.wallet).transfer(bob.wallet, netDebt)
-
-        await updateTroveSnapshot(contracts, alice, "before")
-        await updateCollSurplusSnapshot(contracts, state, "before")
-
-        await performRedemption(contracts, bob, alice, netDebt)
-
-        await updateTroveSnapshot(contracts, alice, "after")
-        await updateCollSurplusSnapshot(contracts, state, "after")
-
-        const liquidatedCollateral =
-          (netDebt * to1e18(1)) / (await contracts.priceFeed.fetchPrice())
-
-        const netCollSurplusChange =
-          state.collSurplusPool.collateral.after -
-          state.collSurplusPool.collateral.before
-
-        const aliceCollateralChange =
-          alice.trove.collateral.before - alice.trove.collateral.after
-
-        expect(netCollSurplusChange).to.equal(
-          aliceCollateralChange - liquidatedCollateral,
-        )
+    it("Returns the collateral balance of the CollSurplusPool after redemption", async () => {
+      await openTrove(contracts, {
+        musdAmount: "50,000",
+        ICR: "500",
+        sender: whale.wallet,
       })
+
+      const { netDebt } = await openTrove(contracts, {
+        musdAmount: to1e18("2,000"),
+        sender: alice.wallet,
+      })
+
+      // Whale sends Bob enough MUSD to liquidate Alice
+      await contracts.musd.connect(whale.wallet).transfer(bob.wallet, netDebt)
+
+      await updateTroveSnapshot(contracts, alice, "before")
+      await updateCollSurplusSnapshot(contracts, state, "before")
+
+      await performRedemption(contracts, bob, alice, netDebt)
+
+      await updateTroveSnapshot(contracts, alice, "after")
+      await updateCollSurplusSnapshot(contracts, state, "after")
+
+      const liquidatedCollateral =
+        (netDebt * to1e18(1)) / (await contracts.priceFeed.fetchPrice())
+
+      const netCollSurplusChange =
+        state.collSurplusPool.collateral.after -
+        state.collSurplusPool.collateral.before
+
+      const aliceCollateralChange =
+        alice.trove.collateral.before - alice.trove.collateral.after
+
+      expect(netCollSurplusChange).to.equal(
+        aliceCollateralChange - liquidatedCollateral,
+      )
     })
-
-    /**
-     *
-     * Individual Troves
-     *
-     */
-    context("Individual Troves", () => {})
-
-    /**
-     *
-     * Balance changes
-     *
-     */
-    context("Balance changes", () => {})
-
-    /**
-     *
-     * Fees
-     *
-     */
-    context("Fees", () => {})
-
-    /**
-     *
-     * State change in other contracts
-     *
-     */
-    context("State change in other contracts", () => {})
   })
 
   describe("receive()", () => {
-    /**
-     *
-     * Expected Reverts
-     *
-     */
     context("Expected Reverts", () => {
-      it("receive(): Reverts when the caller is not the Active Pool", async () => {
+      it("Reverts when the caller is not the Active Pool", async () => {
         const collSurplusPoolAddress =
           await contracts.collSurplusPool.getAddress()
 
@@ -335,47 +187,5 @@ describe("CollSurplusPool in Normal Mode", () => {
         ).to.be.revertedWith("CollSurplusPool: Caller is not Active Pool")
       })
     })
-
-    /**
-     *
-     * Emitted Events
-     *
-     */
-    context("Emitted Events", () => {})
-
-    /**
-     *
-     * System State Changes
-     *
-     */
-    context("System State Changes", () => {})
-
-    /**
-     *
-     * Individual Troves
-     *
-     */
-    context("Individual Troves", () => {})
-
-    /**
-     *
-     * Balance changes
-     *
-     */
-    context("Balance changes", () => {})
-
-    /**
-     *
-     * Fees
-     *
-     */
-    context("Fees", () => {})
-
-    /**
-     *
-     * State change in other contracts
-     *
-     */
-    context("State change in other contracts", () => {})
   })
 })

--- a/solidity/test/normal/DefaultPool.test.ts
+++ b/solidity/test/normal/DefaultPool.test.ts
@@ -34,59 +34,34 @@ describe("DefaultPool", () => {
     troveManagerSigner = await ethers.getSigner(addresses.troveManager)
   })
 
-  /**
-   *
-   * Expected Reverts
-   *
-   */
-  context("Expected Reverts", () => {
-    it.skip("sendCollateralToActivePool(): fails if receiver cannot receive collateral", async () => {
-      // TODO This requires the active pool to be a nonpayable address.  Skipping for now because the extra setup doesn't seem worth it.
-      // THUSD Test link: https://github.com/Threshold-USD/dev/blob/develop/packages/contracts/test/DefaultPoolTest.js#L64
-      await expect(
-        contracts.defaultPool
-          .connect(troveManagerSigner)
-          .sendCollateralToActivePool(to1e18("0"), NO_GAS),
-      ).to.be.revertedWith("Sending BTC failed")
+  describe("sendCollateralToActivePool()", () => {
+    context("Expected Reverts", () => {
+      it.skip("reverts if receiver cannot receive collateral", async () => {
+        // TODO This requires the active pool to be a nonpayable address.  Skipping for now because the extra setup doesn't seem worth it.
+        // THUSD Test link: https://github.com/Threshold-USD/dev/blob/develop/packages/contracts/test/DefaultPoolTest.js#L64
+        await expect(
+          contracts.defaultPool
+            .connect(troveManagerSigner)
+            .sendCollateralToActivePool(to1e18("0"), NO_GAS),
+        ).to.be.revertedWith("Sending BTC failed")
+      })
     })
   })
 
-  /**
-   *
-   * Emitted Events
-   *
-   */
-  context("Emitted Events", () => {})
-
-  /**
-   *
-   * System State Changes
-   *
-   */
-  context("System State Changes", () => {})
-
-  /**
-   *
-   * Individual Troves
-   *
-   */
-  context("Individual Troves", () => {})
-
-  /**
-   *
-   * Balance changes
-   *
-   */
-  context("Balance changes", () => {
-    it("getCollateralBalance(): gets the recorded collateral balance", async () => {
+  describe("getCollateralBalance()", () => {
+    it("gets the recorded collateral balance", async () => {
       expect(await contracts.defaultPool.getCollateralBalance()).to.equal(0)
     })
+  })
 
-    it("getMUSDDebt(): gets the recorded MUSD balance", async () => {
+  describe("getMUSDDebt()", () => {
+    it("gets the recorded MUSD balance", async () => {
       expect(await contracts.defaultPool.getMUSDDebt()).to.equal(0)
     })
+  })
 
-    it("increaseMUSDDebt(): increases the recorded MUSD balance by the correct amount", async () => {
+  context("increaseMUSDDebt()", () => {
+    it("increases the recorded MUSD balance by the correct amount", async () => {
       await updateContractsSnapshot(
         contracts,
         state,
@@ -112,8 +87,10 @@ describe("DefaultPool", () => {
         state.defaultPool.debt.after - state.defaultPool.debt.before,
       ).to.equal(amount)
     })
+  })
 
-    it("decreaseMUSDDebt(): decreases the recorded THUSD balance by the correct amount", async () => {
+  describe("decreaseMUSDDebt()", () => {
+    it("decreases the recorded MUSD balance by the correct amount", async () => {
       const originalAmount = to1e18("200")
       await contracts.defaultPool
         .connect(troveManagerSigner)
@@ -137,18 +114,4 @@ describe("DefaultPool", () => {
       )
     })
   })
-
-  /**
-   *
-   * Fees
-   *
-   */
-  context("Fees", () => {})
-
-  /**
-   *
-   * State change in other contracts
-   *
-   */
-  context("State change in other contracts", () => {})
 })

--- a/solidity/test/normal/HintHelpers_getApproxHint.test.ts
+++ b/solidity/test/normal/HintHelpers_getApproxHint.test.ts
@@ -35,58 +35,62 @@ describe("HintHelpers", () => {
     )
   }
 
-  it.skip("getApproxHint(): returns the address of a Trove within sqrt(length) positions of the correct insert position", async () => {
-    // Tried a simplified version of the test in the THUSD repo, but it is not working, skipping for now.
-    // THUSD Test: https://github.com/Threshold-USD/dev/blob/develop/packages/contracts/test/HintHelpers_getApproxHintTest.js#L117
+  describe("getApproxHint()", () => {
+    it.skip("returns the address of a Trove within sqrt(length) positions of the correct insert position", async () => {
+      // Tried a simplified version of the test in the THUSD repo, but it is not working, skipping for now.
+      // THUSD Test: https://github.com/Threshold-USD/dev/blob/develop/packages/contracts/test/HintHelpers_getApproxHintTest.js#L117
 
-    await setupTroves()
+      await setupTroves()
 
-    // CR = 202% (Carol's Trove)
-    const cr = to1e18("202")
-    ;({ hintAddress, latestRandomSeed } =
-      await contracts.hintHelpers.getApproxHint(
-        cr,
-        sqrtLength * 10,
-        latestRandomSeed,
-      ))
-    const firstTrove = await contracts.sortedTroves.getFirst()
-    expect(hintAddress).to.eq(firstTrove)
+      // CR = 202% (Carol's Trove)
+      const cr = to1e18("202")
+      ;({ hintAddress, latestRandomSeed } =
+        await contracts.hintHelpers.getApproxHint(
+          cr,
+          sqrtLength * 10,
+          latestRandomSeed,
+        ))
+      const firstTrove = await contracts.sortedTroves.getFirst()
+      expect(hintAddress).to.eq(firstTrove)
+    })
+
+    it("returns the head of the list if the CR is the max uint256 value", async () => {
+      await setupTroves()
+
+      // CR = Maximum value, i.e. 2**256 -1
+      const crMax =
+        "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+      ;({ hintAddress, latestRandomSeed } =
+        await contracts.hintHelpers.getApproxHint(
+          crMax,
+          sqrtLength * 10,
+          latestRandomSeed,
+        ))
+      expect(hintAddress).to.eq(await contracts.sortedTroves.getFirst())
+    })
+
+    it("returns the tail of the list if the CR is lower than ICR of any Trove", async () => {
+      await setupTroves()
+      ;({ hintAddress, latestRandomSeed } =
+        await contracts.hintHelpers.getApproxHint(
+          "0",
+          sqrtLength * 10,
+          latestRandomSeed,
+        ))
+
+      await contracts.sortedTroves.getLast()
+
+      expect(hintAddress).to.eq(await contracts.sortedTroves.getLast())
+    })
   })
 
-  it("getApproxHint(): returns the head of the list if the CR is the max uint256 value", async () => {
-    await setupTroves()
-
-    // CR = Maximum value, i.e. 2**256 -1
-    const crMax =
-      "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
-    ;({ hintAddress, latestRandomSeed } =
-      await contracts.hintHelpers.getApproxHint(
-        crMax,
-        sqrtLength * 10,
-        latestRandomSeed,
-      ))
-    expect(hintAddress).to.eq(await contracts.sortedTroves.getFirst())
-  })
-
-  it("getApproxHint(): returns the tail of the list if the CR is lower than ICR of any Trove", async () => {
-    await setupTroves()
-    ;({ hintAddress, latestRandomSeed } =
-      await contracts.hintHelpers.getApproxHint(
-        "0",
-        sqrtLength * 10,
-        latestRandomSeed,
-      ))
-
-    await contracts.sortedTroves.getLast()
-
-    expect(hintAddress).to.eq(await contracts.sortedTroves.getLast())
-  })
-
-  it("computeNominalCR(): returns the correct nominal CR", async () => {
-    const NICR = await contracts.hintHelpers.computeNominalCR(
-      to1e18("3"),
-      to1e18("200"),
-    )
-    expect(NICR).to.eq(to1e18("1.5"))
+  describe("computeNominalCR()", () => {
+    it("returns the correct nominal CR", async () => {
+      const NICR = await contracts.hintHelpers.computeNominalCR(
+        to1e18("3"),
+        to1e18("200"),
+      )
+      expect(NICR).to.eq(to1e18("1.5"))
+    })
   })
 })

--- a/solidity/test/normal/PCV.test.ts
+++ b/solidity/test/normal/PCV.test.ts
@@ -57,378 +57,145 @@ describe("PCV", () => {
   })
 
   describe("initialize()", () => {
-    /**
-     *
-     * Expected Reverts
-     *
-     */
+    it("bootstrap loan deposited to SP and tracked in PCV", async () => {
+      const debtToPay = await contracts.pcv.debtToPay()
+      expect(debtToPay).to.equal(bootstrapLoan)
+
+      const pcvBalance = await ethers.provider.getBalance(addresses.pcv)
+      expect(pcvBalance).to.equal(0n)
+
+      const spBalance = await contracts.stabilityPool.getCompoundedMUSDDeposit(
+        addresses.pcv,
+      )
+      expect(spBalance).to.equal(bootstrapLoan)
+    })
+
     context("Expected Reverts", () => {
-      it("initialize(): reverts when trying to initialize second time", async () => {
+      it("reverts when trying to initialize second time", async () => {
         await expect(PCVDeployer.initialize()).to.be.revertedWith(
           "PCV: already initialized",
         )
       })
     })
-
-    /**
-     *
-     * Emitted Events
-     *
-     */
-    context("Emitted Events", () => {})
-
-    /**
-     *
-     * System State Changes
-     *
-     */
-    context("System State Changes", () => {})
-
-    /**
-     *
-     * Individual Troves
-     *
-     */
-    context("Individual Troves", () => {})
-
-    /**
-     *
-     * Balance changes
-     *
-     */
-    context("Balance changes", () => {
-      it("initialize(): bootstrap loan deposited to SP and tracked in PCV", async () => {
-        const debtToPay = await contracts.pcv.debtToPay()
-        expect(debtToPay).to.equal(bootstrapLoan)
-
-        const pcvBalance = await ethers.provider.getBalance(addresses.pcv)
-        expect(pcvBalance).to.equal(0n)
-
-        const spBalance =
-          await contracts.stabilityPool.getCompoundedMUSDDeposit(addresses.pcv)
-        expect(spBalance).to.equal(bootstrapLoan)
-      })
-    })
-
-    /**
-     *
-     * Fees
-     *
-     */
-    context("Fees", () => {})
-
-    /**
-     *
-     * State change in other contracts
-     *
-     */
-    context("State change in other contracts", () => {})
   })
 
   describe("startChangingRoles()", () => {
-    /**
-     *
-     * Expected Reverts
-     *
-     */
+    it("adds new roles as pending", async () => {
+      await PCVDeployer.startChangingRoles(alice.address, bob.address)
+      expect(await contracts.pcv.council()).to.equal(council.address)
+      expect(await contracts.pcv.treasury()).to.equal(treasury.address)
+      expect(await contracts.pcv.pendingCouncilAddress()).to.equal(
+        alice.address,
+      )
+      expect(await contracts.pcv.pendingTreasuryAddress()).to.equal(bob.address)
+    })
+
+    it("speeds up first setting of roles", async () => {
+      // reset roles first
+      await PCVDeployer.startChangingRoles(ZERO_ADDRESS, ZERO_ADDRESS)
+      await fastForwardTime(Number(delay))
+      await PCVDeployer.finalizeChangingRoles()
+
+      await PCVDeployer.startChangingRoles(alice.address, bob.address)
+      const timeNow = await getLatestBlockTimestamp()
+      expect(Number(await contracts.pcv.changingRolesInitiated())).to.equal(
+        Number(timeNow) - Number(delay),
+      )
+    })
+
     context("Expected Reverts", () => {
-      it("startChangingRoles(): reverts when trying to set same roles twice", async () => {
+      it("reverts when trying to set same roles twice", async () => {
         await expect(
           PCVDeployer.startChangingRoles(council.address, treasury.address),
         ).to.be.revertedWith("PCV: these roles already set")
       })
     })
-
-    /**
-     *
-     * Emitted Events
-     *
-     */
-    context("Emitted Events", () => {})
-
-    /**
-     *
-     * System State Changes
-     *
-     */
-    context("System State Changes", () => {
-      it("startChangingRoles(): adds new roles as pending", async () => {
-        await PCVDeployer.startChangingRoles(alice.address, bob.address)
-        expect(await contracts.pcv.council()).to.equal(council.address)
-        expect(await contracts.pcv.treasury()).to.equal(treasury.address)
-        expect(await contracts.pcv.pendingCouncilAddress()).to.equal(
-          alice.address,
-        )
-        expect(await contracts.pcv.pendingTreasuryAddress()).to.equal(
-          bob.address,
-        )
-      })
-
-      it("startChangingRoles(): speeds up first setting of roles", async () => {
-        // reset roles first
-        await PCVDeployer.startChangingRoles(ZERO_ADDRESS, ZERO_ADDRESS)
-        await fastForwardTime(Number(delay))
-        await PCVDeployer.finalizeChangingRoles()
-
-        await PCVDeployer.startChangingRoles(alice.address, bob.address)
-        const timeNow = await getLatestBlockTimestamp()
-        expect(Number(await contracts.pcv.changingRolesInitiated())).to.equal(
-          Number(timeNow) - Number(delay),
-        )
-      })
-    })
-
-    /**
-     *
-     * Individual Troves
-     *
-     */
-    context("Individual Troves", () => {})
-
-    /**
-     *
-     * Balance changes
-     *
-     */
-    context("Balance changes", () => {})
-
-    /**
-     *
-     * Fees
-     *
-     */
-    context("Fees", () => {})
-
-    /**
-     *
-     * State change in other contracts
-     *
-     */
-    context("State change in other contracts", () => {})
   })
 
   describe("cancelChangingRoles()", () => {
-    /**
-     *
-     * Expected Reverts
-     *
-     */
+    it("resets pending roles", async () => {
+      await PCVDeployer.startChangingRoles(alice.address, bob.address)
+      await PCVDeployer.cancelChangingRoles()
+      expect(await contracts.pcv.pendingCouncilAddress()).to.equal(ZERO_ADDRESS)
+      expect(await contracts.pcv.pendingTreasuryAddress()).to.equal(
+        ZERO_ADDRESS,
+      )
+      expect(await contracts.pcv.treasury()).to.equal(treasury.address)
+      expect(await contracts.pcv.council()).to.equal(council.address)
+    })
+
     context("Expected Reverts", () => {
-      it("cancelChangingRoles(): reverts when changing is not initiated", async () => {
+      it("reverts when changing is not initiated", async () => {
         await expect(PCVDeployer.cancelChangingRoles()).to.be.revertedWith(
           "PCV: Change not initiated",
         )
       })
     })
-
-    /**
-     *
-     * Emitted Events
-     *
-     */
-    context("Emitted Events", () => {})
-
-    /**
-     *
-     * System State Changes
-     *
-     */
-    context("System State Changes", () => {
-      it("cancelChangingRoles(): resets pending roles", async () => {
-        await PCVDeployer.startChangingRoles(alice.address, bob.address)
-        await PCVDeployer.cancelChangingRoles()
-        expect(await contracts.pcv.pendingCouncilAddress()).to.equal(
-          ZERO_ADDRESS,
-        )
-        expect(await contracts.pcv.pendingTreasuryAddress()).to.equal(
-          ZERO_ADDRESS,
-        )
-        expect(await contracts.pcv.treasury()).to.equal(treasury.address)
-        expect(await contracts.pcv.council()).to.equal(council.address)
-      })
-    })
-
-    /**
-     *
-     * Individual Troves
-     *
-     */
-    context("Individual Troves", () => {})
-
-    /**
-     *
-     * Balance changes
-     *
-     */
-    context("Balance changes", () => {})
-
-    /**
-     *
-     * Fees
-     *
-     */
-    context("Fees", () => {})
-
-    /**
-     *
-     * State change in other contracts
-     *
-     */
-    context("State change in other contracts", () => {})
   })
 
   describe("finalizeChangingRoles()", () => {
-    /**
-     *
-     * Expected Reverts
-     *
-     */
+    it("sets new roles", async () => {
+      await PCVDeployer.startChangingRoles(alice.address, bob.address)
+      await fastForwardTime(Number(delay))
+      await PCVDeployer.finalizeChangingRoles()
+      expect(await contracts.pcv.council()).to.equal(alice.address)
+      expect(await contracts.pcv.treasury()).to.equal(bob.address)
+      expect(await contracts.pcv.pendingCouncilAddress()).to.equal(ZERO_ADDRESS)
+      expect(await contracts.pcv.pendingTreasuryAddress()).to.equal(
+        ZERO_ADDRESS,
+      )
+    })
+
     context("Expected Reverts", () => {
-      it("finalizeChangingRoles(): reverts when changing is not initiated", async () => {
+      it("reverts when changing is not initiated", async () => {
         await expect(PCVDeployer.finalizeChangingRoles()).to.be.revertedWith(
           "PCV: Change not initiated",
         )
       })
 
-      it("finalizeChangingRoles(): reverts when not enough time has passed", async () => {
+      it("reverts when not enough time has passed", async () => {
         await PCVDeployer.startChangingRoles(alice.address, bob.address)
         await expect(PCVDeployer.finalizeChangingRoles()).to.be.revertedWith(
           "PCV: Governance delay has not elapsed",
         )
       })
     })
-
-    /**
-     *
-     * Emitted Events
-     *
-     */
-    context("Emitted Events", () => {})
-
-    /**
-     *
-     * System State Changes
-     *
-     */
-    context("System State Changes", () => {
-      it("finalizeChangingRoles(): sets new roles", async () => {
-        await PCVDeployer.startChangingRoles(alice.address, bob.address)
-        await fastForwardTime(Number(delay))
-        await PCVDeployer.finalizeChangingRoles()
-        expect(await contracts.pcv.council()).to.equal(alice.address)
-        expect(await contracts.pcv.treasury()).to.equal(bob.address)
-        expect(await contracts.pcv.pendingCouncilAddress()).to.equal(
-          ZERO_ADDRESS,
-        )
-        expect(await contracts.pcv.pendingTreasuryAddress()).to.equal(
-          ZERO_ADDRESS,
-        )
-      })
-    })
-
-    /**
-     *
-     * Individual Troves
-     *
-     */
-    context("Individual Troves", () => {})
-
-    /**
-     *
-     * Balance changes
-     *
-     */
-    context("Balance changes", () => {})
-
-    /**
-     *
-     * Fees
-     *
-     */
-    context("Fees", () => {})
-
-    /**
-     *
-     * State change in other contracts
-     *
-     */
-    context("State change in other contracts", () => {})
   })
 
   describe("depositToStabilityPool()", () => {
-    /**
-     *
-     * Expected Reverts
-     *
-     */
+    it("deposits additional MUSD to StabilityPool", async () => {
+      const depositAmount = to1e18("20")
+      await contracts.musd.unprotectedMint(addresses.pcv, depositAmount)
+      await PCVDeployer.depositToStabilityPool(depositAmount)
+      const spBalance = await contracts.stabilityPool.getCompoundedMUSDDeposit(
+        addresses.pcv,
+      )
+      expect(spBalance).to.equal(bootstrapLoan + depositAmount)
+    })
+
     context("Expected Reverts", () => {
-      it("depositToStabilityPool(): reverts when not enough MUSD", async () => {
+      it("reverts when not enough MUSD", async () => {
         await expect(
           PCVDeployer.depositToStabilityPool(bootstrapLoan + 1n),
         ).to.be.revertedWith("PCV: not enough tokens")
       })
     })
-
-    /**
-     *
-     * Emitted Events
-     *
-     */
-    context("Emitted Events", () => {})
-
-    /**
-     *
-     * System State Changes
-     *
-     */
-    context("System State Changes", () => {})
-
-    /**
-     *
-     * Individual Troves
-     *
-     */
-    context("Individual Troves", () => {})
-
-    /**
-     *
-     * Balance changes
-     *
-     */
-    context("Balance changes", () => {
-      it("depositToStabilityPool(): deposits additional MUSD to StabilityPool", async () => {
-        const depositAmount = to1e18("20")
-        await contracts.musd.unprotectedMint(addresses.pcv, depositAmount)
-        await PCVDeployer.depositToStabilityPool(depositAmount)
-        const spBalance =
-          await contracts.stabilityPool.getCompoundedMUSDDeposit(addresses.pcv)
-        expect(spBalance).to.equal(bootstrapLoan + depositAmount)
-      })
-    })
-
-    /**
-     *
-     * Fees
-     *
-     */
-    context("Fees", () => {})
-
-    /**
-     *
-     * State change in other contracts
-     *
-     */
-    context("State change in other contracts", () => {})
   })
 
   describe("withdrawMUSD()", () => {
-    /**
-     *
-     * Expected Reverts
-     *
-     */
+    it("withdraws MUSD to recipient", async () => {
+      await debtPaid()
+      const value = to1e18("20")
+      await contracts.musd.unprotectedMint(addresses.pcv, value)
+      await contracts.pcv
+        .connect(treasury.wallet)
+        .withdrawMUSD(alice.address, value)
+      expect(await contracts.musd.balanceOf(alice.address)).to.equal(value)
+      expect(await contracts.musd.balanceOf(addresses.pcv)).to.equal(0n)
+    })
+
     context("Expected Reverts", () => {
-      it("withdrawMUSD(): reverts when debt is not paid", async () => {
+      it("reverts when debt is not paid", async () => {
         await expect(
           contracts.pcv
             .connect(treasury.wallet)
@@ -436,7 +203,7 @@ describe("PCV", () => {
         ).to.be.revertedWith("PCV: debt must be paid")
       })
 
-      it("withdrawMUSD(): reverts if recipient is not in whitelist", async () => {
+      it("reverts if recipient is not in whitelist", async () => {
         await debtPaid()
         await contracts.musd.unprotectedMint(addresses.pcv, bootstrapLoan)
         await expect(
@@ -446,7 +213,7 @@ describe("PCV", () => {
         ).to.be.revertedWith("PCV: recipient must be in whitelist")
       })
 
-      it("withdrawMUSD(): reverts if not enough MUSD", async () => {
+      it("reverts if not enough MUSD", async () => {
         await debtPaid()
         await contracts.musd.unprotectedMint(addresses.pcv, bootstrapLoan)
         await expect(
@@ -456,75 +223,26 @@ describe("PCV", () => {
         ).to.be.revertedWith("PCV: not enough tokens")
       })
     })
-
-    /**
-     *
-     * Emitted Events
-     *
-     */
-    context("Emitted Events", () => {})
-
-    /**
-     *
-     * System State Changes
-     *
-     */
-    context("System State Changes", () => {})
-
-    /**
-     *
-     * Individual Troves
-     *
-     */
-    context("Individual Troves", () => {})
-
-    /**
-     *
-     * Balance changes
-     *
-     */
-    context("Balance changes", () => {
-      it("withdrawMUSD(): withdraws MUSD to recipient", async () => {
-        await debtPaid()
-        const value = to1e18("20")
-        await contracts.musd.unprotectedMint(addresses.pcv, value)
-        await contracts.pcv
-          .connect(treasury.wallet)
-          .withdrawMUSD(alice.address, value)
-        expect(await contracts.musd.balanceOf(alice.address)).to.equal(value)
-        expect(await contracts.musd.balanceOf(addresses.pcv)).to.equal(0n)
-      })
-    })
-
-    /**
-     *
-     * Fees
-     *
-     */
-    context("Fees", () => {})
-
-    /**
-     *
-     * State change in other contracts
-     *
-     */
-    context("State change in other contracts", () => {})
   })
 
   describe("payDebt()", () => {
-    /**
-     *
-     * Expected Reverts
-     *
-     */
+    it("pays some value of debt", async () => {
+      const value = bootstrapLoan / 3n
+      await contracts.musd.unprotectedMint(addresses.pcv, value)
+      await contracts.pcv.connect(treasury.wallet).payDebt(value)
+      const debtToPay = await contracts.pcv.debtToPay()
+      expect(debtToPay).to.equal(bootstrapLoan - value)
+      expect(await contracts.musd.balanceOf(addresses.pcv)).to.equal(0n)
+    })
+
     context("Expected Reverts", () => {
-      it("payDebt(): reverts when not enough tokens to burn", async () => {
+      it("reverts when not enough tokens to burn", async () => {
         await expect(
           contracts.pcv.connect(council.wallet).payDebt(1n),
         ).to.be.revertedWith("PCV: not enough tokens")
       })
 
-      it("payDebt(): reverts when trying to pay again", async () => {
+      it("reverts when trying to pay again", async () => {
         await debtPaid()
         await contracts.musd.unprotectedMint(addresses.pcv, bootstrapLoan)
         await expect(
@@ -532,67 +250,31 @@ describe("PCV", () => {
         ).to.be.revertedWith("PCV: debt has already paid")
       })
     })
-
-    /**
-     *
-     * Emitted Events
-     *
-     */
-    context("Emitted Events", () => {})
-
-    /**
-     *
-     * System State Changes
-     *
-     */
-    context("System State Changes", () => {})
-
-    /**
-     *
-     * Individual Troves
-     *
-     */
-    context("Individual Troves", () => {})
-
-    /**
-     *
-     * Balance changes
-     *
-     */
-    context("Balance changes", () => {
-      it("payDebt(): pays some value of debt", async () => {
-        const value = bootstrapLoan / 3n
-        await contracts.musd.unprotectedMint(addresses.pcv, value)
-        await contracts.pcv.connect(treasury.wallet).payDebt(value)
-        const debtToPay = await contracts.pcv.debtToPay()
-        expect(debtToPay).to.equal(bootstrapLoan - value)
-        expect(await contracts.musd.balanceOf(addresses.pcv)).to.equal(0n)
-      })
-    })
-
-    /**
-     *
-     * Fees
-     *
-     */
-    context("Fees", () => {})
-
-    /**
-     *
-     * State change in other contracts
-     *
-     */
-    context("State change in other contracts", () => {})
   })
 
   describe("addRecipientToWhitelist() / addRecipientsToWhitelist()", () => {
-    /**
-     *
-     * Expected Reverts
-     *
-     */
+    it("adds new recipient to the whitelist", async () => {
+      await PCVDeployer.addRecipientToWhitelist(bob.address)
+      expect(await contracts.pcv.recipientsWhitelist(bob.address)).to.equal(
+        true,
+      )
+    })
+
+    it("adds new recipients to the whitelist", async () => {
+      await PCVDeployer.addRecipientsToWhitelist([
+        bob.address,
+        deployer.address,
+      ])
+      expect(await contracts.pcv.recipientsWhitelist(bob.address)).to.equal(
+        true,
+      )
+      expect(
+        await contracts.pcv.recipientsWhitelist(deployer.address),
+      ).to.equal(true)
+    })
+
     context("Expected Reverts", () => {
-      it("addRecipientToWhitelist(): reverts when address is already in the whitelist", async () => {
+      it("reverts when address is already in the whitelist", async () => {
         await expect(
           PCVDeployer.addRecipientToWhitelist(alice.address),
         ).to.be.revertedWith(
@@ -600,7 +282,7 @@ describe("PCV", () => {
         )
       })
 
-      it("addRecipientsToWhitelist(): reverts when address is already in the whitelist", async () => {
+      it("reverts when address is already in the whitelist", async () => {
         await expect(
           PCVDeployer.addRecipientsToWhitelist([alice.address, bob.address]),
         ).to.be.revertedWith(
@@ -608,84 +290,37 @@ describe("PCV", () => {
         )
       })
     })
-
-    /**
-     *
-     * Emitted Events
-     *
-     */
-    context("Emitted Events", () => {})
-
-    /**
-     *
-     * System State Changes
-     *
-     */
-    context("System State Changes", () => {
-      it("addRecipientToWhitelist(): adds new recipient to the whitelist", async () => {
-        await PCVDeployer.addRecipientToWhitelist(bob.address)
-        expect(await contracts.pcv.recipientsWhitelist(bob.address)).to.equal(
-          true,
-        )
-      })
-
-      it("addRecipientsToWhitelist(): adds new recipients to the whitelist", async () => {
-        await PCVDeployer.addRecipientsToWhitelist([
-          bob.address,
-          deployer.address,
-        ])
-        expect(await contracts.pcv.recipientsWhitelist(bob.address)).to.equal(
-          true,
-        )
-        expect(
-          await contracts.pcv.recipientsWhitelist(deployer.address),
-        ).to.equal(true)
-      })
-    })
-
-    /**
-     *
-     * Individual Troves
-     *
-     */
-    context("Individual Troves", () => {})
-
-    /**
-     *
-     * Balance changes
-     *
-     */
-    context("Balance changes", () => {})
-
-    /**
-     *
-     * Fees
-     *
-     */
-    context("Fees", () => {})
-
-    /**
-     *
-     * State change in other contracts
-     *
-     */
-    context("State change in other contracts", () => {})
   })
 
   describe("removeRecipientFromWhitelist() / removeRecipientsFromWhitelist()", () => {
-    /**
-     *
-     * Expected Reverts
-     *
-     */
+    it("removes recipient from the whitelist", async () => {
+      await PCVDeployer.removeRecipientFromWhitelist(alice.address)
+      expect(await contracts.pcv.recipientsWhitelist(alice.address)).to.equal(
+        false,
+      )
+    })
+
+    it("removes recipients from the whitelist", async () => {
+      await PCVDeployer.removeRecipientsFromWhitelist([
+        alice.address,
+        council.address,
+      ])
+      expect(await contracts.pcv.recipientsWhitelist(alice.address)).to.equal(
+        false,
+      )
+      expect(await contracts.pcv.recipientsWhitelist(council.address)).to.equal(
+        false,
+      )
+    })
+
     context("Expected Reverts", () => {
-      it("removeRecipientFromWhitelist(): reverts when address is not in the whitelist", async () => {
+      it("reverts when address is not in the whitelist", async () => {
         await expect(
           PCVDeployer.removeRecipientFromWhitelist(bob.address),
         ).to.be.revertedWith("PCV: Recipient is not in whitelist")
       })
 
-      it("removeRecipientsFromWhitelist(): reverts when address is not in the whitelist", async () => {
+      it("reverts when address is not in the whitelist", async () => {
         await expect(
           PCVDeployer.removeRecipientsFromWhitelist([
             alice.address,
@@ -694,78 +329,28 @@ describe("PCV", () => {
         ).to.be.revertedWith("PCV: Recipient is not in whitelist")
       })
     })
-
-    /**
-     *
-     * Emitted Events
-     *
-     */
-    context("Emitted Events", () => {})
-
-    /**
-     *
-     * System State Changes
-     *
-     */
-    context("System State Changes", () => {
-      it("removeRecipientFromWhitelist(): removes recipient from the whitelist", async () => {
-        await PCVDeployer.removeRecipientFromWhitelist(alice.address)
-        expect(await contracts.pcv.recipientsWhitelist(alice.address)).to.equal(
-          false,
-        )
-      })
-
-      it("removeRecipientsFromWhitelist(): removes recipients from the whitelist", async () => {
-        await PCVDeployer.removeRecipientsFromWhitelist([
-          alice.address,
-          council.address,
-        ])
-        expect(await contracts.pcv.recipientsWhitelist(alice.address)).to.equal(
-          false,
-        )
-        expect(
-          await contracts.pcv.recipientsWhitelist(council.address),
-        ).to.equal(false)
-      })
-    })
-
-    /**
-     *
-     * Individual Troves
-     *
-     */
-    context("Individual Troves", () => {})
-
-    /**
-     *
-     * Balance changes
-     *
-     */
-    context("Balance changes", () => {})
-
-    /**
-     *
-     * Fees
-     *
-     */
-    context("Fees", () => {})
-
-    /**
-     *
-     * State change in other contracts
-     *
-     */
-    context("State change in other contracts", () => {})
   })
 
   describe("withdrawCollateral()", () => {
-    /**
-     *
-     * Expected Reverts
-     *
-     */
+    it("withdraws BTC to recipient", async () => {
+      await debtPaid()
+      const value = to1e18("20")
+      await updateWalletSnapshot(contracts, alice, "before")
+      // Send BTC to PCV
+      await deployer.wallet.sendTransaction({
+        to: addresses.pcv,
+        value,
+      })
+      await contracts.pcv
+        .connect(council.wallet)
+        .withdrawCollateral(alice.address, value)
+      await updateWalletSnapshot(contracts, alice, "after")
+      expect(await ethers.provider.getBalance(addresses.pcv)).to.equal(0n)
+      expect(alice.btc.after - alice.btc.before).to.equal(value)
+    })
+
     context("Expected Reverts", () => {
-      it("withdrawCollateral(): reverts if recipient is not in whitelist", async () => {
+      it("reverts if recipient is not in whitelist", async () => {
         await debtPaid()
         await expect(
           contracts.pcv
@@ -774,7 +359,7 @@ describe("PCV", () => {
         ).to.be.revertedWith("PCV: recipient must be in whitelist")
       })
 
-      it("withdrawCollateral(): reverts if not enough collateral", async () => {
+      it("reverts if not enough collateral", async () => {
         await debtPaid()
         await expect(
           contracts.pcv
@@ -783,64 +368,5 @@ describe("PCV", () => {
         ).to.be.revertedWith("Sending BTC failed")
       })
     })
-
-    /**
-     *
-     * Emitted Events
-     *
-     */
-    context("Emitted Events", () => {})
-
-    /**
-     *
-     * System State Changes
-     *
-     */
-    context("System State Changes", () => {})
-
-    /**
-     *
-     * Individual Troves
-     *
-     */
-    context("Individual Troves", () => {})
-
-    /**
-     *
-     * Balance changes
-     *
-     */
-    context("Balance changes", () => {
-      it("withdrawCollateral(): withdraws BTC to recipient", async () => {
-        await debtPaid()
-        const value = to1e18("20")
-        await updateWalletSnapshot(contracts, alice, "before")
-        // Send BTC to PCV
-        await deployer.wallet.sendTransaction({
-          to: addresses.pcv,
-          value,
-        })
-        await contracts.pcv
-          .connect(council.wallet)
-          .withdrawCollateral(alice.address, value)
-        await updateWalletSnapshot(contracts, alice, "after")
-        expect(await ethers.provider.getBalance(addresses.pcv)).to.equal(0n)
-        expect(alice.btc.after - alice.btc.before).to.equal(value)
-      })
-    })
-
-    /**
-     *
-     * Fees
-     *
-     */
-    context("Fees", () => {})
-
-    /**
-     *
-     * State change in other contracts
-     *
-     */
-    context("State change in other contracts", () => {})
   })
 })

--- a/solidity/test/normal/PriceFeed.test.ts
+++ b/solidity/test/normal/PriceFeed.test.ts
@@ -13,13 +13,20 @@ describe("PriceFeed in Normal Mode", () => {
   })
 
   describe("setOracle()", () => {
-    /**
-     *
-     * Expected Reverts
-     *
-     */
+    it("Updates the oracle address", async () => {
+      const priceFeed: PriceFeed = await getDeployedContract(
+        "UnconnectedPriceFeed",
+      )
+
+      const mockAggregatorAddress = await contracts.mockAggregator.getAddress()
+
+      await priceFeed.connect(deployer.wallet).setOracle(mockAggregatorAddress)
+
+      expect(await priceFeed.oracle()).to.equal(mockAggregatorAddress)
+    })
+
     context("Expected Reverts", () => {
-      it("setOracle(): Reverts when trying to set the oracle a second time", async () => {
+      it("Reverts when trying to set the oracle a second time", async () => {
         await expect(
           contracts.priceFeed.connect(deployer.wallet).setOracle(ZERO_ADDRESS),
         )
@@ -30,7 +37,7 @@ describe("PriceFeed in Normal Mode", () => {
           .withArgs(deployer.address)
       })
 
-      it("setOracle(): Reverts when the oracle has 0-decimal precision", async () => {
+      it("Reverts when the oracle has 0-decimal precision", async () => {
         const priceFeed: PriceFeed = await getDeployedContract(
           "UnconnectedPriceFeed",
         )
@@ -45,7 +52,7 @@ describe("PriceFeed in Normal Mode", () => {
         ).to.be.revertedWith("Invalid Decimals from Oracle")
       })
 
-      it("setOracle(): Reverts when the oracle has a price of 0", async () => {
+      it("Reverts when the oracle has a price of 0", async () => {
         const priceFeed: PriceFeed = await getDeployedContract(
           "UnconnectedPriceFeed",
         )
@@ -60,134 +67,28 @@ describe("PriceFeed in Normal Mode", () => {
         ).to.be.revertedWith("Oracle returns 0 for price")
       })
     })
-
-    /**
-     *
-     * Emitted Events
-     *
-     */
-    context("Emitted Events", () => {})
-
-    /**
-     *
-     * System State Changes
-     *
-     */
-    context("System State Changes", () => {
-      it("setOracle(): Updates the oracle address", async () => {
-        const priceFeed: PriceFeed = await getDeployedContract(
-          "UnconnectedPriceFeed",
-        )
-
-        const mockAggregatorAddress =
-          await contracts.mockAggregator.getAddress()
-
-        await priceFeed
-          .connect(deployer.wallet)
-          .setOracle(mockAggregatorAddress)
-
-        expect(await priceFeed.oracle()).to.equal(mockAggregatorAddress)
-      })
-    })
-
-    /**
-     *
-     * Individual Troves
-     *
-     */
-    context("Individual Troves", () => {})
-
-    /**
-     *
-     * Balance changes
-     *
-     */
-    context("Balance changes", () => {})
-
-    /**
-     *
-     * Fees
-     *
-     */
-    context("Fees", () => {})
-
-    /**
-     *
-     * State change in other contracts
-     *
-     */
-    context("State change in other contracts", () => {})
   })
 
   describe("fetchPrice()", () => {
-    /**
-     *
-     * Expected Reverts
-     *
-     */
-    context("Expected Reverts", () => {})
-
-    /**
-     *
-     * Emitted Events
-     *
-     */
-    context("Emitted Events", () => {})
-
-    /**
-     *
-     * System State Changes
-     *
-     */
-    context("System State Changes", () => {
-      it("fetchPrice(): Handles an 8 decimal oracle", async () => {
-        await contracts.mockAggregator.setPrecision(8n)
-        expect(await contracts.priceFeed.fetchPrice()).to.be.equal(
-          to1e18("50,000"),
-        )
-      })
-
-      it("fetchPrice(): Handles an 18 decimal oracle", async () => {
-        await contracts.mockAggregator.setPrecision(18n)
-        expect(await contracts.priceFeed.fetchPrice()).to.be.equal(
-          to1e18("50,000"),
-        )
-      })
-
-      it("fetchPrice(): Handles a 25 decimal oracle", async () => {
-        await contracts.mockAggregator.setPrecision(25n)
-        expect(await contracts.priceFeed.fetchPrice()).to.be.equal(
-          to1e18("50,000"),
-        )
-      })
+    it("Handles an 8 decimal oracle", async () => {
+      await contracts.mockAggregator.setPrecision(8n)
+      expect(await contracts.priceFeed.fetchPrice()).to.be.equal(
+        to1e18("50,000"),
+      )
     })
 
-    /**
-     *
-     * Individual Troves
-     *
-     */
-    context("Individual Troves", () => {})
+    it("Handles an 18 decimal oracle", async () => {
+      await contracts.mockAggregator.setPrecision(18n)
+      expect(await contracts.priceFeed.fetchPrice()).to.be.equal(
+        to1e18("50,000"),
+      )
+    })
 
-    /**
-     *
-     * Balance changes
-     *
-     */
-    context("Balance changes", () => {})
-
-    /**
-     *
-     * Fees
-     *
-     */
-    context("Fees", () => {})
-
-    /**
-     *
-     * State change in other contracts
-     *
-     */
-    context("State change in other contracts", () => {})
+    it("Handles a 25 decimal oracle", async () => {
+      await contracts.mockAggregator.setPrecision(25n)
+      expect(await contracts.priceFeed.fetchPrice()).to.be.equal(
+        to1e18("50,000"),
+      )
+    })
   })
 })

--- a/solidity/test/normal/SortedTroves.test.ts
+++ b/solidity/test/normal/SortedTroves.test.ts
@@ -17,196 +17,141 @@ describe("SortedTroves", () => {
   })
 
   describe("contains()", () => {
-    /**
-     *
-     * Expected Reverts
-     *
-     */
-    context("Expected Reverts", () => {})
+    it("returns true for addresses that have opened troves", async () => {
+      const users = [alice, bob]
+      await openTroves(contracts, users, "2,000", "200")
 
-    /**
-     *
-     * Emitted Events
-     *
-     */
-    context("Emitted Events", () => {})
-
-    /**
-     *
-     * System State Changes
-     *
-     */
-    context("System State Changes", () => {
-      it("contains(): returns true for addresses that have opened troves", async () => {
-        const users = [alice, bob]
-        await openTroves(contracts, users, "2,000", "200")
-
-        expect(await contracts.sortedTroves.contains(alice.wallet)).to.equal(
-          true,
-        )
-        expect(await contracts.sortedTroves.contains(bob.wallet)).to.equal(true)
-      })
-
-      it("contains(): returns false for addresses that have not opened troves", async () => {
-        await openTrove(contracts, {
-          musdAmount: "3,000",
-          sender: whale.wallet,
-        })
-
-        expect(await contracts.sortedTroves.contains(alice.wallet)).to.equal(
-          false,
-        )
-        expect(await contracts.sortedTroves.contains(bob.wallet)).to.equal(
-          false,
-        )
-      })
-
-      it("contains(): returns false for addresses that opened and then closed a trove", async () => {
-        // Need to open two troves so that we can close Alice's. We can't close the last trove.
-        await openTroves(contracts, [alice, bob], "2,000", "200")
-
-        // Give Alice extra MUSD to pay back fees.
-        await contracts.musd.unprotectedMint(alice.wallet, to1e18("1,000"))
-
-        await contracts.borrowerOperations.connect(alice.wallet).closeTrove()
-
-        expect(await contracts.sortedTroves.contains(alice.wallet)).to.equal(
-          false,
-        )
-      })
-
-      it("contains(): returns true for addresses that opened, closed and then re-opened a trove", async () => {
-        // Need to open two troves so that we can close Alice's. We can't close the last trove.
-        await openTroves(contracts, [alice, bob], "2,000", "200")
-
-        // Give Alice extra MUSD to pay back fees.
-        await contracts.musd.unprotectedMint(alice.wallet, to1e18("1,000"))
-
-        await contracts.borrowerOperations.connect(alice.wallet).closeTrove()
-
-        await openTrove(contracts, {
-          musdAmount: "2,000",
-          sender: alice.wallet,
-        })
-
-        expect(await contracts.sortedTroves.contains(alice.wallet)).to.equal(
-          true,
-        )
-      })
-
-      it("contains(): returns false when there are no troves in the system", async () => {
-        expect(await contracts.sortedTroves.contains(alice.wallet)).to.equal(
-          false,
-        )
-        expect(await contracts.sortedTroves.contains(bob.wallet)).to.equal(
-          false,
-        )
-        expect(await contracts.sortedTroves.contains(carol.wallet)).to.equal(
-          false,
-        )
-      })
-
-      it("contains(): true when list size is 1 and the trove is the only one in system", async () => {
-        await openTrove(contracts, {
-          musdAmount: "3,000",
-          sender: whale.wallet,
-        })
-
-        expect(await contracts.sortedTroves.contains(whale.wallet)).to.equal(
-          true,
-        )
-      })
+      expect(await contracts.sortedTroves.contains(alice.wallet)).to.equal(true)
+      expect(await contracts.sortedTroves.contains(bob.wallet)).to.equal(true)
     })
 
-    /**
-     *
-     * Individual Troves
-     *
-     */
-    context("Individual Troves", () => {})
+    it("returns false for addresses that have not opened troves", async () => {
+      await openTrove(contracts, {
+        musdAmount: "3,000",
+        sender: whale.wallet,
+      })
 
-    /**
-     *
-     * Balance changes
-     *
-     */
-    context("Balance changes", () => {})
+      expect(await contracts.sortedTroves.contains(alice.wallet)).to.equal(
+        false,
+      )
+      expect(await contracts.sortedTroves.contains(bob.wallet)).to.equal(false)
+    })
 
-    /**
-     *
-     * Fees
-     *
-     */
-    context("Fees", () => {})
+    it("returns false for addresses that opened and then closed a trove", async () => {
+      // Need to open two troves so that we can close Alice's. We can't close the last trove.
+      await openTroves(contracts, [alice, bob], "2,000", "200")
 
-    /**
-     *
-     * State change in other contracts
-     *
-     */
-    context("State change in other contracts", () => {})
+      // Give Alice extra MUSD to pay back fees.
+      await contracts.musd.unprotectedMint(alice.wallet, to1e18("1,000"))
+
+      await contracts.borrowerOperations.connect(alice.wallet).closeTrove()
+
+      expect(await contracts.sortedTroves.contains(alice.wallet)).to.equal(
+        false,
+      )
+    })
+
+    it("returns true for addresses that opened, closed and then re-opened a trove", async () => {
+      // Need to open two troves so that we can close Alice's. We can't close the last trove.
+      await openTroves(contracts, [alice, bob], "2,000", "200")
+
+      // Give Alice extra MUSD to pay back fees.
+      await contracts.musd.unprotectedMint(alice.wallet, to1e18("1,000"))
+
+      await contracts.borrowerOperations.connect(alice.wallet).closeTrove()
+
+      await openTrove(contracts, {
+        musdAmount: "2,000",
+        sender: alice.wallet,
+      })
+
+      expect(await contracts.sortedTroves.contains(alice.wallet)).to.equal(true)
+    })
+
+    it("returns false when there are no troves in the system", async () => {
+      expect(await contracts.sortedTroves.contains(alice.wallet)).to.equal(
+        false,
+      )
+      expect(await contracts.sortedTroves.contains(bob.wallet)).to.equal(false)
+      expect(await contracts.sortedTroves.contains(carol.wallet)).to.equal(
+        false,
+      )
+    })
+
+    it("true when list size is 1 and the trove is the only one in system", async () => {
+      await openTrove(contracts, {
+        musdAmount: "3,000",
+        sender: whale.wallet,
+      })
+
+      expect(await contracts.sortedTroves.contains(whale.wallet)).to.equal(true)
+    })
   })
 
-  it("getMaxSize(): Returns the maximum list size", async () => {
-    const maxBytes32 = BigInt(
-      "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-    )
+  describe("getMaxSize()", () => {
+    it("Returns the maximum list size", async () => {
+      const maxBytes32 = BigInt(
+        "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      )
 
-    expect(await contracts.sortedTroves.getMaxSize()).to.equal(maxBytes32)
+      expect(await contracts.sortedTroves.getMaxSize()).to.equal(maxBytes32)
+    })
   })
 
-  it("findInsertPosition(): Finds the correct insert position given two addresses that loosely bound the correct position", async () => {
-    // Use 1 BTC = $100 to make the math easy.
-    await contracts.mockAggregator.setPrice(to1e18(100))
+  describe("findInsertPosition()", () => {
+    it("Finds the correct insert position given two addresses that loosely bound the correct position", async () => {
+      // Use 1 BTC = $100 to make the math easy.
+      await contracts.mockAggregator.setPrice(to1e18(100))
 
-    const troveData: { user: User; icr: string }[] = [
-      {
-        user: whale,
-        icr: "500",
-      },
-      {
-        user: alice,
-        icr: "450",
-      },
-      {
-        user: bob,
-        icr: "400",
-      },
-      {
-        user: carol,
-        icr: "350",
-      },
-      {
-        user: dennis,
-        icr: "300",
-      },
-      {
-        user: eric,
-        icr: "250",
-      },
-    ]
+      const troveData: { user: User; icr: string }[] = [
+        {
+          user: whale,
+          icr: "500",
+        },
+        {
+          user: alice,
+          icr: "450",
+        },
+        {
+          user: bob,
+          icr: "400",
+        },
+        {
+          user: carol,
+          icr: "350",
+        },
+        {
+          user: dennis,
+          icr: "300",
+        },
+        {
+          user: eric,
+          icr: "250",
+        },
+      ]
 
-    await Promise.all(
-      troveData.map(({ user, icr }) =>
-        openTrove(contracts, {
-          musdAmount: "3,000",
-          ICR: icr,
-          sender: user.wallet,
-        }),
-      ),
-    )
+      await Promise.all(
+        troveData.map(({ user, icr }) =>
+          openTrove(contracts, {
+            musdAmount: "3,000",
+            ICR: icr,
+            sender: user.wallet,
+          }),
+        ),
+      )
 
-    // 375%; should go between Bob and Carol
-    const targetNICR = to1e18(3.75)
+      // 375%; should go between Bob and Carol
+      const targetNICR = to1e18(3.75)
 
-    // Pass addresses that loosely bound the right postiion
-    const [low, high] = await contracts.sortedTroves.findInsertPosition(
-      targetNICR,
-      alice.wallet,
-      eric.wallet,
-    )
+      // Pass addresses that loosely bound the right postiion
+      const [low, high] = await contracts.sortedTroves.findInsertPosition(
+        targetNICR,
+        alice.wallet,
+        eric.wallet,
+      )
 
-    expect(low).to.equal(bob.wallet)
-    expect(high).to.equal(carol.wallet)
+      expect(low).to.equal(bob.wallet)
+      expect(high).to.equal(carol.wallet)
+    })
   })
 })

--- a/solidity/test/normal/StabilityPool.test.ts
+++ b/solidity/test/normal/StabilityPool.test.ts
@@ -83,20 +83,277 @@ describe("StabilityPool in Normal Mode", () => {
       await createLiquidationEvent(contracts)
     }
 
-    /**
-     *
-     * Expected Reverts
-     *
-     */
+    it("increases the Stability Pool MUSD balance", async () => {
+      const amount = to1e18(30)
+
+      await updateStabilityPoolSnapshot(contracts, state, "before")
+      await provideToSP(contracts, alice, amount)
+      await updateStabilityPoolSnapshot(contracts, state, "after")
+
+      expect(state.stabilityPool.musd.after).to.equal(
+        state.stabilityPool.musd.before + amount,
+      )
+    })
+
+    it("updates the user's deposit record in StabilityPool", async () => {
+      const amount = to1e18(200)
+      await provideToSP(contracts, alice, amount)
+
+      await updateStabilityPoolUserSnapshot(contracts, alice, "after")
+
+      expect(alice.stabilityPool.deposit.after).to.be.equal(amount)
+    })
+
+    it("Correctly updates user snapshots of accumulated rewards per unit staked", async () => {
+      await provideToSP(contracts, whale, to1e18("20,000"))
+      await createLiquidationEvent(contracts)
+
+      await updateStabilityPoolSnapshot(contracts, state, "before")
+
+      expect(state.stabilityPool.P.before).to.be.greaterThan(0n)
+      expect(state.stabilityPool.S.before).to.be.greaterThan(0n)
+
+      await updateStabilityPoolUserSnapshot(contracts, alice, "before")
+
+      expect(alice.stabilityPool.P.before).to.equal(0n)
+      expect(alice.stabilityPool.S.before).to.equal(0n)
+
+      // Make deposit
+      await provideToSP(contracts, alice, to1e18(100))
+
+      // Check 'After' snapshots
+      await updateStabilityPoolUserSnapshot(contracts, alice, "after")
+
+      expect(alice.stabilityPool.P.after).to.equal(state.stabilityPool.P.before)
+      expect(alice.stabilityPool.S.after).to.equal(state.stabilityPool.S.before)
+    })
+
+    // This test calls `provideToSP` multiple times and makes assertions after each time.
+    // To accomplish this in our state framework, we overwrite `before` and `after` each time.
+    it("multiple deposits: updates user's deposit and snapshots", async () => {
+      // To make sure the pool does not get fully offset.
+      await provideToSP(contracts, whale, to1e18("20,000"))
+
+      // Alice makes deposit #1: $1,000
+      await provideToSP(contracts, alice, to1e18("1,000"))
+
+      await createLiquidationEvent(contracts)
+
+      await updateStabilityPoolUserSnapshot(contracts, alice, "before")
+
+      // Alice makes deposit #2
+      const firstDepositAmount = to1e18(100)
+      await provideToSP(contracts, alice, firstDepositAmount)
+
+      await updateStabilityPoolUserSnapshot(contracts, alice, "after")
+
+      expect(
+        alice.stabilityPool.compoundedDeposit.before + firstDepositAmount,
+      ).to.equal(alice.stabilityPool.deposit.after)
+
+      await updateStabilityPoolSnapshot(contracts, state, "after")
+
+      // System rewards should change
+
+      expect(state.stabilityPool.P.after).to.be.lessThan(to1e18(1))
+      expect(state.stabilityPool.S.after).to.be.greaterThan(0n)
+
+      expect(alice.stabilityPool.P.after).to.equal(state.stabilityPool.P.after)
+      expect(alice.stabilityPool.S.after).to.equal(state.stabilityPool.S.after)
+
+      // Bob withdraws MUSD and deposits to StabilityPool
+
+      await openTrove(contracts, {
+        musdAmount: "3,000",
+        ICR: "200",
+        sender: bob.wallet,
+      })
+
+      await updateStabilityPoolSnapshot(contracts, state, "before")
+
+      await provideToSP(contracts, bob, to1e18(427))
+
+      // Trigger another liquidation
+      await createLiquidationEvent(contracts)
+
+      await updateStabilityPoolSnapshot(contracts, state, "after")
+
+      expect(state.stabilityPool.P.after).to.be.lessThan(
+        state.stabilityPool.P.before,
+      )
+      expect(state.stabilityPool.S.after).to.be.greaterThan(
+        state.stabilityPool.S.before,
+      )
+
+      await updateStabilityPoolSnapshot(contracts, state, "before")
+
+      // Alice makes deposit #3: $100
+      await provideToSP(contracts, alice, to1e18(100))
+
+      await updateStabilityPoolUserSnapshot(contracts, alice, "after")
+
+      expect(alice.stabilityPool.P.after).to.equal(state.stabilityPool.P.before)
+      expect(alice.stabilityPool.S.after).to.equal(state.stabilityPool.S.before)
+    })
+
+    it("doesn't impact other users' deposits or collateral gains", async () => {
+      await provideToSP(contracts, whale, to1e18("20,000"))
+
+      await setupTroveAndLiquidation()
+      const users = [alice, bob, carol]
+      await updateStabilityPoolUserSnapshots(contracts, users, "before")
+
+      // Dennis provides $1,000 to the stability pool.
+      await provideToSP(contracts, dennis, to1e18("1,000"))
+
+      expect(
+        (
+          await contracts.stabilityPool.getCompoundedMUSDDeposit(dennis.wallet)
+        ).toString(),
+      ).to.equal(to1e18("1,000"))
+
+      await updateStabilityPoolUserSnapshots(contracts, users, "after")
+
+      users.forEach((user) => {
+        expect(user.stabilityPool.compoundedDeposit.before).to.equal(
+          user.stabilityPool.compoundedDeposit.after,
+        )
+        expect(user.stabilityPool.collateralGain.before).to.equal(
+          user.stabilityPool.collateralGain.after,
+        )
+      })
+    })
+
+    it("new deposit; depositor does not receive collateral gains", async () => {
+      await createLiquidationEvent(contracts)
+
+      // Alice deposits to the Pool
+
+      await provideToSP(contracts, alice, to1e18("2,000"))
+
+      await updateStabilityPoolUserSnapshot(contracts, alice, "after")
+
+      expect(alice.stabilityPool.collateralGain.after).to.equal(0n)
+    })
+
+    it("new deposit after past full withdrawal; depositor does not receive collateral gains", async () => {
+      // Alice enters and then exits the pool
+      const amount = to1e18("2,000")
+
+      await provideToSP(contracts, alice, amount)
+
+      await contracts.stabilityPool.connect(alice.wallet).withdrawFromSP(amount)
+
+      await createLiquidationEvent(contracts)
+
+      // Alice deposits to the Pool
+      await provideToSP(contracts, alice, amount)
+
+      await updateStabilityPoolUserSnapshot(contracts, alice, "after")
+
+      expect(alice.stabilityPool.collateralGain.after).to.equal(0n)
+    })
+
+    it("doesn't impact any troves, including the caller's trove", async () => {
+      await setupTroveAndLiquidation()
+      const users = [whale, alice, bob, carol, dennis]
+
+      await updateTroveSnapshots(contracts, users, "before")
+
+      // Dennis provides $1,000 to the stability pool.
+      await provideToSP(contracts, dennis, to1e18("1,000"))
+
+      await updateTroveSnapshots(contracts, users, "after")
+
+      users.forEach((user) => {
+        expect(user.trove.collateral.before).to.equal(
+          user.trove.collateral.after,
+        )
+        expect(user.trove.debt.before).to.equal(user.trove.debt.after)
+        expect(user.trove.icr.before).to.equal(user.trove.icr.after)
+      })
+    })
+
+    it("doesn't protect the depositor's trove from liquidation", async () => {
+      await openTrove(contracts, {
+        musdAmount: "2,000",
+        ICR: "120",
+        sender: bob.wallet,
+      })
+
+      await provideToSP(contracts, bob, to1e18("2,000"))
+
+      await dropPrice(contracts, bob)
+
+      // Liquidate bob
+      await contracts.troveManager.liquidate(bob.wallet)
+
+      // Check Bob's trove has been removed from the system
+      expect(await contracts.sortedTroves.contains(bob.wallet)).to.equal(false)
+
+      // check Bob's trove status was closed by liquidation
+      expect(
+        (await contracts.troveManager.getTroveStatus(bob.wallet)).toString(),
+      ).to.equal("3")
+    })
+
+    it("reduces the user's MUSD balance", async () => {
+      await updateWalletSnapshot(contracts, alice, "before")
+
+      const amount = to1e18(200)
+
+      await provideToSP(contracts, alice, amount)
+
+      await updateWalletSnapshot(contracts, alice, "after")
+
+      expect(alice.musd.after).to.equal(alice.musd.before - amount)
+    })
+
+    it("doesn't impact system debt, collateral or TCR", async () => {
+      await setupTroveAndLiquidation()
+      const fetchState = async (checkPoint: CheckPoint) => {
+        await Promise.all(
+          pools.map((pool) =>
+            updateContractsSnapshot(
+              contracts,
+              state,
+              pool,
+              checkPoint,
+              addresses,
+            ),
+          ),
+        )
+        await updateTroveManagerSnapshot(contracts, state, checkPoint)
+      }
+
+      await fetchState("before")
+
+      // Dennis provides $1,000 to the stability pool.
+      await provideToSP(contracts, dennis, to1e18("1,000"))
+
+      await fetchState("after")
+
+      pools.forEach((pool) => {
+        expect(state[pool].debt.before).to.equal(state[pool].debt.after)
+        expect(state[pool].collateral.before).to.equal(
+          state[pool].collateral.after,
+        )
+      })
+
+      expect(state.troveManager.TCR.before).to.equal(
+        state.troveManager.TCR.after,
+      )
+    })
+
     context("Expected Reverts", () => {
-      it("provideToSP(): reverts if user tries to provide more than their MUSD balance", async () => {
+      it("reverts if user tries to provide more than their MUSD balance", async () => {
         await updateWalletSnapshot(contracts, alice, "before")
 
         await expect(provideToSP(contracts, alice, alice.musd.before + 1n)).to
           .be.reverted
       })
 
-      it("provideToSP(): reverts if user tries to provide 2^256-1 MUSD, which exceeds their balance", async () => {
+      it("reverts if user tries to provide 2^256-1 MUSD, which exceeds their balance", async () => {
         // Alice attempts to deposit 2^256-1 MUSD
         const maxBytes32 = BigInt(
           "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
@@ -105,330 +362,8 @@ describe("StabilityPool in Normal Mode", () => {
         await expect(provideToSP(contracts, alice, maxBytes32)).to.be.reverted
       })
 
-      it("provideToSP(): providing $0 reverts", async () => {
+      it("providing $0 reverts", async () => {
         await expect(provideToSP(contracts, alice, 0n)).to.be.reverted
-      })
-    })
-
-    /**
-     *
-     * Emitted Events
-     *
-     */
-    context("Emitted Events", () => {})
-
-    /**
-     *
-     * System State Changes
-     *
-     */
-    context("System State Changes", () => {
-      it("provideToSP(): increases the Stability Pool MUSD balance", async () => {
-        const amount = to1e18(30)
-
-        await updateStabilityPoolSnapshot(contracts, state, "before")
-        await provideToSP(contracts, alice, amount)
-        await updateStabilityPoolSnapshot(contracts, state, "after")
-
-        expect(state.stabilityPool.musd.after).to.equal(
-          state.stabilityPool.musd.before + amount,
-        )
-      })
-
-      it("provideToSP(): updates the user's deposit record in StabilityPool", async () => {
-        const amount = to1e18(200)
-        await provideToSP(contracts, alice, amount)
-
-        await updateStabilityPoolUserSnapshot(contracts, alice, "after")
-
-        expect(alice.stabilityPool.deposit.after).to.be.equal(amount)
-      })
-
-      it("provideToSP(): Correctly updates user snapshots of accumulated rewards per unit staked", async () => {
-        await provideToSP(contracts, whale, to1e18("20,000"))
-        await createLiquidationEvent(contracts)
-
-        await updateStabilityPoolSnapshot(contracts, state, "before")
-
-        expect(state.stabilityPool.P.before).to.be.greaterThan(0n)
-        expect(state.stabilityPool.S.before).to.be.greaterThan(0n)
-
-        await updateStabilityPoolUserSnapshot(contracts, alice, "before")
-
-        expect(alice.stabilityPool.P.before).to.equal(0n)
-        expect(alice.stabilityPool.S.before).to.equal(0n)
-
-        // Make deposit
-        await provideToSP(contracts, alice, to1e18(100))
-
-        // Check 'After' snapshots
-        await updateStabilityPoolUserSnapshot(contracts, alice, "after")
-
-        expect(alice.stabilityPool.P.after).to.equal(
-          state.stabilityPool.P.before,
-        )
-        expect(alice.stabilityPool.S.after).to.equal(
-          state.stabilityPool.S.before,
-        )
-      })
-
-      // This test calls `provideToSP` multiple times and makes assertions after each time.
-      // To accomplish this in our state framework, we overwrite `before` and `after` each time.
-      it("provideToSP(): multiple deposits: updates user's deposit and snapshots", async () => {
-        // To make sure the pool does not get fully offset.
-        await provideToSP(contracts, whale, to1e18("20,000"))
-
-        // Alice makes deposit #1: $1,000
-        await provideToSP(contracts, alice, to1e18("1,000"))
-
-        await createLiquidationEvent(contracts)
-
-        await updateStabilityPoolUserSnapshot(contracts, alice, "before")
-
-        // Alice makes deposit #2
-        const firstDepositAmount = to1e18(100)
-        await provideToSP(contracts, alice, firstDepositAmount)
-
-        await updateStabilityPoolUserSnapshot(contracts, alice, "after")
-
-        expect(
-          alice.stabilityPool.compoundedDeposit.before + firstDepositAmount,
-        ).to.equal(alice.stabilityPool.deposit.after)
-
-        await updateStabilityPoolSnapshot(contracts, state, "after")
-
-        // System rewards should change
-
-        expect(state.stabilityPool.P.after).to.be.lessThan(to1e18(1))
-        expect(state.stabilityPool.S.after).to.be.greaterThan(0n)
-
-        expect(alice.stabilityPool.P.after).to.equal(
-          state.stabilityPool.P.after,
-        )
-        expect(alice.stabilityPool.S.after).to.equal(
-          state.stabilityPool.S.after,
-        )
-
-        // Bob withdraws MUSD and deposits to StabilityPool
-
-        await openTrove(contracts, {
-          musdAmount: "3,000",
-          ICR: "200",
-          sender: bob.wallet,
-        })
-
-        await updateStabilityPoolSnapshot(contracts, state, "before")
-
-        await provideToSP(contracts, bob, to1e18(427))
-
-        // Trigger another liquidation
-        await createLiquidationEvent(contracts)
-
-        await updateStabilityPoolSnapshot(contracts, state, "after")
-
-        expect(state.stabilityPool.P.after).to.be.lessThan(
-          state.stabilityPool.P.before,
-        )
-        expect(state.stabilityPool.S.after).to.be.greaterThan(
-          state.stabilityPool.S.before,
-        )
-
-        await updateStabilityPoolSnapshot(contracts, state, "before")
-
-        // Alice makes deposit #3: $100
-        await provideToSP(contracts, alice, to1e18(100))
-
-        await updateStabilityPoolUserSnapshot(contracts, alice, "after")
-
-        expect(alice.stabilityPool.P.after).to.equal(
-          state.stabilityPool.P.before,
-        )
-        expect(alice.stabilityPool.S.after).to.equal(
-          state.stabilityPool.S.before,
-        )
-      })
-
-      it("provideToSP(): doesn't impact other users' deposits or collateral gains", async () => {
-        await provideToSP(contracts, whale, to1e18("20,000"))
-
-        await setupTroveAndLiquidation()
-        const users = [alice, bob, carol]
-        await updateStabilityPoolUserSnapshots(contracts, users, "before")
-
-        // Dennis provides $1,000 to the stability pool.
-        await provideToSP(contracts, dennis, to1e18("1,000"))
-
-        expect(
-          (
-            await contracts.stabilityPool.getCompoundedMUSDDeposit(
-              dennis.wallet,
-            )
-          ).toString(),
-        ).to.equal(to1e18("1,000"))
-
-        await updateStabilityPoolUserSnapshots(contracts, users, "after")
-
-        users.forEach((user) => {
-          expect(user.stabilityPool.compoundedDeposit.before).to.equal(
-            user.stabilityPool.compoundedDeposit.after,
-          )
-          expect(user.stabilityPool.collateralGain.before).to.equal(
-            user.stabilityPool.collateralGain.after,
-          )
-        })
-      })
-
-      it("provideToSP(): new deposit; depositor does not receive collateral gains", async () => {
-        await createLiquidationEvent(contracts)
-
-        // Alice deposits to the Pool
-
-        await provideToSP(contracts, alice, to1e18("2,000"))
-
-        await updateStabilityPoolUserSnapshot(contracts, alice, "after")
-
-        expect(alice.stabilityPool.collateralGain.after).to.equal(0n)
-      })
-
-      it("provideToSP(): new deposit after past full withdrawal; depositor does not receive collateral gains", async () => {
-        // Alice enters and then exits the pool
-        const amount = to1e18("2,000")
-
-        await provideToSP(contracts, alice, amount)
-
-        await contracts.stabilityPool
-          .connect(alice.wallet)
-          .withdrawFromSP(amount)
-
-        await createLiquidationEvent(contracts)
-
-        // Alice deposits to the Pool
-        await provideToSP(contracts, alice, amount)
-
-        await updateStabilityPoolUserSnapshot(contracts, alice, "after")
-
-        expect(alice.stabilityPool.collateralGain.after).to.equal(0n)
-      })
-    })
-
-    /**
-     *
-     * Individual Troves
-     *
-     */
-    context("Individual Troves", () => {
-      it("provideToSP(): doesn't impact any troves, including the caller's trove", async () => {
-        await setupTroveAndLiquidation()
-        const users = [whale, alice, bob, carol, dennis]
-
-        await updateTroveSnapshots(contracts, users, "before")
-
-        // Dennis provides $1,000 to the stability pool.
-        await provideToSP(contracts, dennis, to1e18("1,000"))
-
-        await updateTroveSnapshots(contracts, users, "after")
-
-        users.forEach((user) => {
-          expect(user.trove.collateral.before).to.equal(
-            user.trove.collateral.after,
-          )
-          expect(user.trove.debt.before).to.equal(user.trove.debt.after)
-          expect(user.trove.icr.before).to.equal(user.trove.icr.after)
-        })
-      })
-
-      it("provideToSP(): doesn't protect the depositor's trove from liquidation", async () => {
-        await openTrove(contracts, {
-          musdAmount: "2,000",
-          ICR: "120",
-          sender: bob.wallet,
-        })
-
-        await provideToSP(contracts, bob, to1e18("2,000"))
-
-        await dropPrice(contracts, bob)
-
-        // Liquidate bob
-        await contracts.troveManager.liquidate(bob.wallet)
-
-        // Check Bob's trove has been removed from the system
-        expect(await contracts.sortedTroves.contains(bob.wallet)).to.equal(
-          false,
-        )
-
-        // check Bob's trove status was closed by liquidation
-        expect(
-          (await contracts.troveManager.getTroveStatus(bob.wallet)).toString(),
-        ).to.equal("3")
-      })
-    })
-
-    /**
-     *
-     * Balance changes
-     *
-     */
-    context("Balance changes", () => {
-      it("provideToSP(): reduces the user's MUSD balance", async () => {
-        await updateWalletSnapshot(contracts, alice, "before")
-
-        const amount = to1e18(200)
-
-        await provideToSP(contracts, alice, amount)
-
-        await updateWalletSnapshot(contracts, alice, "after")
-
-        expect(alice.musd.after).to.equal(alice.musd.before - amount)
-      })
-    })
-
-    /**
-     *
-     * Fees
-     *
-     */
-    context("Fees", () => {})
-
-    /**
-     *
-     * State change in other contracts
-     *
-     */
-    context("State change in other contracts", () => {
-      it("provideToSP(): doesn't impact system debt, collateral or TCR", async () => {
-        await setupTroveAndLiquidation()
-        const fetchState = async (checkPoint: CheckPoint) => {
-          await Promise.all(
-            pools.map((pool) =>
-              updateContractsSnapshot(
-                contracts,
-                state,
-                pool,
-                checkPoint,
-                addresses,
-              ),
-            ),
-          )
-          await updateTroveManagerSnapshot(contracts, state, checkPoint)
-        }
-
-        await fetchState("before")
-
-        // Dennis provides $1,000 to the stability pool.
-        await provideToSP(contracts, dennis, to1e18("1,000"))
-
-        await fetchState("after")
-
-        pools.forEach((pool) => {
-          expect(state[pool].debt.before).to.equal(state[pool].debt.after)
-          expect(state[pool].collateral.before).to.equal(
-            state[pool].collateral.after,
-          )
-        })
-
-        expect(state.troveManager.TCR.before).to.equal(
-          state.troveManager.TCR.after,
-        )
       })
     })
   })
@@ -460,19 +395,885 @@ describe("StabilityPool in Normal Mode", () => {
       await updateWalletSnapshot(contracts, alice, "after")
     }
 
-    /**
-     *
-     * Expected Reverts
-     *
-     */
+    it("leaves the correct amount of MUSD in the Stability Pool", async () => {
+      await setupPartialRetrieval()
+      const { liquidatedDebt } =
+        await getEmittedLiquidationValues(liquidationTx)
+
+      const expectedMUSD =
+        state.stabilityPool.musd.before -
+        to1e18(900) - // alice withdrew $900
+        liquidatedDebt
+
+      expect(state.stabilityPool.musd.after).to.equal(expectedMUSD)
+    })
+
+    it("full retrieval - leaves the correct amount of MUSD in the Stability Pool", async () => {
+      await provideToSP(contracts, alice, to1e18("5,000"))
+
+      await updateStabilityPoolUserSnapshots(
+        contracts,
+        [alice, whale],
+        "before",
+      )
+      await updateStabilityPoolSnapshot(contracts, state, "before")
+
+      const tx = await createLiquidationEvent(contracts)
+
+      const { liquidatedDebt } = await getEmittedLiquidationValues(tx)
+
+      const expectedMUSDLoss =
+        (liquidatedDebt * alice.stabilityPool.deposit.before) /
+        (alice.stabilityPool.deposit.before +
+          whale.stabilityPool.deposit.before)
+
+      // fully withdraw
+      await contracts.stabilityPool
+        .connect(alice.wallet)
+        .withdrawFromSP(alice.stabilityPool.deposit.before, NO_GAS)
+
+      await updateStabilityPoolSnapshot(contracts, state, "after")
+
+      const aliceRemainingDeposit =
+        alice.stabilityPool.deposit.before - expectedMUSDLoss
+
+      expect(state.stabilityPool.musd.after).to.be.closeTo(
+        state.stabilityPool.musd.before -
+          liquidatedDebt -
+          aliceRemainingDeposit,
+        5000n,
+      )
+    })
+
+    it("it correctly updates the user's MUSD and collateral snapshots of entitled reward per unit staked", async () => {
+      await provideToSP(contracts, alice, to1e18("4,000"))
+
+      await createLiquidationEvent(contracts)
+      await contracts.stabilityPool
+        .connect(alice.wallet)
+        .withdrawFromSP(to1e18(900))
+
+      await updateStabilityPoolSnapshot(contracts, state, "after")
+      await updateStabilityPoolUserSnapshot(contracts, alice, "after")
+
+      expect(alice.stabilityPool.P.after).to.equal(state.stabilityPool.P.after)
+      expect(alice.stabilityPool.S.after).to.equal(state.stabilityPool.S.after)
+    })
+
+    it("decreases StabilityPool collateral", async () => {
+      await provideToSP(contracts, alice, to1e18("4,000"))
+
+      await createLiquidationEvent(contracts)
+
+      await updateStabilityPoolSnapshot(contracts, state, "before")
+      await updateStabilityPoolUserSnapshot(contracts, alice, "before")
+
+      await contracts.stabilityPool
+        .connect(alice.wallet)
+        .withdrawFromSP(to1e18(900))
+
+      await updateStabilityPoolSnapshot(contracts, state, "after")
+
+      expect(state.stabilityPool.collateral.after).to.equal(
+        state.stabilityPool.collateral.before -
+          alice.stabilityPool.collateralGain.before,
+      )
+    })
+
+    it("All depositors are able to withdraw from the SP to their account", async () => {
+      await provideToSP(contracts, whale, to1e18("20,000"))
+      await provideToSP(contracts, alice, to1e18("4,000"))
+
+      await createLiquidationEvent(contracts)
+
+      const users = [alice, whale]
+      await Promise.all(
+        users.map(async (user) => {
+          await updateStabilityPoolUserSnapshot(contracts, user, "before")
+          await contracts.stabilityPool
+            .connect(user.wallet)
+            .withdrawFromSP(user.stabilityPool.compoundedDeposit.before)
+          await updateStabilityPoolUserSnapshot(contracts, user, "after")
+        }),
+      )
+      await updateStabilityPoolSnapshot(contracts, state, "after")
+
+      users.forEach((user) =>
+        expect(user.stabilityPool.compoundedDeposit.after).to.equal(0n),
+      )
+      expect(state.stabilityPool.musd.after).to.be.closeTo(0n, 20000n)
+    })
+
+    it("doesn't impact other users deposits or collateral gains", async () => {
+      await provideToSP(contracts, alice, to1e18("3,000"))
+      await openTrovesAndProvideStability(
+        contracts,
+        [bob, carol],
+        "5,000",
+        "200",
+      )
+
+      await createLiquidationEvent(contracts)
+
+      await updateStabilityPoolUserSnapshots(contracts, [bob, carol], "before")
+
+      // Alice withdraws from the Stability Pool
+      await contracts.stabilityPool
+        .connect(alice.wallet)
+        .withdrawFromSP(to1e18(1000))
+
+      await updateStabilityPoolUserSnapshots(contracts, [bob, carol], "after")
+
+      // Check that Bob and Carol's deposits and collateral gains haven't changed
+      ;[bob, carol].forEach((user) => {
+        expect(user.stabilityPool.deposit.after).to.equal(
+          user.stabilityPool.deposit.before,
+        )
+        expect(user.stabilityPool.collateralGain.after).to.equal(
+          user.stabilityPool.collateralGain.before,
+        )
+      })
+    })
+
+    it("succeeds when amount is 0 and system has an undercollateralized trove", async () => {
+      await provideToSP(contracts, whale, to1e18("20,000"))
+      await createLiquidationEvent(contracts)
+
+      await openTrove(contracts, {
+        musdAmount: "2,000", // slightly over the minimum of $1800
+        ICR: "120", // 120%
+        sender: bob.wallet,
+      })
+
+      await dropPrice(contracts, bob)
+
+      await updateStabilityPoolUserSnapshot(contracts, whale, "before")
+      await updateWalletSnapshot(contracts, whale, "before")
+
+      await contracts.stabilityPool
+        .connect(whale.wallet)
+        .withdrawFromSP(0n, NO_GAS)
+
+      await updateStabilityPoolUserSnapshot(contracts, whale, "after")
+      await updateWalletSnapshot(contracts, whale, "after")
+
+      expect(whale.musd.after).to.equal(whale.musd.before)
+      expect(whale.btc.after).to.equal(
+        whale.btc.before + whale.stabilityPool.collateralGain.before,
+      )
+      expect(whale.stabilityPool.compoundedDeposit.after).to.equal(
+        whale.stabilityPool.compoundedDeposit.before,
+      )
+      expect(whale.stabilityPool.collateralGain.after).to.equal(0n)
+    })
+
+    it("withdrawing 0 MUSD doesn't alter the caller's deposit or the total MUSD in the Stability Pool", async () => {
+      await provideToSP(contracts, whale, to1e18("20,000"))
+      await createLiquidationEvent(contracts)
+
+      await updateStabilityPoolUserSnapshot(contracts, whale, "before")
+      await updateStabilityPoolSnapshot(contracts, state, "before")
+
+      await contracts.stabilityPool.connect(whale.wallet).withdrawFromSP(0n)
+
+      await updateStabilityPoolUserSnapshot(contracts, whale, "after")
+      await updateStabilityPoolSnapshot(contracts, state, "after")
+
+      expect(whale.stabilityPool.compoundedDeposit.after).to.equal(
+        whale.stabilityPool.compoundedDeposit.before,
+      )
+      expect(state.stabilityPool.musd.after).to.equal(
+        state.stabilityPool.musd.before,
+      )
+    })
+
+    it("doesn't impact any troves, including the caller's trove", async () => {
+      await provideToSP(contracts, whale, to1e18("20,000"))
+
+      await openTroves(contracts, [bob, carol], "5,000", "200")
+
+      await createLiquidationEvent(contracts)
+
+      const users = [alice, bob, carol, whale]
+      await updateTroveSnapshots(contracts, users, "before")
+
+      await contracts.stabilityPool
+        .connect(whale.wallet)
+        .withdrawFromSP(to1e18("3,000"))
+
+      await updateTroveSnapshots(contracts, users, "after")
+
+      users.forEach((user) => {
+        expect(user.trove.collateral.after).to.equal(
+          user.trove.collateral.before,
+        )
+        expect(user.trove.debt.after).to.equal(user.trove.debt.before)
+        expect(user.trove.icr.after).to.equal(user.trove.icr.before)
+      })
+    })
+
+    it("retrieves correct MUSD amount and the entire collateral Gain, and updates deposit", async () => {
+      await setupPartialRetrieval()
+      const { liquidatedDebt, liquidatedColl } =
+        await getEmittedLiquidationValues(liquidationTx)
+
+      const expectedMUSDLoss =
+        (liquidatedDebt * alice.stabilityPool.deposit.before) /
+        (alice.stabilityPool.deposit.before +
+          whale.stabilityPool.deposit.before)
+
+      const expectedCollateralGain =
+        (liquidatedColl * alice.stabilityPool.deposit.before) /
+        (alice.stabilityPool.deposit.before +
+          whale.stabilityPool.deposit.before)
+      expect(alice.musd.after).to.equal(alice.musd.before + to1e18(900))
+      expect(alice.btc.after - alice.btc.before).to.equal(
+        expectedCollateralGain,
+      )
+
+      expect(alice.stabilityPool.deposit.after).to.be.closeTo(
+        alice.stabilityPool.deposit.before - to1e18(900) - expectedMUSDLoss,
+        5000n,
+      )
+
+      expect(alice.stabilityPool.collateralGain.after).to.equal(0n)
+    })
+
+    it("Subsequent deposit and withdrawal attempt from same account, with no intermediate liquidations, withdraws zero collateral", async () => {
+      await provideToSP(contracts, alice, to1e18("5,000"))
+
+      await createLiquidationEvent(contracts)
+
+      await contracts.stabilityPool
+        .connect(alice.wallet)
+        .withdrawFromSP(to1e18(900), NO_GAS)
+
+      await updateWalletSnapshot(contracts, alice, "before")
+
+      await provideToSP(contracts, alice, to1e18(900))
+      await contracts.stabilityPool
+        .connect(alice.wallet)
+        .withdrawFromSP(to1e18(900), NO_GAS)
+
+      await updateWalletSnapshot(contracts, alice, "after")
+      expect(alice.btc.after).to.equal(alice.btc.before)
+    })
+
+    it("increases depositor's MUSD token balance by the expected amount", async () => {
+      await provideToSP(contracts, alice, to1e18("4,000"))
+
+      await createLiquidationEvent(contracts)
+
+      await updateWalletSnapshot(contracts, alice, "before")
+      await updateStabilityPoolUserSnapshot(contracts, alice, "before")
+
+      await contracts.stabilityPool
+        .connect(alice.wallet)
+        .withdrawFromSP(alice.stabilityPool.compoundedDeposit.before)
+
+      await updateWalletSnapshot(contracts, alice, "after")
+
+      expect(alice.musd.after).to.equal(
+        alice.musd.before + alice.stabilityPool.compoundedDeposit.before,
+      )
+    })
+
+    it("withdrawing 0 collateral Gain does not alter the caller's collateral balance, their trove collateral, or the collateral in the Stability Pool", async () => {
+      await createLiquidationEvent(contracts)
+
+      const amount = to1e18("3,000")
+      await provideToSP(contracts, alice, amount)
+
+      await updateTroveSnapshot(contracts, alice, "before")
+      await updateWalletSnapshot(contracts, alice, "before")
+      await updateStabilityPoolSnapshot(contracts, state, "before")
+
+      await contracts.stabilityPool
+        .connect(alice.wallet)
+        .withdrawFromSP(amount, NO_GAS)
+
+      await updateTroveSnapshot(contracts, alice, "after")
+      await updateWalletSnapshot(contracts, alice, "after")
+      await updateStabilityPoolSnapshot(contracts, state, "after")
+
+      expect(alice.btc.after).to.equal(alice.btc.before)
+      expect(alice.trove.collateral.after).to.equal(
+        alice.trove.collateral.before,
+      )
+      expect(state.stabilityPool.collateral.after).to.equal(
+        state.stabilityPool.collateral.before,
+      )
+    })
+
+    it("Requests to withdraw amounts greater than the caller's compounded deposit only withdraws the caller's compounded deposit", async () => {
+      const amount = to1e18("20,000")
+      await provideToSP(contracts, whale, amount)
+      await updateStabilityPoolSnapshot(contracts, state, "before")
+      await updateWalletSnapshot(contracts, whale, "before")
+      await updateStabilityPoolUserSnapshot(contracts, whale, "before")
+
+      await contracts.stabilityPool
+        .connect(whale.wallet)
+        .withdrawFromSP(whale.stabilityPool.compoundedDeposit.before + amount)
+
+      await updateStabilityPoolSnapshot(contracts, state, "after")
+      await updateWalletSnapshot(contracts, whale, "after")
+      await updateStabilityPoolUserSnapshot(contracts, whale, "after")
+
+      expect(state.stabilityPool.musd.after).to.equal(
+        state.stabilityPool.musd.before -
+          whale.stabilityPool.compoundedDeposit.before,
+      )
+      expect(whale.musd.after).to.equal(
+        whale.musd.before + whale.stabilityPool.compoundedDeposit.before,
+      )
+      expect(whale.stabilityPool.compoundedDeposit.after).to.equal(0n)
+    })
+
+    it("Request to withdraw 2^256-1 MUSD only withdraws the caller's compounded deposit", async () => {
+      await provideToSP(contracts, whale, to1e18("20,000"))
+      const maxBytes32 = BigInt(
+        "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      )
+
+      await updateStabilityPoolSnapshot(contracts, state, "before")
+      await updateWalletSnapshot(contracts, whale, "before")
+      await updateStabilityPoolUserSnapshot(contracts, whale, "before")
+
+      await contracts.stabilityPool
+        .connect(whale.wallet)
+        .withdrawFromSP(maxBytes32)
+
+      await updateStabilityPoolSnapshot(contracts, state, "after")
+      await updateWalletSnapshot(contracts, whale, "after")
+      await updateStabilityPoolUserSnapshot(contracts, whale, "after")
+
+      expect(state.stabilityPool.musd.after).to.equal(
+        state.stabilityPool.musd.before -
+          whale.stabilityPool.compoundedDeposit.before,
+      )
+      expect(whale.musd.after).to.equal(
+        whale.musd.before + whale.stabilityPool.compoundedDeposit.before,
+      )
+      expect(whale.stabilityPool.compoundedDeposit.after).to.equal(0n)
+    })
+
+    context("compounded deposit and collateral Gain", () => {
+      const setupIdenticalDeposits = async () => {
+        const users = [bob, carol, dennis]
+        await openTrovesAndProvideStability(contracts, users, "5,000", "200")
+      }
+
+      const setupVaryingDeposits = async () => {
+        const usersAndAmounts: { user: User; amount: bigint }[] = [
+          { user: bob, amount: to1e18("10,000") },
+          { user: carol, amount: to1e18("20,000") },
+          { user: dennis, amount: to1e18("30,000") },
+        ]
+
+        await Promise.all(
+          usersAndAmounts.map(async ({ user, amount }) => {
+            await openTrove(contracts, {
+              musdAmount: amount,
+              ICR: "200",
+              sender: user.wallet,
+            })
+            await provideToSP(contracts, user, amount)
+          }),
+        )
+      }
+
+      const verify = async () => {
+        const users = [bob, carol, dennis]
+        await updateStabilityPoolUserSnapshots(contracts, users, "before")
+        await Promise.all(
+          users.map((user) => updateWalletSnapshot(contracts, user, "before")),
+        )
+
+        await Promise.all(
+          users.map((user) =>
+            contracts.stabilityPool
+              .connect(user.wallet)
+              .withdrawFromSP(to1e18("500,000"), NO_GAS),
+          ),
+        )
+
+        await updateStabilityPoolUserSnapshots(contracts, users, "after")
+        await Promise.all(
+          users.map((user) => updateWalletSnapshot(contracts, user, "after")),
+        )
+
+        users.forEach((user) => {
+          expect(user.stabilityPool.collateralGain.after).to.equal(0n)
+          expect(user.btc.after).to.equal(
+            user.btc.before + user.stabilityPool.collateralGain.before,
+          )
+          expect(user.musd.after).to.equal(
+            user.musd.before + user.stabilityPool.compoundedDeposit.before,
+          )
+        })
+      }
+
+      it("Depositors with equal initial deposit withdraw correct compounded deposit and collateral Gain after one liquidation", async () => {
+        await setupIdenticalDeposits()
+        await createLiquidationEvent(contracts)
+        await verify()
+      })
+
+      it("Depositors with equal initial deposit withdraw correct compounded deposit and collateral Gain after two identical liquidations", async () => {
+        await setupIdenticalDeposits()
+        await createLiquidationEvent(contracts)
+        await createLiquidationEvent(contracts)
+        await verify()
+      })
+
+      it("Depositors with equal initial deposit withdraw correct compounded deposit and collateral Gain after three identical liquidations", async () => {
+        await setupIdenticalDeposits()
+        await createLiquidationEvent(contracts)
+        await createLiquidationEvent(contracts)
+        await createLiquidationEvent(contracts)
+        await verify()
+      })
+
+      it("Depositors with equal initial deposit withdraw correct compounded deposit and collateral Gain after two liquidations of increasing MUSD", async () => {
+        await setupIdenticalDeposits()
+        await createLiquidationEvent(contracts)
+        await createLiquidationEvent(contracts, "3,000")
+        await verify()
+      })
+
+      it("Depositors with equal initial deposit withdraw correct compounded deposit and collateral Gain after three liquidations of increasing MUSD", async () => {
+        await setupIdenticalDeposits()
+        await createLiquidationEvent(contracts)
+        await createLiquidationEvent(contracts, "3,000")
+        await createLiquidationEvent(contracts, "5,000")
+        await verify()
+      })
+
+      it("Depositors with varying deposits withdraw correct compounded deposit and collateral Gain after two identical liquidations", async () => {
+        await setupVaryingDeposits()
+        await createLiquidationEvent(contracts)
+        await createLiquidationEvent(contracts)
+        await verify()
+      })
+
+      it("Depositors with varying deposits withdraw correct compounded deposit and collateral Gain after three identical liquidations", async () => {
+        await setupVaryingDeposits()
+        await createLiquidationEvent(contracts)
+        await createLiquidationEvent(contracts)
+        await createLiquidationEvent(contracts)
+        await verify()
+      })
+
+      it("Depositors with varying deposits withdraw correct compounded deposit and collateral Gain after three varying liquidations", async () => {
+        await setupVaryingDeposits()
+        await createLiquidationEvent(contracts)
+        await createLiquidationEvent(contracts, "3,000")
+        await createLiquidationEvent(contracts, "6,000")
+        await verify()
+      })
+
+      it("Bob and Carol deposit -> 2 liquidations -> Dennis deposits -> 2 liquidations. Various deposit and liquidation vals.", async () => {
+        await openTrove(contracts, {
+          musdAmount: "10,000",
+          ICR: "200",
+          sender: bob.wallet,
+        })
+        await provideToSP(contracts, bob, to1e18("10,000"))
+
+        await openTrove(contracts, {
+          musdAmount: "20,000",
+          ICR: "200",
+          sender: carol.wallet,
+        })
+        await provideToSP(contracts, carol, to1e18("20,000"))
+
+        await createLiquidationEvent(contracts)
+        await createLiquidationEvent(contracts, "4,000")
+
+        await openTrove(contracts, {
+          musdAmount: "30,000",
+          ICR: "200",
+          sender: dennis.wallet,
+        })
+        await provideToSP(contracts, dennis, to1e18("30,000"))
+
+        await createLiquidationEvent(contracts, "7,000")
+        await createLiquidationEvent(contracts, "9,000")
+
+        await verify()
+      })
+
+      it("Bob, Carol, Dennis deposit -> 2 liquidations -> Eric deposits -> 2 liquidations. All deposits and liquidations = 10,000 MUSD.", async () => {
+        await openTrove(contracts, {
+          musdAmount: "10,000",
+          ICR: "200",
+          sender: bob.wallet,
+        })
+        await provideToSP(contracts, bob, to1e18("10,000"))
+
+        await openTrove(contracts, {
+          musdAmount: "10,000",
+          ICR: "200",
+          sender: carol.wallet,
+        })
+        await provideToSP(contracts, carol, to1e18("10,000"))
+
+        await openTrove(contracts, {
+          musdAmount: "10,000",
+          ICR: "200",
+          sender: dennis.wallet,
+        })
+        await provideToSP(contracts, dennis, to1e18("10,000"))
+
+        await createLiquidationEvent(contracts, "10,000")
+        await createLiquidationEvent(contracts, "10,000")
+
+        await openTrove(contracts, {
+          musdAmount: "10,000",
+          ICR: "200",
+          sender: eric.wallet,
+        })
+        await provideToSP(contracts, eric, to1e18("10,000"))
+
+        await createLiquidationEvent(contracts, "10,000")
+        await createLiquidationEvent(contracts, "10,000")
+
+        await verify()
+      })
+
+      it("Bob, Carol, Dennis deposit -> 2 liquidations -> Dennis withdraws -> 2 liquidations. All deposits and liquidations = 2,000 MUSD.", async () => {
+        const users = [bob, carol, dennis]
+        const amount = "2,000"
+
+        await openTrovesAndProvideStability(contracts, users, amount, "200")
+
+        await createLiquidationEvent(contracts, amount)
+        await createLiquidationEvent(contracts, amount)
+
+        await contracts.stabilityPool
+          .connect(dennis.wallet)
+          .withdrawFromSP(to1e18(amount))
+
+        await createLiquidationEvent(contracts, amount)
+        await createLiquidationEvent(contracts, amount)
+
+        await updateStabilityPoolUserSnapshots(contracts, users, "before")
+        await Promise.all(
+          users.map((user) => updateWalletSnapshot(contracts, user, "before")),
+        )
+
+        // Dennis already withdrew
+        await Promise.all(
+          [bob, carol].map((user) =>
+            contracts.stabilityPool
+              .connect(user.wallet)
+              .withdrawFromSP(to1e18("500,000"), NO_GAS),
+          ),
+        )
+
+        await updateStabilityPoolUserSnapshots(contracts, users, "after")
+        await Promise.all(
+          users.map((user) => updateWalletSnapshot(contracts, user, "after")),
+        )
+
+        users.forEach((user) => {
+          expect(user.stabilityPool.collateralGain.after).to.equal(0n)
+          expect(user.btc.after).to.equal(
+            user.btc.before + user.stabilityPool.collateralGain.before,
+          )
+          expect(user.musd.after).to.equal(
+            user.musd.before + user.stabilityPool.compoundedDeposit.before,
+          )
+        })
+      })
+
+      it("Depositor withdraws correct compounded deposit after liquidation empties the pool", async () => {
+        const amount = "20,000"
+        await provideToSP(contracts, whale, to1e18(amount))
+        await createLiquidationEvent(contracts, amount)
+
+        await updateWalletSnapshot(contracts, whale, "before")
+        await updateStabilityPoolUserSnapshot(contracts, whale, "before")
+
+        // Withdraw everything
+        await contracts.stabilityPool
+          .connect(whale.wallet)
+          .withdrawFromSP(to1e18("500,000"), NO_GAS)
+
+        await updateWalletSnapshot(contracts, whale, "after")
+        await updateStabilityPoolUserSnapshot(contracts, whale, "after")
+
+        expect(whale.stabilityPool.compoundedDeposit.before).to.equal(0n)
+        expect(whale.stabilityPool.collateralGain.after).to.equal(0n)
+        expect(whale.btc.after).to.equal(
+          whale.btc.before + whale.stabilityPool.collateralGain.before,
+        )
+        expect(whale.musd.after).to.equal(whale.musd.before)
+      })
+    })
+
+    it("Single deposit fully offset. After a subsequent liquidation, depositor withdraws 0 musd and the collateral Gain from one liquidation", async () => {
+      const amount = "20,000"
+      await provideToSP(contracts, whale, to1e18(amount))
+      // Fully offset the whale's $20k deposit
+      await createLiquidationEvent(contracts, amount)
+
+      await updateWalletSnapshot(contracts, whale, "before")
+      await updateStabilityPoolUserSnapshot(contracts, whale, "before")
+
+      // Subsequent liquidation
+      await createLiquidationEvent(contracts, "10,000")
+
+      // The whale withdraws everything
+      await contracts.stabilityPool
+        .connect(whale.wallet)
+        .withdrawFromSP(to1e18("500,000"), NO_GAS)
+
+      await updateWalletSnapshot(contracts, whale, "after")
+      await updateStabilityPoolUserSnapshot(contracts, whale, "after")
+
+      expect(whale.musd.after).to.equal(whale.musd.before)
+      expect(whale.stabilityPool.compoundedDeposit.before).to.equal(0n)
+      expect(whale.stabilityPool.deposit.after).to.equal(0n)
+      expect(whale.btc.after).to.equal(
+        whale.btc.before + whale.stabilityPool.collateralGain.before,
+      )
+    })
+
+    it("deposit spans one scale factor change: Single depositor withdraws correct compounded deposit and collateral Gain after one liquidation", async () => {
+      // Add just enough MUSD to increase the scale
+      await provideToSP(contracts, whale, to1e18("10250") + 500000n)
+
+      await createLiquidationEvent(contracts, "10,000")
+
+      await updateStabilityPoolUserSnapshot(contracts, whale, "before")
+      await updateWalletSnapshot(contracts, whale, "before")
+      await updateStabilityPoolSnapshot(contracts, state, "before")
+
+      await contracts.stabilityPool
+        .connect(whale.wallet)
+        .withdrawFromSP(to1e18("10,000"), NO_GAS)
+
+      await updateStabilityPoolUserSnapshot(contracts, whale, "after")
+      await updateWalletSnapshot(contracts, whale, "after")
+
+      expect(state.stabilityPool.currentScale.before).to.equal(1n)
+      expect(whale.musd.after).to.equal(whale.musd.before)
+      expect(whale.stabilityPool.compoundedDeposit.before).to.equal(0n)
+      expect(whale.stabilityPool.deposit.after).to.equal(0n)
+      expect(whale.btc.after).to.equal(
+        whale.btc.before + whale.stabilityPool.collateralGain.before,
+      )
+    })
+
+    it("Several deposits of varying amounts span one scale factor change. Depositors withdraw correct compounded deposit and collateral Gain after one liquidation", async () => {
+      await openTrove(contracts, {
+        musdAmount: "10,000",
+        ICR: "200",
+        sender: bob.wallet,
+      })
+      await provideToSP(contracts, bob, to1e18("10,000"))
+
+      await openTrove(contracts, {
+        musdAmount: "20,000",
+        ICR: "200",
+        sender: carol.wallet,
+      })
+      await provideToSP(contracts, carol, to1e18("20,000"))
+
+      // Just enough left over to increase the scale
+      const dennisAmount = to1e18("30,500") + 500000n
+      await openTrove(contracts, {
+        musdAmount: dennisAmount,
+        ICR: "200",
+        sender: dennis.wallet,
+      })
+      await provideToSP(contracts, dennis, dennisAmount)
+
+      await createLiquidationEvent(contracts, "60,000")
+
+      const users = [bob, carol, dennis]
+      await updateStabilityPoolSnapshot(contracts, state, "before")
+      await Promise.all(
+        users.map(async (user) => {
+          await updateStabilityPoolUserSnapshot(contracts, user, "before")
+          await updateWalletSnapshot(contracts, user, "before")
+        }),
+      )
+
+      await Promise.all(
+        users.map((user) =>
+          contracts.stabilityPool
+            .connect(user.wallet)
+            .withdrawFromSP(to1e18("500,000"), NO_GAS),
+        ),
+      )
+
+      await Promise.all(
+        users.map(async (user) => {
+          await updateStabilityPoolUserSnapshot(contracts, user, "after")
+          await updateWalletSnapshot(contracts, user, "after")
+        }),
+      )
+
+      users.forEach((user) => {
+        expect(user.musd.after).to.equal(user.musd.before)
+        expect(user.stabilityPool.compoundedDeposit.before).to.equal(0n)
+        expect(user.stabilityPool.deposit.after).to.equal(0n)
+        expect(user.btc.after).to.equal(
+          user.btc.before + user.stabilityPool.collateralGain.before,
+        )
+      })
+      expect(state.stabilityPool.currentScale.before).to.equal(1n)
+    })
+
+    it("Deposit that decreases to less than 1e-9 of it's original value is reduced to 0", async () => {
+      const amount = "10,000"
+      await provideToSP(contracts, whale, to1e18(amount) + 10n)
+
+      await createLiquidationEvent(contracts, amount)
+
+      await updateWalletSnapshot(contracts, whale, "before")
+      await updateStabilityPoolUserSnapshot(contracts, whale, "before")
+
+      await contracts.stabilityPool
+        .connect(whale.wallet)
+        .withdrawFromSP(to1e18(amount), NO_GAS)
+
+      await updateWalletSnapshot(contracts, whale, "after")
+
+      expect(whale.musd.after).to.equal(whale.musd.before)
+      expect(whale.stabilityPool.compoundedDeposit.before).to.equal(0n)
+    })
+
+    it("2 depositors can withdraw after each receiving half of a pool-emptying liquidation", async () => {
+      const users = [bob, carol]
+
+      await openTrovesAndProvideStability(contracts, users, "10,000", "200")
+
+      await createLiquidationEvent(contracts, "30,000")
+
+      await updateStabilityPoolUserSnapshots(contracts, users, "before")
+      await updateWalletSnapshot(contracts, bob, "before")
+      await updateWalletSnapshot(contracts, carol, "before")
+
+      await Promise.all(
+        users.map((user) =>
+          contracts.stabilityPool
+            .connect(user.wallet)
+            .withdrawFromSP(to1e18("20,000"), NO_GAS),
+        ),
+      )
+
+      await updateStabilityPoolUserSnapshots(contracts, users, "after")
+      await updateWalletSnapshot(contracts, bob, "after")
+      await updateWalletSnapshot(contracts, carol, "after")
+
+      users.forEach((user) => {
+        expect(user.stabilityPool.compoundedDeposit.before).to.equal(0n)
+        expect(user.stabilityPool.collateralGain.before).to.be.greaterThan(0n)
+
+        expect(user.stabilityPool.compoundedDeposit.after).to.equal(0n)
+        expect(user.stabilityPool.collateralGain.after).to.equal(0n)
+
+        expect(user.musd.after).to.equal(user.musd.before)
+        expect(user.btc.after).to.equal(
+          user.btc.before + user.stabilityPool.collateralGain.before,
+        )
+      })
+    })
+
+    it("Large liquidated coll/debt, deposits and BTC price", async () => {
+      // collateral:USD price is $2 billion per BTC
+      await contracts.mockAggregator.setPrice(2n * 10n ** 27n)
+
+      const users = [bob, carol]
+      const amount = 1n * 10n ** 27n // $ 1 billion
+      await openTrovesAndProvideStability(contracts, users, amount, "200")
+
+      await createLiquidationEvent(contracts, amount)
+
+      await updateStabilityPoolUserSnapshots(contracts, users, "before")
+      await Promise.all(
+        users.map(async (user) => {
+          await updateWalletSnapshot(contracts, user, "before")
+        }),
+      )
+
+      await Promise.all(
+        users.map((user) =>
+          contracts.stabilityPool
+            .connect(user.wallet)
+            .withdrawFromSP(amount, NO_GAS),
+        ),
+      )
+
+      await updateStabilityPoolUserSnapshots(contracts, users, "after")
+      await Promise.all(
+        users.map(async (user) => {
+          await updateWalletSnapshot(contracts, user, "after")
+        }),
+      )
+
+      users.forEach((user) => {
+        expect(user.stabilityPool.compoundedDeposit.after).to.equal(0n)
+        expect(user.stabilityPool.collateralGain.after).to.equal(0n)
+
+        expect(user.musd.after).to.equal(
+          user.musd.before + user.stabilityPool.compoundedDeposit.before,
+        )
+        expect(user.btc.after).to.equal(
+          user.btc.before + user.stabilityPool.collateralGain.before,
+        )
+      })
+    })
+
+    it("doesn't impact system debt, collateral or TCR ", async () => {
+      await provideToSP(contracts, whale, to1e18("20,000"))
+      await createLiquidationEvent(contracts)
+
+      await updateTroveManagerSnapshot(contracts, state, "before")
+      await Promise.all(
+        pools.map((pool) =>
+          updateContractsSnapshot(contracts, state, pool, "before", addresses),
+        ),
+      )
+
+      await contracts.stabilityPool
+        .connect(whale.wallet)
+        .withdrawFromSP(to1e18("3,000"))
+
+      await updateTroveManagerSnapshot(contracts, state, "after")
+      await Promise.all(
+        pools.map((pool) =>
+          updateContractsSnapshot(contracts, state, pool, "after", addresses),
+        ),
+      )
+
+      expect(state.activePool.collateral.after).to.equal(
+        state.activePool.collateral.before,
+      )
+      expect(state.activePool.debt.after).to.equal(state.activePool.debt.before)
+      expect(state.defaultPool.collateral.after).to.equal(
+        state.defaultPool.collateral.before,
+      )
+      expect(state.defaultPool.debt.after).to.equal(
+        state.defaultPool.debt.before,
+      )
+      expect(state.troveManager.TCR.after).to.equal(
+        state.troveManager.TCR.before,
+      )
+    })
+
     context("Expected Reverts", () => {
-      it("withdrawFromSP(): reverts when user has no active deposit", async () => {
+      it("reverts when user has no active deposit", async () => {
         await expect(
           contracts.stabilityPool.connect(alice.wallet).withdrawFromSP(1n),
         ).to.be.revertedWith("StabilityPool: User must have a non-zero deposit")
       })
 
-      it("withdrawFromSP(): reverts when amount > 0 and system has an undercollateralized trove", async () => {
+      it("reverts when amount > 0 and system has an undercollateralized trove", async () => {
         // Open a barely-collateralized trove for Bob.
         await openTrove(contracts, {
           musdAmount: "2000",
@@ -489,955 +1290,614 @@ describe("StabilityPool in Normal Mode", () => {
         )
       })
     })
-
-    /**
-     *
-     * Emitted Events
-     *
-     */
-    context("Emitted Events", () => {})
-
-    /**
-     *
-     * System State Changes
-     *
-     */
-    context("System State Changes", () => {
-      it("withdrawFromSP(): leaves the correct amount of MUSD in the Stability Pool", async () => {
-        await setupPartialRetrieval()
-        const { liquidatedDebt } =
-          await getEmittedLiquidationValues(liquidationTx)
-
-        const expectedMUSD =
-          state.stabilityPool.musd.before -
-          to1e18(900) - // alice withdrew $900
-          liquidatedDebt
-
-        expect(state.stabilityPool.musd.after).to.equal(expectedMUSD)
-      })
-
-      it("withdrawFromSP(): full retrieval - leaves the correct amount of MUSD in the Stability Pool", async () => {
-        await provideToSP(contracts, alice, to1e18("5,000"))
-
-        await updateStabilityPoolUserSnapshots(
-          contracts,
-          [alice, whale],
-          "before",
-        )
-        await updateStabilityPoolSnapshot(contracts, state, "before")
-
-        const tx = await createLiquidationEvent(contracts)
-
-        const { liquidatedDebt } = await getEmittedLiquidationValues(tx)
-
-        const expectedMUSDLoss =
-          (liquidatedDebt * alice.stabilityPool.deposit.before) /
-          (alice.stabilityPool.deposit.before +
-            whale.stabilityPool.deposit.before)
-
-        // fully withdraw
-        await contracts.stabilityPool
-          .connect(alice.wallet)
-          .withdrawFromSP(alice.stabilityPool.deposit.before, NO_GAS)
-
-        await updateStabilityPoolSnapshot(contracts, state, "after")
-
-        const aliceRemainingDeposit =
-          alice.stabilityPool.deposit.before - expectedMUSDLoss
-
-        expect(state.stabilityPool.musd.after).to.be.closeTo(
-          state.stabilityPool.musd.before -
-            liquidatedDebt -
-            aliceRemainingDeposit,
-          5000n,
-        )
-      })
-
-      it("withdrawFromSP(): it correctly updates the user's MUSD and collateral snapshots of entitled reward per unit staked", async () => {
-        await provideToSP(contracts, alice, to1e18("4,000"))
-
-        await createLiquidationEvent(contracts)
-        await contracts.stabilityPool
-          .connect(alice.wallet)
-          .withdrawFromSP(to1e18(900))
-
-        await updateStabilityPoolSnapshot(contracts, state, "after")
-        await updateStabilityPoolUserSnapshot(contracts, alice, "after")
-
-        expect(alice.stabilityPool.P.after).to.equal(
-          state.stabilityPool.P.after,
-        )
-        expect(alice.stabilityPool.S.after).to.equal(
-          state.stabilityPool.S.after,
-        )
-      })
-
-      it("withdrawFromSP(): decreases StabilityPool collateral", async () => {
-        await provideToSP(contracts, alice, to1e18("4,000"))
-
-        await createLiquidationEvent(contracts)
-
-        await updateStabilityPoolSnapshot(contracts, state, "before")
-        await updateStabilityPoolUserSnapshot(contracts, alice, "before")
-
-        await contracts.stabilityPool
-          .connect(alice.wallet)
-          .withdrawFromSP(to1e18(900))
-
-        await updateStabilityPoolSnapshot(contracts, state, "after")
-
-        expect(state.stabilityPool.collateral.after).to.equal(
-          state.stabilityPool.collateral.before -
-            alice.stabilityPool.collateralGain.before,
-        )
-      })
-
-      it("withdrawFromSP(): All depositors are able to withdraw from the SP to their account", async () => {
-        await provideToSP(contracts, whale, to1e18("20,000"))
-        await provideToSP(contracts, alice, to1e18("4,000"))
-
-        await createLiquidationEvent(contracts)
-
-        const users = [alice, whale]
-        await Promise.all(
-          users.map(async (user) => {
-            await updateStabilityPoolUserSnapshot(contracts, user, "before")
-            await contracts.stabilityPool
-              .connect(user.wallet)
-              .withdrawFromSP(user.stabilityPool.compoundedDeposit.before)
-            await updateStabilityPoolUserSnapshot(contracts, user, "after")
-          }),
-        )
-        await updateStabilityPoolSnapshot(contracts, state, "after")
-
-        users.forEach((user) =>
-          expect(user.stabilityPool.compoundedDeposit.after).to.equal(0n),
-        )
-        expect(state.stabilityPool.musd.after).to.be.closeTo(0n, 20000n)
-      })
-
-      it("withdrawFromSP(): doesn't impact other users deposits or collateral gains", async () => {
-        await provideToSP(contracts, alice, to1e18("3,000"))
-        await openTrovesAndProvideStability(
-          contracts,
-          [bob, carol],
-          "5,000",
-          "200",
-        )
-
-        await createLiquidationEvent(contracts)
-
-        await updateStabilityPoolUserSnapshots(
-          contracts,
-          [bob, carol],
-          "before",
-        )
-
-        // Alice withdraws from the Stability Pool
-        await contracts.stabilityPool
-          .connect(alice.wallet)
-          .withdrawFromSP(to1e18(1000))
-
-        await updateStabilityPoolUserSnapshots(contracts, [bob, carol], "after")
-
-        // Check that Bob and Carol's deposits and collateral gains haven't changed
-        ;[bob, carol].forEach((user) => {
-          expect(user.stabilityPool.deposit.after).to.equal(
-            user.stabilityPool.deposit.before,
-          )
-          expect(user.stabilityPool.collateralGain.after).to.equal(
-            user.stabilityPool.collateralGain.before,
-          )
-        })
-      })
-
-      it("withdrawFromSP(): succeeds when amount is 0 and system has an undercollateralized trove", async () => {
-        await provideToSP(contracts, whale, to1e18("20,000"))
-        await createLiquidationEvent(contracts)
-
-        await openTrove(contracts, {
-          musdAmount: "2,000", // slightly over the minimum of $1800
-          ICR: "120", // 120%
-          sender: bob.wallet,
-        })
-
-        await dropPrice(contracts, bob)
-
-        await updateStabilityPoolUserSnapshot(contracts, whale, "before")
-        await updateWalletSnapshot(contracts, whale, "before")
-
-        await contracts.stabilityPool
-          .connect(whale.wallet)
-          .withdrawFromSP(0n, NO_GAS)
-
-        await updateStabilityPoolUserSnapshot(contracts, whale, "after")
-        await updateWalletSnapshot(contracts, whale, "after")
-
-        expect(whale.musd.after).to.equal(whale.musd.before)
-        expect(whale.btc.after).to.equal(
-          whale.btc.before + whale.stabilityPool.collateralGain.before,
-        )
-        expect(whale.stabilityPool.compoundedDeposit.after).to.equal(
-          whale.stabilityPool.compoundedDeposit.before,
-        )
-        expect(whale.stabilityPool.collateralGain.after).to.equal(0n)
-      })
-
-      it("withdrawFromSP(): withdrawing 0 MUSD doesn't alter the caller's deposit or the total MUSD in the Stability Pool", async () => {
-        await provideToSP(contracts, whale, to1e18("20,000"))
-        await createLiquidationEvent(contracts)
-
-        await updateStabilityPoolUserSnapshot(contracts, whale, "before")
-        await updateStabilityPoolSnapshot(contracts, state, "before")
-
-        await contracts.stabilityPool.connect(whale.wallet).withdrawFromSP(0n)
-
-        await updateStabilityPoolUserSnapshot(contracts, whale, "after")
-        await updateStabilityPoolSnapshot(contracts, state, "after")
-
-        expect(whale.stabilityPool.compoundedDeposit.after).to.equal(
-          whale.stabilityPool.compoundedDeposit.before,
-        )
-        expect(state.stabilityPool.musd.after).to.equal(
-          state.stabilityPool.musd.before,
-        )
-      })
-    })
-
-    /**
-     *
-     * Individual Troves
-     *
-     */
-    context("Individual Troves", () => {
-      it("withdrawFromSP(): doesn't impact any troves, including the caller's trove", async () => {
-        await provideToSP(contracts, whale, to1e18("20,000"))
-
-        await openTroves(contracts, [bob, carol], "5,000", "200")
-
-        await createLiquidationEvent(contracts)
-
-        const users = [alice, bob, carol, whale]
-        await updateTroveSnapshots(contracts, users, "before")
-
-        await contracts.stabilityPool
-          .connect(whale.wallet)
-          .withdrawFromSP(to1e18("3,000"))
-
-        await updateTroveSnapshots(contracts, users, "after")
-
-        users.forEach((user) => {
-          expect(user.trove.collateral.after).to.equal(
-            user.trove.collateral.before,
-          )
-          expect(user.trove.debt.after).to.equal(user.trove.debt.before)
-          expect(user.trove.icr.after).to.equal(user.trove.icr.before)
-        })
-      })
-    })
-
-    /**
-     *
-     * Balance changes
-     *
-     */
-    context("Balance changes", () => {
-      it("withdrawFromSP(): retrieves correct MUSD amount and the entire collateral Gain, and updates deposit", async () => {
-        await setupPartialRetrieval()
-        const { liquidatedDebt, liquidatedColl } =
-          await getEmittedLiquidationValues(liquidationTx)
-
-        const expectedMUSDLoss =
-          (liquidatedDebt * alice.stabilityPool.deposit.before) /
-          (alice.stabilityPool.deposit.before +
-            whale.stabilityPool.deposit.before)
-
-        const expectedCollateralGain =
-          (liquidatedColl * alice.stabilityPool.deposit.before) /
-          (alice.stabilityPool.deposit.before +
-            whale.stabilityPool.deposit.before)
-        expect(alice.musd.after).to.equal(alice.musd.before + to1e18(900))
-        expect(alice.btc.after - alice.btc.before).to.equal(
-          expectedCollateralGain,
-        )
-
-        expect(alice.stabilityPool.deposit.after).to.be.closeTo(
-          alice.stabilityPool.deposit.before - to1e18(900) - expectedMUSDLoss,
-          5000n,
-        )
-
-        expect(alice.stabilityPool.collateralGain.after).to.equal(0n)
-      })
-
-      it("withdrawFromSP(): Subsequent deposit and withdrawal attempt from same account, with no intermediate liquidations, withdraws zero collateral", async () => {
-        await provideToSP(contracts, alice, to1e18("5,000"))
-
-        await createLiquidationEvent(contracts)
-
-        await contracts.stabilityPool
-          .connect(alice.wallet)
-          .withdrawFromSP(to1e18(900), NO_GAS)
-
-        await updateWalletSnapshot(contracts, alice, "before")
-
-        await provideToSP(contracts, alice, to1e18(900))
-        await contracts.stabilityPool
-          .connect(alice.wallet)
-          .withdrawFromSP(to1e18(900), NO_GAS)
-
-        await updateWalletSnapshot(contracts, alice, "after")
-        expect(alice.btc.after).to.equal(alice.btc.before)
-      })
-
-      it("withdrawFromSP(): increases depositor's MUSD token balance by the expected amount", async () => {
-        await provideToSP(contracts, alice, to1e18("4,000"))
-
-        await createLiquidationEvent(contracts)
-
-        await updateWalletSnapshot(contracts, alice, "before")
-        await updateStabilityPoolUserSnapshot(contracts, alice, "before")
-
-        await contracts.stabilityPool
-          .connect(alice.wallet)
-          .withdrawFromSP(alice.stabilityPool.compoundedDeposit.before)
-
-        await updateWalletSnapshot(contracts, alice, "after")
-
-        expect(alice.musd.after).to.equal(
-          alice.musd.before + alice.stabilityPool.compoundedDeposit.before,
-        )
-      })
-
-      it("withdrawFromSP(): withdrawing 0 collateral Gain does not alter the caller's collateral balance, their trove collateral, or the collateral in the Stability Pool", async () => {
-        await createLiquidationEvent(contracts)
-
-        const amount = to1e18("3,000")
-        await provideToSP(contracts, alice, amount)
-
-        await updateTroveSnapshot(contracts, alice, "before")
-        await updateWalletSnapshot(contracts, alice, "before")
-        await updateStabilityPoolSnapshot(contracts, state, "before")
-
-        await contracts.stabilityPool
-          .connect(alice.wallet)
-          .withdrawFromSP(amount, NO_GAS)
-
-        await updateTroveSnapshot(contracts, alice, "after")
-        await updateWalletSnapshot(contracts, alice, "after")
-        await updateStabilityPoolSnapshot(contracts, state, "after")
-
-        expect(alice.btc.after).to.equal(alice.btc.before)
-        expect(alice.trove.collateral.after).to.equal(
-          alice.trove.collateral.before,
-        )
-        expect(state.stabilityPool.collateral.after).to.equal(
-          state.stabilityPool.collateral.before,
-        )
-      })
-
-      it("withdrawFromSP(): Requests to withdraw amounts greater than the caller's compounded deposit only withdraws the caller's compounded deposit", async () => {
-        const amount = to1e18("20,000")
-        await provideToSP(contracts, whale, amount)
-        await updateStabilityPoolSnapshot(contracts, state, "before")
-        await updateWalletSnapshot(contracts, whale, "before")
-        await updateStabilityPoolUserSnapshot(contracts, whale, "before")
-
-        await contracts.stabilityPool
-          .connect(whale.wallet)
-          .withdrawFromSP(whale.stabilityPool.compoundedDeposit.before + amount)
-
-        await updateStabilityPoolSnapshot(contracts, state, "after")
-        await updateWalletSnapshot(contracts, whale, "after")
-        await updateStabilityPoolUserSnapshot(contracts, whale, "after")
-
-        expect(state.stabilityPool.musd.after).to.equal(
-          state.stabilityPool.musd.before -
-            whale.stabilityPool.compoundedDeposit.before,
-        )
-        expect(whale.musd.after).to.equal(
-          whale.musd.before + whale.stabilityPool.compoundedDeposit.before,
-        )
-        expect(whale.stabilityPool.compoundedDeposit.after).to.equal(0n)
-      })
-
-      it("withdrawFromSP(): Request to withdraw 2^256-1 MUSD only withdraws the caller's compounded deposit", async () => {
-        await provideToSP(contracts, whale, to1e18("20,000"))
-        const maxBytes32 = BigInt(
-          "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-        )
-
-        await updateStabilityPoolSnapshot(contracts, state, "before")
-        await updateWalletSnapshot(contracts, whale, "before")
-        await updateStabilityPoolUserSnapshot(contracts, whale, "before")
-
-        await contracts.stabilityPool
-          .connect(whale.wallet)
-          .withdrawFromSP(maxBytes32)
-
-        await updateStabilityPoolSnapshot(contracts, state, "after")
-        await updateWalletSnapshot(contracts, whale, "after")
-        await updateStabilityPoolUserSnapshot(contracts, whale, "after")
-
-        expect(state.stabilityPool.musd.after).to.equal(
-          state.stabilityPool.musd.before -
-            whale.stabilityPool.compoundedDeposit.before,
-        )
-        expect(whale.musd.after).to.equal(
-          whale.musd.before + whale.stabilityPool.compoundedDeposit.before,
-        )
-        expect(whale.stabilityPool.compoundedDeposit.after).to.equal(0n)
-      })
-
-      context("compounded deposit and collateral Gain", () => {
-        const setupIdenticalDeposits = async () => {
-          const users = [bob, carol, dennis]
-          await openTrovesAndProvideStability(contracts, users, "5,000", "200")
-        }
-
-        const setupVaryingDeposits = async () => {
-          const usersAndAmounts: { user: User; amount: bigint }[] = [
-            { user: bob, amount: to1e18("10,000") },
-            { user: carol, amount: to1e18("20,000") },
-            { user: dennis, amount: to1e18("30,000") },
-          ]
-
-          await Promise.all(
-            usersAndAmounts.map(async ({ user, amount }) => {
-              await openTrove(contracts, {
-                musdAmount: amount,
-                ICR: "200",
-                sender: user.wallet,
-              })
-              await provideToSP(contracts, user, amount)
-            }),
-          )
-        }
-
-        const verify = async () => {
-          const users = [bob, carol, dennis]
-          await updateStabilityPoolUserSnapshots(contracts, users, "before")
-          await Promise.all(
-            users.map((user) =>
-              updateWalletSnapshot(contracts, user, "before"),
-            ),
-          )
-
-          await Promise.all(
-            users.map((user) =>
-              contracts.stabilityPool
-                .connect(user.wallet)
-                .withdrawFromSP(to1e18("500,000"), NO_GAS),
-            ),
-          )
-
-          await updateStabilityPoolUserSnapshots(contracts, users, "after")
-          await Promise.all(
-            users.map((user) => updateWalletSnapshot(contracts, user, "after")),
-          )
-
-          users.forEach((user) => {
-            expect(user.stabilityPool.collateralGain.after).to.equal(0n)
-            expect(user.btc.after).to.equal(
-              user.btc.before + user.stabilityPool.collateralGain.before,
-            )
-            expect(user.musd.after).to.equal(
-              user.musd.before + user.stabilityPool.compoundedDeposit.before,
-            )
-          })
-        }
-
-        it("withdrawFromSP(): Depositors with equal initial deposit withdraw correct compounded deposit and collateral Gain after one liquidation", async () => {
-          await setupIdenticalDeposits()
-          await createLiquidationEvent(contracts)
-          await verify()
-        })
-
-        it("withdrawFromSP(): Depositors with equal initial deposit withdraw correct compounded deposit and collateral Gain after two identical liquidations", async () => {
-          await setupIdenticalDeposits()
-          await createLiquidationEvent(contracts)
-          await createLiquidationEvent(contracts)
-          await verify()
-        })
-
-        it("withdrawFromSP(): Depositors with equal initial deposit withdraw correct compounded deposit and collateral Gain after three identical liquidations", async () => {
-          await setupIdenticalDeposits()
-          await createLiquidationEvent(contracts)
-          await createLiquidationEvent(contracts)
-          await createLiquidationEvent(contracts)
-          await verify()
-        })
-
-        it("withdrawFromSP(): Depositors with equal initial deposit withdraw correct compounded deposit and collateral Gain after two liquidations of increasing MUSD", async () => {
-          await setupIdenticalDeposits()
-          await createLiquidationEvent(contracts)
-          await createLiquidationEvent(contracts, "3,000")
-          await verify()
-        })
-
-        it("withdrawFromSP(): Depositors with equal initial deposit withdraw correct compounded deposit and collateral Gain after three liquidations of increasing MUSD", async () => {
-          await setupIdenticalDeposits()
-          await createLiquidationEvent(contracts)
-          await createLiquidationEvent(contracts, "3,000")
-          await createLiquidationEvent(contracts, "5,000")
-          await verify()
-        })
-
-        it("withdrawFromSP(): Depositors with varying deposits withdraw correct compounded deposit and collateral Gain after two identical liquidations", async () => {
-          await setupVaryingDeposits()
-          await createLiquidationEvent(contracts)
-          await createLiquidationEvent(contracts)
-          await verify()
-        })
-
-        it("withdrawFromSP(): Depositors with varying deposits withdraw correct compounded deposit and collateral Gain after three identical liquidations", async () => {
-          await setupVaryingDeposits()
-          await createLiquidationEvent(contracts)
-          await createLiquidationEvent(contracts)
-          await createLiquidationEvent(contracts)
-          await verify()
-        })
-
-        it("withdrawFromSP(): Depositors with varying deposits withdraw correct compounded deposit and collateral Gain after three varying liquidations", async () => {
-          await setupVaryingDeposits()
-          await createLiquidationEvent(contracts)
-          await createLiquidationEvent(contracts, "3,000")
-          await createLiquidationEvent(contracts, "6,000")
-          await verify()
-        })
-
-        it("withdrawFromSP(): Bob and Carol deposit -> 2 liquidations -> Dennis deposits -> 2 liquidations. Various deposit and liquidation vals.", async () => {
-          await openTrove(contracts, {
-            musdAmount: "10,000",
-            ICR: "200",
-            sender: bob.wallet,
-          })
-          await provideToSP(contracts, bob, to1e18("10,000"))
-
-          await openTrove(contracts, {
-            musdAmount: "20,000",
-            ICR: "200",
-            sender: carol.wallet,
-          })
-          await provideToSP(contracts, carol, to1e18("20,000"))
-
-          await createLiquidationEvent(contracts)
-          await createLiquidationEvent(contracts, "4,000")
-
-          await openTrove(contracts, {
-            musdAmount: "30,000",
-            ICR: "200",
-            sender: dennis.wallet,
-          })
-          await provideToSP(contracts, dennis, to1e18("30,000"))
-
-          await createLiquidationEvent(contracts, "7,000")
-          await createLiquidationEvent(contracts, "9,000")
-
-          await verify()
-        })
-
-        it("withdrawFromSP(): Bob, Carol, Dennis deposit -> 2 liquidations -> Eric deposits -> 2 liquidations. All deposits and liquidations = 10,000 MUSD.", async () => {
-          await openTrove(contracts, {
-            musdAmount: "10,000",
-            ICR: "200",
-            sender: bob.wallet,
-          })
-          await provideToSP(contracts, bob, to1e18("10,000"))
-
-          await openTrove(contracts, {
-            musdAmount: "10,000",
-            ICR: "200",
-            sender: carol.wallet,
-          })
-          await provideToSP(contracts, carol, to1e18("10,000"))
-
-          await openTrove(contracts, {
-            musdAmount: "10,000",
-            ICR: "200",
-            sender: dennis.wallet,
-          })
-          await provideToSP(contracts, dennis, to1e18("10,000"))
-
-          await createLiquidationEvent(contracts, "10,000")
-          await createLiquidationEvent(contracts, "10,000")
-
-          await openTrove(contracts, {
-            musdAmount: "10,000",
-            ICR: "200",
-            sender: eric.wallet,
-          })
-          await provideToSP(contracts, eric, to1e18("10,000"))
-
-          await createLiquidationEvent(contracts, "10,000")
-          await createLiquidationEvent(contracts, "10,000")
-
-          await verify()
-        })
-
-        it("withdrawFromSP(): Bob, Carol, Dennis deposit -> 2 liquidations -> Dennis withdraws -> 2 liquidations. All deposits and liquidations = 2,000 MUSD.", async () => {
-          const users = [bob, carol, dennis]
-          const amount = "2,000"
-
-          await openTrovesAndProvideStability(contracts, users, amount, "200")
-
-          await createLiquidationEvent(contracts, amount)
-          await createLiquidationEvent(contracts, amount)
-
-          await contracts.stabilityPool
-            .connect(dennis.wallet)
-            .withdrawFromSP(to1e18(amount))
-
-          await createLiquidationEvent(contracts, amount)
-          await createLiquidationEvent(contracts, amount)
-
-          await updateStabilityPoolUserSnapshots(contracts, users, "before")
-          await Promise.all(
-            users.map((user) =>
-              updateWalletSnapshot(contracts, user, "before"),
-            ),
-          )
-
-          // Dennis already withdrew
-          await Promise.all(
-            [bob, carol].map((user) =>
-              contracts.stabilityPool
-                .connect(user.wallet)
-                .withdrawFromSP(to1e18("500,000"), NO_GAS),
-            ),
-          )
-
-          await updateStabilityPoolUserSnapshots(contracts, users, "after")
-          await Promise.all(
-            users.map((user) => updateWalletSnapshot(contracts, user, "after")),
-          )
-
-          users.forEach((user) => {
-            expect(user.stabilityPool.collateralGain.after).to.equal(0n)
-            expect(user.btc.after).to.equal(
-              user.btc.before + user.stabilityPool.collateralGain.before,
-            )
-            expect(user.musd.after).to.equal(
-              user.musd.before + user.stabilityPool.compoundedDeposit.before,
-            )
-          })
-        })
-
-        it("withdrawFromSP(): Depositor withdraws correct compounded deposit after liquidation empties the pool", async () => {
-          const amount = "20,000"
-          await provideToSP(contracts, whale, to1e18(amount))
-          await createLiquidationEvent(contracts, amount)
-
-          await updateWalletSnapshot(contracts, whale, "before")
-          await updateStabilityPoolUserSnapshot(contracts, whale, "before")
-
-          // Withdraw everything
-          await contracts.stabilityPool
-            .connect(whale.wallet)
-            .withdrawFromSP(to1e18("500,000"), NO_GAS)
-
-          await updateWalletSnapshot(contracts, whale, "after")
-          await updateStabilityPoolUserSnapshot(contracts, whale, "after")
-
-          expect(whale.stabilityPool.compoundedDeposit.before).to.equal(0n)
-          expect(whale.stabilityPool.collateralGain.after).to.equal(0n)
-          expect(whale.btc.after).to.equal(
-            whale.btc.before + whale.stabilityPool.collateralGain.before,
-          )
-          expect(whale.musd.after).to.equal(whale.musd.before)
-        })
-      })
-
-      it("withdrawFromSP(): Single deposit fully offset. After a subsequent liquidation, depositor withdraws 0 musd and the collateral Gain from one liquidation", async () => {
-        const amount = "20,000"
-        await provideToSP(contracts, whale, to1e18(amount))
-        // Fully offset the whale's $20k deposit
-        await createLiquidationEvent(contracts, amount)
-
-        await updateWalletSnapshot(contracts, whale, "before")
-        await updateStabilityPoolUserSnapshot(contracts, whale, "before")
-
-        // Subsequent liquidation
-        await createLiquidationEvent(contracts, "10,000")
-
-        // The whale withdraws everything
-        await contracts.stabilityPool
-          .connect(whale.wallet)
-          .withdrawFromSP(to1e18("500,000"), NO_GAS)
-
-        await updateWalletSnapshot(contracts, whale, "after")
-        await updateStabilityPoolUserSnapshot(contracts, whale, "after")
-
-        expect(whale.musd.after).to.equal(whale.musd.before)
-        expect(whale.stabilityPool.compoundedDeposit.before).to.equal(0n)
-        expect(whale.stabilityPool.deposit.after).to.equal(0n)
-        expect(whale.btc.after).to.equal(
-          whale.btc.before + whale.stabilityPool.collateralGain.before,
-        )
-      })
-
-      it("withdrawFromSP(): deposit spans one scale factor change: Single depositor withdraws correct compounded deposit and collateral Gain after one liquidation", async () => {
-        // Add just enough MUSD to increase the scale
-        await provideToSP(contracts, whale, to1e18("10250") + 500000n)
-
-        await createLiquidationEvent(contracts, "10,000")
-
-        await updateStabilityPoolUserSnapshot(contracts, whale, "before")
-        await updateWalletSnapshot(contracts, whale, "before")
-        await updateStabilityPoolSnapshot(contracts, state, "before")
-
-        await contracts.stabilityPool
-          .connect(whale.wallet)
-          .withdrawFromSP(to1e18("10,000"), NO_GAS)
-
-        await updateStabilityPoolUserSnapshot(contracts, whale, "after")
-        await updateWalletSnapshot(contracts, whale, "after")
-
-        expect(state.stabilityPool.currentScale.before).to.equal(1n)
-        expect(whale.musd.after).to.equal(whale.musd.before)
-        expect(whale.stabilityPool.compoundedDeposit.before).to.equal(0n)
-        expect(whale.stabilityPool.deposit.after).to.equal(0n)
-        expect(whale.btc.after).to.equal(
-          whale.btc.before + whale.stabilityPool.collateralGain.before,
-        )
-      })
-
-      it("withdrawFromSP(): Several deposits of varying amounts span one scale factor change. Depositors withdraw correct compounded deposit and collateral Gain after one liquidation", async () => {
-        await openTrove(contracts, {
-          musdAmount: "10,000",
-          ICR: "200",
-          sender: bob.wallet,
-        })
-        await provideToSP(contracts, bob, to1e18("10,000"))
-
-        await openTrove(contracts, {
-          musdAmount: "20,000",
-          ICR: "200",
-          sender: carol.wallet,
-        })
-        await provideToSP(contracts, carol, to1e18("20,000"))
-
-        // Just enough left over to increase the scale
-        const dennisAmount = to1e18("30,500") + 500000n
-        await openTrove(contracts, {
-          musdAmount: dennisAmount,
-          ICR: "200",
-          sender: dennis.wallet,
-        })
-        await provideToSP(contracts, dennis, dennisAmount)
-
-        await createLiquidationEvent(contracts, "60,000")
-
-        const users = [bob, carol, dennis]
-        await updateStabilityPoolSnapshot(contracts, state, "before")
-        await Promise.all(
-          users.map(async (user) => {
-            await updateStabilityPoolUserSnapshot(contracts, user, "before")
-            await updateWalletSnapshot(contracts, user, "before")
-          }),
-        )
-
-        await Promise.all(
-          users.map((user) =>
-            contracts.stabilityPool
-              .connect(user.wallet)
-              .withdrawFromSP(to1e18("500,000"), NO_GAS),
-          ),
-        )
-
-        await Promise.all(
-          users.map(async (user) => {
-            await updateStabilityPoolUserSnapshot(contracts, user, "after")
-            await updateWalletSnapshot(contracts, user, "after")
-          }),
-        )
-
-        users.forEach((user) => {
-          expect(user.musd.after).to.equal(user.musd.before)
-          expect(user.stabilityPool.compoundedDeposit.before).to.equal(0n)
-          expect(user.stabilityPool.deposit.after).to.equal(0n)
-          expect(user.btc.after).to.equal(
-            user.btc.before + user.stabilityPool.collateralGain.before,
-          )
-        })
-        expect(state.stabilityPool.currentScale.before).to.equal(1n)
-      })
-
-      it("withdrawFromSP(): Deposit that decreases to less than 1e-9 of it's original value is reduced to 0", async () => {
-        const amount = "10,000"
-        await provideToSP(contracts, whale, to1e18(amount) + 10n)
-
-        await createLiquidationEvent(contracts, amount)
-
-        await updateWalletSnapshot(contracts, whale, "before")
-        await updateStabilityPoolUserSnapshot(contracts, whale, "before")
-
-        await contracts.stabilityPool
-          .connect(whale.wallet)
-          .withdrawFromSP(to1e18(amount), NO_GAS)
-
-        await updateWalletSnapshot(contracts, whale, "after")
-
-        expect(whale.musd.after).to.equal(whale.musd.before)
-        expect(whale.stabilityPool.compoundedDeposit.before).to.equal(0n)
-      })
-
-      it("withdrawFromSP(): 2 depositors can withdraw after each receiving half of a pool-emptying liquidation", async () => {
-        const users = [bob, carol]
-
-        await openTrovesAndProvideStability(contracts, users, "10,000", "200")
-
-        await createLiquidationEvent(contracts, "30,000")
-
-        await updateStabilityPoolUserSnapshots(contracts, users, "before")
-        await updateWalletSnapshot(contracts, bob, "before")
-        await updateWalletSnapshot(contracts, carol, "before")
-
-        await Promise.all(
-          users.map((user) =>
-            contracts.stabilityPool
-              .connect(user.wallet)
-              .withdrawFromSP(to1e18("20,000"), NO_GAS),
-          ),
-        )
-
-        await updateStabilityPoolUserSnapshots(contracts, users, "after")
-        await updateWalletSnapshot(contracts, bob, "after")
-        await updateWalletSnapshot(contracts, carol, "after")
-
-        users.forEach((user) => {
-          expect(user.stabilityPool.compoundedDeposit.before).to.equal(0n)
-          expect(user.stabilityPool.collateralGain.before).to.be.greaterThan(0n)
-
-          expect(user.stabilityPool.compoundedDeposit.after).to.equal(0n)
-          expect(user.stabilityPool.collateralGain.after).to.equal(0n)
-
-          expect(user.musd.after).to.equal(user.musd.before)
-          expect(user.btc.after).to.equal(
-            user.btc.before + user.stabilityPool.collateralGain.before,
-          )
-        })
-      })
-
-      it("withdrawFromSP(): Large liquidated coll/debt, deposits and BTC price", async () => {
-        // collateral:USD price is $2 billion per BTC
-        await contracts.mockAggregator.setPrice(2n * 10n ** 27n)
-
-        const users = [bob, carol]
-        const amount = 1n * 10n ** 27n // $ 1 billion
-        await openTrovesAndProvideStability(contracts, users, amount, "200")
-
-        await createLiquidationEvent(contracts, amount)
-
-        await updateStabilityPoolUserSnapshots(contracts, users, "before")
-        await Promise.all(
-          users.map(async (user) => {
-            await updateWalletSnapshot(contracts, user, "before")
-          }),
-        )
-
-        await Promise.all(
-          users.map((user) =>
-            contracts.stabilityPool
-              .connect(user.wallet)
-              .withdrawFromSP(amount, NO_GAS),
-          ),
-        )
-
-        await updateStabilityPoolUserSnapshots(contracts, users, "after")
-        await Promise.all(
-          users.map(async (user) => {
-            await updateWalletSnapshot(contracts, user, "after")
-          }),
-        )
-
-        users.forEach((user) => {
-          expect(user.stabilityPool.compoundedDeposit.after).to.equal(0n)
-          expect(user.stabilityPool.collateralGain.after).to.equal(0n)
-
-          expect(user.musd.after).to.equal(
-            user.musd.before + user.stabilityPool.compoundedDeposit.before,
-          )
-          expect(user.btc.after).to.equal(
-            user.btc.before + user.stabilityPool.collateralGain.before,
-          )
-        })
-      })
-    })
-
-    /**
-     *
-     * Fees
-     *
-     */
-    context("Fees", () => {})
-
-    /**
-     *
-     * State change in other contracts
-     *
-     */
-    context("State change in other contracts", () => {
-      it("withdrawFromSP(): doesn't impact system debt, collateral or TCR ", async () => {
-        await provideToSP(contracts, whale, to1e18("20,000"))
-        await createLiquidationEvent(contracts)
-
-        await updateTroveManagerSnapshot(contracts, state, "before")
-        await Promise.all(
-          pools.map((pool) =>
-            updateContractsSnapshot(
-              contracts,
-              state,
-              pool,
-              "before",
-              addresses,
-            ),
-          ),
-        )
-
-        await contracts.stabilityPool
-          .connect(whale.wallet)
-          .withdrawFromSP(to1e18("3,000"))
-
-        await updateTroveManagerSnapshot(contracts, state, "after")
-        await Promise.all(
-          pools.map((pool) =>
-            updateContractsSnapshot(contracts, state, pool, "after", addresses),
-          ),
-        )
-
-        expect(state.activePool.collateral.after).to.equal(
-          state.activePool.collateral.before,
-        )
-        expect(state.activePool.debt.after).to.equal(
-          state.activePool.debt.before,
-        )
-        expect(state.defaultPool.collateral.after).to.equal(
-          state.defaultPool.collateral.before,
-        )
-        expect(state.defaultPool.debt.after).to.equal(
-          state.defaultPool.debt.before,
-        )
-        expect(state.troveManager.TCR.after).to.equal(
-          state.troveManager.TCR.before,
-        )
-      })
-    })
   })
 
   describe("withdrawCollateralGainToTrove()", () => {
-    /**
-     *
-     * Expected Reverts
-     *
-     */
+    let users: User[] = []
+    beforeEach(() => {
+      users = [bob, carol, dennis]
+    })
+
+    it("decreases StabilityPool collateral and increases activePool collateral", async () => {
+      await provideToSP(contracts, whale, to1e18("20,000"))
+
+      await createLiquidationEvent(contracts)
+
+      await updateStabilityPoolSnapshot(contracts, state, "before")
+      await updateStabilityPoolUserSnapshot(contracts, whale, "before")
+      await updateContractsSnapshot(
+        contracts,
+        state,
+        "activePool",
+        "before",
+        addresses,
+      )
+
+      await withdrawCollateralGainToTrove(contracts, whale)
+
+      await updateStabilityPoolSnapshot(contracts, state, "after")
+      await updateContractsSnapshot(
+        contracts,
+        state,
+        "activePool",
+        "after",
+        addresses,
+      )
+
+      expect(state.stabilityPool.collateral.after).to.equal(
+        state.stabilityPool.collateral.before -
+          whale.stabilityPool.collateralGain.before,
+      )
+      expect(state.activePool.collateral.after).to.equal(
+        state.activePool.collateral.before +
+          whale.stabilityPool.collateralGain.before,
+      )
+    })
+
+    const expectCorrectCollateralGain = (user: User) => {
+      expect(user.stabilityPool.deposit.after).to.equal(
+        user.stabilityPool.compoundedDeposit.before,
+      )
+      expect(user.stabilityPool.collateralGain.after).to.equal(0n)
+      expect(user.trove.collateral.after).to.equal(
+        user.trove.collateral.before + user.stabilityPool.collateralGain.before,
+      )
+    }
+
+    it("Applies MUSDLoss to user's deposit, and redirects collateral reward to user's Trove", async () => {
+      await provideToSP(contracts, whale, to1e18("20,000"))
+
+      await createLiquidationEvent(contracts)
+
+      await updateTroveSnapshot(contracts, whale, "before")
+      await updateStabilityPoolUserSnapshot(contracts, whale, "before")
+
+      await withdrawCollateralGainToTrove(contracts, whale)
+
+      await updateTroveSnapshot(contracts, whale, "after")
+      await updateStabilityPoolUserSnapshot(contracts, whale, "after")
+
+      expectCorrectCollateralGain(whale)
+    })
+
+    it("All depositors are able to withdraw their collateral gain from the SP to their Trove", async () => {
+      await openTrovesAndProvideStability(contracts, users, "5,000", "200")
+
+      await createLiquidationEvent(contracts)
+
+      await updateTroveSnapshots(contracts, users, "before")
+      await updateStabilityPoolUserSnapshots(contracts, users, "before")
+
+      await withdrawCollateralGainToTroves(contracts, users)
+
+      await updateTroveSnapshots(contracts, users, "after")
+      await updateStabilityPoolUserSnapshots(contracts, users, "after")
+
+      users.forEach((user) => {
+        expectCorrectCollateralGain(user)
+      })
+    })
+
+    const expectCorrectCollateralGainWithEqualDeposits = () =>
+      users.forEach((user) => {
+        expectCorrectCollateralGain(user)
+        expect(user.trove.collateral.after).to.equal(
+          users[0].trove.collateral.after,
+        )
+      })
+
+    it("Depositors with equal initial deposit withdraw correct collateral Gain after one liquidation", async () => {
+      await openTrovesAndProvideStability(contracts, users, "10,000", "200")
+
+      await createLiquidationEvent(contracts)
+
+      await updateTroveSnapshots(contracts, users, "before")
+      await updateStabilityPoolUserSnapshots(contracts, users, "before")
+
+      await withdrawCollateralGainToTroves(contracts, users)
+
+      await updateTroveSnapshots(contracts, users, "after")
+      await updateStabilityPoolUserSnapshots(contracts, users, "after")
+
+      expectCorrectCollateralGainWithEqualDeposits()
+    })
+
+    it("Depositors with equal initial deposit withdraw correct collateral Gain after three identical liquidations", async () => {
+      await openTrovesAndProvideStability(contracts, users, "10,000", "200")
+
+      await createLiquidationEvent(contracts)
+      await createLiquidationEvent(contracts)
+      await createLiquidationEvent(contracts)
+
+      await updateTroveSnapshots(contracts, users, "before")
+      await updateStabilityPoolUserSnapshots(contracts, users, "before")
+
+      await withdrawCollateralGainToTroves(contracts, users)
+
+      await updateTroveSnapshots(contracts, users, "after")
+      await updateStabilityPoolUserSnapshots(contracts, users, "after")
+
+      expectCorrectCollateralGainWithEqualDeposits()
+    })
+
+    it("Depositors with equal initial deposit withdraw correct collateral Gain after two liquidations of increasing MUSD", async () => {
+      await openTrovesAndProvideStability(contracts, users, "10,000", "200")
+
+      await createLiquidationEvent(contracts, "5,000")
+      await createLiquidationEvent(contracts, "8,000")
+      await createLiquidationEvent(contracts, "11,000")
+
+      await updateTroveSnapshots(contracts, users, "before")
+      await updateStabilityPoolUserSnapshots(contracts, users, "before")
+
+      await withdrawCollateralGainToTroves(contracts, users)
+
+      await updateTroveSnapshots(contracts, users, "after")
+      await updateStabilityPoolUserSnapshots(contracts, users, "after")
+
+      expectCorrectCollateralGainWithEqualDeposits()
+    })
+
+    const expectCorrectCollateralGainWithVaryingDeposits = () =>
+      users.forEach((user, i) => {
+        expectCorrectCollateralGain(user)
+
+        // Each subsequent user deposited more, and so should receive more collateral
+        if (i < users.length - 1) {
+          expect(users[i].trove.collateral.after).to.be.lessThan(
+            users[i + 1].trove.collateral.after,
+          )
+        }
+      })
+
+    it("Depositors with varying deposits withdraw correct collateral Gain after two identical liquidations", async () => {
+      await openTroveAndProvideStability(contracts, bob, "10,000", "200")
+      await openTroveAndProvideStability(contracts, carol, "20,000", "200")
+      await openTroveAndProvideStability(contracts, dennis, "30,000", "200")
+
+      await createLiquidationEvent(contracts)
+      await createLiquidationEvent(contracts)
+
+      await updateTroveSnapshots(contracts, users, "before")
+      await updateStabilityPoolUserSnapshots(contracts, users, "before")
+
+      await withdrawCollateralGainToTroves(contracts, users)
+
+      await updateTroveSnapshots(contracts, users, "after")
+      await updateStabilityPoolUserSnapshots(contracts, users, "after")
+
+      expectCorrectCollateralGainWithVaryingDeposits()
+    })
+
+    it("Depositors with varying deposits withdraw correct collateral Gain after three identical liquidations", async () => {
+      await openTroveAndProvideStability(contracts, bob, "10,000", "200")
+      await openTroveAndProvideStability(contracts, carol, "20,000", "200")
+      await openTroveAndProvideStability(contracts, dennis, "30,000", "200")
+
+      await createLiquidationEvent(contracts)
+      await createLiquidationEvent(contracts)
+      await createLiquidationEvent(contracts)
+
+      await updateTroveSnapshots(contracts, users, "before")
+      await updateStabilityPoolUserSnapshots(contracts, users, "before")
+
+      await withdrawCollateralGainToTroves(contracts, users)
+
+      await updateTroveSnapshots(contracts, users, "after")
+      await updateStabilityPoolUserSnapshots(contracts, users, "after")
+
+      expectCorrectCollateralGainWithVaryingDeposits()
+    })
+
+    it("Depositors with varying deposits withdraw correct collateral Gain after three varying liquidations", async () => {
+      await openTroveAndProvideStability(contracts, bob, "10,000", "200")
+      await openTroveAndProvideStability(contracts, carol, "20,000", "200")
+      await openTroveAndProvideStability(contracts, dennis, "30,000", "200")
+
+      await createLiquidationEvent(contracts, "4,500")
+      await createLiquidationEvent(contracts, "7,000")
+      await createLiquidationEvent(contracts, "12,345")
+
+      await updateTroveSnapshots(contracts, users, "before")
+      await updateStabilityPoolUserSnapshots(contracts, users, "before")
+
+      await withdrawCollateralGainToTroves(contracts, users)
+
+      await updateTroveSnapshots(contracts, users, "after")
+      await updateStabilityPoolUserSnapshots(contracts, users, "after")
+
+      expectCorrectCollateralGainWithVaryingDeposits()
+    })
+
+    it("B, C, D Deposit -> 2 liquidations -> E deposits -> 1 liquidation. All deposits and liquidations = $2000.  B, C, D, E withdraw correct collateral Gain", async () => {
+      await openTrovesAndProvideStability(contracts, users, "2000", "200")
+
+      await createLiquidationEvent(contracts, "2000")
+      await createLiquidationEvent(contracts, "2000")
+
+      await openTroveAndProvideStability(contracts, eric, "2000", "200")
+
+      await createLiquidationEvent(contracts, "2000")
+
+      const allUsers = [...users, eric]
+      await updateTroveSnapshots(contracts, allUsers, "before")
+      await updateStabilityPoolUserSnapshots(contracts, allUsers, "before")
+
+      await withdrawCollateralGainToTroves(contracts, allUsers)
+
+      await updateTroveSnapshots(contracts, allUsers, "after")
+      await updateStabilityPoolUserSnapshots(contracts, allUsers, "after")
+
+      expectCorrectCollateralGainWithEqualDeposits()
+      expectCorrectCollateralGain(eric)
+      expect(eric.trove.collateral.after).to.be.lessThan(
+        bob.trove.collateral.after,
+      )
+    })
+
+    it("B, C, D Deposit -> 2 liquidations -> E deposits -> 2 liquidations. All deposits and liquidations = $2000.  B, C, D, E withdraw correct collateral Gain", async () => {
+      // The whale provides so that the pool is not fully offset.
+      await provideToSP(contracts, whale, "20,000")
+      await openTrovesAndProvideStability(contracts, users, "2000", "200")
+
+      await createLiquidationEvent(contracts, "2000")
+      await createLiquidationEvent(contracts, "2000")
+
+      await openTroveAndProvideStability(contracts, eric, "2000", "200")
+
+      await createLiquidationEvent(contracts, "2000")
+      await createLiquidationEvent(contracts, "2000")
+
+      const allUsers = [...users, eric]
+      await updateTroveSnapshots(contracts, allUsers, "before")
+      await updateStabilityPoolUserSnapshots(contracts, allUsers, "before")
+
+      await withdrawCollateralGainToTroves(contracts, allUsers)
+
+      await updateTroveSnapshots(contracts, allUsers, "after")
+      await updateStabilityPoolUserSnapshots(contracts, allUsers, "after")
+
+      expectCorrectCollateralGainWithEqualDeposits()
+      expectCorrectCollateralGain(eric)
+      expect(eric.trove.collateral.after).to.be.lessThan(
+        bob.trove.collateral.after,
+      )
+    })
+
+    it("B, C, D Deposit -> 2 liquidations -> E deposits -> 2 liquidations. Various deposit and liquidation vals.  B, C, D, E withdraw correct collateral Gain", async () => {
+      await provideToSP(contracts, whale, to1e18("20,000"))
+      await Promise.all(
+        [
+          { user: bob, amount: "5,000" },
+          { user: carol, amount: "40,929" },
+          { user: dennis, amount: "61,123" },
+        ].map(({ user, amount }) =>
+          openTroveAndProvideStability(contracts, user, amount, "200"),
+        ),
+      )
+
+      await createLiquidationEvent(contracts, "2000")
+      await createLiquidationEvent(contracts, "3456")
+
+      await openTroveAndProvideStability(contracts, eric, "2000", "200")
+
+      await createLiquidationEvent(contracts, "8899")
+      await createLiquidationEvent(contracts, "11234")
+
+      const allUsers = [...users, eric]
+      await updateTroveSnapshots(contracts, allUsers, "before")
+      await updateStabilityPoolUserSnapshots(contracts, allUsers, "before")
+
+      await withdrawCollateralGainToTroves(contracts, allUsers)
+
+      await updateTroveSnapshots(contracts, allUsers, "after")
+      await updateStabilityPoolUserSnapshots(contracts, allUsers, "after")
+
+      expectCorrectCollateralGainWithVaryingDeposits()
+      expectCorrectCollateralGain(eric)
+      expect(eric.trove.collateral.after).to.be.lessThan(
+        bob.trove.collateral.after,
+      )
+    })
+
+    it("B, C, D, E deposit -> 2 liquidations -> E withdraws -> 2 liquidations. All deposits and liquidations = $2000.  B, C, D, E withdraw correct collateral Gain", async () => {
+      // The whale provides so that the pool is not fully offset.
+      await provideToSP(contracts, whale, "20,000")
+
+      const allUsers = [...users, eric]
+      await openTrovesAndProvideStability(contracts, allUsers, "2000", "200")
+
+      await createLiquidationEvent(contracts)
+      await createLiquidationEvent(contracts)
+
+      await updateTroveSnapshot(contracts, eric, "before")
+      await updateStabilityPoolUserSnapshot(contracts, eric, "before")
+
+      await withdrawCollateralGainToTrove(contracts, eric)
+
+      await updateTroveSnapshot(contracts, eric, "after")
+      await updateStabilityPoolUserSnapshot(contracts, eric, "after")
+
+      await createLiquidationEvent(contracts)
+      await createLiquidationEvent(contracts)
+
+      await updateTroveSnapshots(contracts, users, "before")
+      await updateStabilityPoolUserSnapshots(contracts, users, "before")
+
+      await withdrawCollateralGainToTroves(contracts, users)
+
+      await updateTroveSnapshots(contracts, users, "after")
+      await updateStabilityPoolUserSnapshots(contracts, users, "after")
+
+      expectCorrectCollateralGainWithEqualDeposits()
+      expectCorrectCollateralGain(eric)
+      expect(eric.trove.collateral.after).to.be.lessThan(
+        bob.trove.collateral.after,
+      )
+    })
+
+    it("B, C, D, E deposit -> 2 liquidations -> E withdraws -> 2 liquidations. Various deposit and liquidation vals. A, B, C, D withdraw correct collateral Gain", async () => {
+      // The whale provides so that the pool is not fully offset.
+      await provideToSP(contracts, whale, "20,000")
+
+      await Promise.all(
+        [
+          { user: bob, amount: "5,000" },
+          { user: carol, amount: "40,929" },
+          { user: dennis, amount: "61,123" },
+          { user: eric, amount: "81,123" },
+        ].map(({ user, amount }) =>
+          openTroveAndProvideStability(contracts, user, amount, "200"),
+        ),
+      )
+
+      await createLiquidationEvent(contracts, "2000")
+      await createLiquidationEvent(contracts, "3456")
+
+      await updateTroveSnapshot(contracts, eric, "before")
+      await updateStabilityPoolUserSnapshot(contracts, eric, "before")
+
+      await withdrawCollateralGainToTrove(contracts, eric)
+
+      await updateTroveSnapshot(contracts, eric, "after")
+      await updateStabilityPoolUserSnapshot(contracts, eric, "after")
+
+      await createLiquidationEvent(contracts, "5678")
+      await createLiquidationEvent(contracts, "7890")
+
+      await updateTroveSnapshots(contracts, users, "before")
+      await updateStabilityPoolUserSnapshots(contracts, users, "before")
+
+      await withdrawCollateralGainToTroves(contracts, users)
+
+      await updateTroveSnapshots(contracts, users, "after")
+      await updateStabilityPoolUserSnapshots(contracts, users, "after")
+
+      expectCorrectCollateralGainWithVaryingDeposits()
+      expectCorrectCollateralGain(eric)
+    })
+
+    it("Depositor withdraws correct compounded deposit after liquidation empties the pool", async () => {
+      await provideToSP(contracts, whale, "5,000")
+
+      // Empty the pool
+      await createLiquidationEvent(contracts, "6,000")
+
+      await updateTroveSnapshot(contracts, whale, "before")
+      await updateStabilityPoolUserSnapshot(contracts, whale, "before")
+      await updatePendingSnapshot(contracts, whale, "before")
+
+      await withdrawCollateralGainToTrove(contracts, whale)
+
+      await updateTroveSnapshot(contracts, whale, "after")
+      await updateStabilityPoolUserSnapshot(contracts, whale, "after")
+      await updatePendingSnapshot(contracts, whale, "after")
+
+      expect(whale.stabilityPool.deposit.after).to.equal(
+        whale.stabilityPool.compoundedDeposit.before,
+      )
+      expect(whale.stabilityPool.collateralGain.after).to.equal(0n)
+      expect(whale.trove.collateral.after).to.equal(
+        whale.trove.collateral.before +
+          whale.pending.collateral.before +
+          whale.stabilityPool.collateralGain.before,
+      )
+    })
+
+    it("single deposit fully offset. After subsequent liquidations, depositor withdraws *only* the collateral Gain from one liquidation", async () => {
+      await provideToSP(contracts, whale, "5,000")
+
+      // Empty the pool
+      await createLiquidationEvent(contracts, "6,000")
+
+      const collateralGain =
+        await contracts.stabilityPool.getDepositorCollateralGain(whale.wallet)
+
+      await createLiquidationEvent(contracts)
+      await createLiquidationEvent(contracts)
+
+      await updateTroveSnapshot(contracts, whale, "before")
+      await updateStabilityPoolUserSnapshot(contracts, whale, "before")
+      await updatePendingSnapshot(contracts, whale, "before")
+
+      await withdrawCollateralGainToTrove(contracts, whale)
+
+      await updateTroveSnapshot(contracts, whale, "after")
+      await updateStabilityPoolUserSnapshot(contracts, whale, "after")
+      await updatePendingSnapshot(contracts, whale, "after")
+
+      expect(whale.stabilityPool.collateralGain.before).to.equal(collateralGain)
+      expect(whale.stabilityPool.deposit.after).to.equal(
+        whale.stabilityPool.compoundedDeposit.before,
+      )
+      expect(whale.stabilityPool.collateralGain.after).to.equal(0n)
+      expect(whale.trove.collateral.after).to.equal(
+        whale.trove.collateral.before +
+          whale.pending.collateral.before +
+          whale.stabilityPool.collateralGain.before,
+      )
+    })
+
+    it("deposit spans one scale factor change: Single depositor withdraws correct collateral Gain after one liquidation", async () => {
+      // Add just enough MUSD to increase the scale
+      await provideToSP(contracts, whale, to1e18("10250") + 500000n)
+
+      await createLiquidationEvent(contracts, "10,000")
+
+      await updateStabilityPoolUserSnapshot(contracts, whale, "before")
+      await updateTroveSnapshot(contracts, whale, "before")
+      await updateStabilityPoolSnapshot(contracts, state, "before")
+
+      await withdrawCollateralGainToTrove(contracts, whale)
+
+      await updateStabilityPoolUserSnapshot(contracts, whale, "after")
+      await updateTroveSnapshot(contracts, whale, "after")
+
+      expect(state.stabilityPool.currentScale.before).to.equal(1n)
+      expect(whale.stabilityPool.deposit.after).to.equal(
+        whale.stabilityPool.compoundedDeposit.before,
+      )
+      expect(whale.stabilityPool.collateralGain.after).to.equal(0n)
+      expect(whale.trove.collateral.after).to.equal(
+        whale.trove.collateral.before +
+          whale.stabilityPool.collateralGain.before,
+      )
+    })
+
+    it("Several deposits of varying amounts span one scale factor change. Depositors withdraw correct compounded deposit and collateral Gain after one liquidation", async () => {
+      // Add just enough MUSD to increase the scale
+      await provideToSP(contracts, whale, to1e18("5250") + 500000n)
+
+      await openTroveAndProvideStability(contracts, bob, "3,000", "200")
+      await openTroveAndProvideStability(contracts, carol, "2,000", "200")
+
+      await createLiquidationEvent(contracts, "10,000")
+
+      const allUsers = [bob, carol, whale]
+      await updateStabilityPoolUserSnapshots(contracts, allUsers, "before")
+      await updateTroveSnapshots(contracts, allUsers, "before")
+      await updateStabilityPoolSnapshot(contracts, state, "before")
+
+      await withdrawCollateralGainToTroves(contracts, allUsers)
+
+      await updateStabilityPoolUserSnapshots(contracts, allUsers, "after")
+      await updateTroveSnapshots(contracts, allUsers, "after")
+
+      expect(state.stabilityPool.currentScale.before).to.equal(1n)
+      users.forEach((user) => {
+        expect(user.stabilityPool.deposit.after).to.equal(
+          user.stabilityPool.compoundedDeposit.before,
+        )
+        expect(user.stabilityPool.collateralGain.after).to.equal(0n)
+        expect(user.trove.collateral.after).to.equal(
+          user.trove.collateral.before +
+            user.stabilityPool.collateralGain.before,
+        )
+      })
+    })
+
+    it("2 depositors can withdraw after each receiving half of a pool-emptying liquidation", async () => {
+      const allUsers = [bob, carol]
+
+      await openTrovesAndProvideStability(contracts, allUsers, "10,000", "200")
+
+      await createLiquidationEvent(contracts, "30,000")
+
+      await updatePendingSnapshots(contracts, allUsers, "before")
+      await updateStabilityPoolUserSnapshots(contracts, allUsers, "before")
+      await updateTroveSnapshots(contracts, allUsers, "before")
+
+      await withdrawCollateralGainToTroves(contracts, allUsers)
+
+      await updateStabilityPoolUserSnapshots(contracts, allUsers, "after")
+      await updateTroveSnapshots(contracts, allUsers, "after")
+
+      allUsers.forEach((user) => {
+        expect(user.stabilityPool.compoundedDeposit.before).to.equal(0n)
+        expect(user.stabilityPool.collateralGain.before).to.be.greaterThan(0n)
+
+        expect(user.stabilityPool.compoundedDeposit.after).to.equal(0n)
+        expect(user.stabilityPool.collateralGain.after).to.equal(0n)
+
+        expect(user.trove.collateral.after).to.equal(
+          user.trove.collateral.before +
+            user.pending.collateral.before +
+            user.stabilityPool.collateralGain.before,
+        )
+        expect(user.trove.debt.after).to.equal(
+          user.trove.debt.before + user.pending.debt.before,
+        )
+      })
+    })
+
+    it("Large liquidated coll/debt, deposits and BTC price", async () => {
+      // collateral:USD price is $2 billion per BTC
+      await contracts.mockAggregator.setPrice(2n * 10n ** 27n)
+
+      const allUsers = [bob, carol]
+      const amount = 1n * 10n ** 27n // $ 1 billion
+      await openTrovesAndProvideStability(contracts, allUsers, amount, "200")
+
+      await createLiquidationEvent(contracts, amount)
+
+      await updateStabilityPoolUserSnapshots(contracts, allUsers, "before")
+      await updateTroveSnapshots(contracts, allUsers, "before")
+
+      await withdrawCollateralGainToTroves(contracts, allUsers)
+
+      await updateStabilityPoolUserSnapshots(contracts, allUsers, "after")
+      await updateTroveSnapshots(contracts, allUsers, "after")
+
+      allUsers.forEach((user) => {
+        expect(user.stabilityPool.collateralGain.before).to.be.greaterThan(0n)
+        expect(user.stabilityPool.collateralGain.after).to.equal(0n)
+
+        expect(user.trove.collateral.after).to.equal(
+          user.trove.collateral.before +
+            user.stabilityPool.collateralGain.before,
+        )
+        expect(user.trove.debt.after).to.equal(user.trove.debt.before)
+      })
+    })
+
+    it("Small liquidated coll/debt, large deposits and collateral price", async () => {
+      // collateral:USD price is $2 billion per BTC
+      await contracts.mockAggregator.setPrice(2n * 10n ** 27n)
+
+      const allUsers = [bob, carol]
+      const amount = 1n * 10n ** 27n // $ 1 billion
+      await openTrovesAndProvideStability(contracts, allUsers, amount, "200")
+
+      await createLiquidationEvent(contracts, "2,000")
+
+      await updateStabilityPoolUserSnapshots(contracts, allUsers, "before")
+      await updateTroveSnapshots(contracts, allUsers, "before")
+
+      await withdrawCollateralGainToTroves(contracts, allUsers)
+
+      await updateStabilityPoolUserSnapshots(contracts, allUsers, "after")
+      await updateTroveSnapshots(contracts, allUsers, "after")
+
+      allUsers.forEach((user) => {
+        expect(user.stabilityPool.collateralGain.before).to.be.greaterThan(0n)
+        expect(user.stabilityPool.collateralGain.after).to.equal(0n)
+
+        expect(user.trove.collateral.after).to.equal(
+          user.trove.collateral.before +
+            user.stabilityPool.collateralGain.before,
+        )
+        expect(user.trove.debt.after).to.equal(user.trove.debt.before)
+      })
+    })
+
     context("Expected Reverts", () => {
-      it("withdrawCollateralGainToTrove(): reverts when user has no active deposit", async () => {
+      it("reverts when user has no active deposit", async () => {
         await expect(
           withdrawCollateralGainToTrove(contracts, alice),
         ).to.be.revertedWith("StabilityPool: User must have a non-zero deposit")
       })
 
-      it("withdrawCollateralGainToTrove(): reverts if it would leave trove with ICR < MCR", async () => {
+      it("reverts if it would leave trove with ICR < MCR", async () => {
         await openTrove(contracts, {
           musdAmount: "5,000",
           ICR: "120",
@@ -1457,7 +1917,7 @@ describe("StabilityPool in Normal Mode", () => {
         )
       })
 
-      it("withdrawCollateralGainToTrove(): reverts with subsequent deposit and withdrawal attempt from same account with no intermediate liquidations", async () => {
+      it("reverts with subsequent deposit and withdrawal attempt from same account with no intermediate liquidations", async () => {
         await provideToSP(contracts, whale, to1e18("20,000"))
 
         await createLiquidationEvent(contracts)
@@ -1471,7 +1931,7 @@ describe("StabilityPool in Normal Mode", () => {
         )
       })
 
-      it("withdrawCollateralGainToTrove(): reverts if user has no trove", async () => {
+      it("reverts if user has no trove", async () => {
         const amount = to1e18(900)
         await transferMUSD(contracts, whale, bob, amount)
         await provideToSP(contracts, bob, amount)
@@ -1485,7 +1945,7 @@ describe("StabilityPool in Normal Mode", () => {
         )
       })
 
-      it("withdrawCollateralGainToTrove(): reverts when depositor has no collateral gain", async () => {
+      it("reverts when depositor has no collateral gain", async () => {
         await provideToSP(contracts, whale, to1e18("20,000"))
         await expect(
           withdrawCollateralGainToTrove(contracts, whale),
@@ -1494,653 +1954,6 @@ describe("StabilityPool in Normal Mode", () => {
         )
       })
     })
-
-    /**
-     *
-     * Emitted Events
-     *
-     */
-    context("Emitted Events", () => {})
-
-    /**
-     *
-     * System State Changes
-     *
-     */
-    context("System State Changes", () => {
-      it("withdrawCollateralGainToTrove(): decreases StabilityPool collateral and increases activePool collateral", async () => {
-        await provideToSP(contracts, whale, to1e18("20,000"))
-
-        await createLiquidationEvent(contracts)
-
-        await updateStabilityPoolSnapshot(contracts, state, "before")
-        await updateStabilityPoolUserSnapshot(contracts, whale, "before")
-        await updateContractsSnapshot(
-          contracts,
-          state,
-          "activePool",
-          "before",
-          addresses,
-        )
-
-        await withdrawCollateralGainToTrove(contracts, whale)
-
-        await updateStabilityPoolSnapshot(contracts, state, "after")
-        await updateContractsSnapshot(
-          contracts,
-          state,
-          "activePool",
-          "after",
-          addresses,
-        )
-
-        expect(state.stabilityPool.collateral.after).to.equal(
-          state.stabilityPool.collateral.before -
-            whale.stabilityPool.collateralGain.before,
-        )
-        expect(state.activePool.collateral.after).to.equal(
-          state.activePool.collateral.before +
-            whale.stabilityPool.collateralGain.before,
-        )
-      })
-    })
-
-    /**
-     *
-     * Individual Troves
-     *
-     */
-    context("Individual Troves", () => {})
-
-    /**
-     *
-     * Balance changes
-     *
-     */
-    context("Balance changes", () => {
-      let users: User[] = []
-      beforeEach(() => {
-        users = [bob, carol, dennis]
-      })
-
-      const expectCorrectCollateralGain = (user: User) => {
-        expect(user.stabilityPool.deposit.after).to.equal(
-          user.stabilityPool.compoundedDeposit.before,
-        )
-        expect(user.stabilityPool.collateralGain.after).to.equal(0n)
-        expect(user.trove.collateral.after).to.equal(
-          user.trove.collateral.before +
-            user.stabilityPool.collateralGain.before,
-        )
-      }
-
-      it("withdrawCollateralGainToTrove(): Applies MUSDLoss to user's deposit, and redirects collateral reward to user's Trove", async () => {
-        await provideToSP(contracts, whale, to1e18("20,000"))
-
-        await createLiquidationEvent(contracts)
-
-        await updateTroveSnapshot(contracts, whale, "before")
-        await updateStabilityPoolUserSnapshot(contracts, whale, "before")
-
-        await withdrawCollateralGainToTrove(contracts, whale)
-
-        await updateTroveSnapshot(contracts, whale, "after")
-        await updateStabilityPoolUserSnapshot(contracts, whale, "after")
-
-        expectCorrectCollateralGain(whale)
-      })
-
-      it("withdrawCollateralGainToTrove(): All depositors are able to withdraw their collateral gain from the SP to their Trove", async () => {
-        await openTrovesAndProvideStability(contracts, users, "5,000", "200")
-
-        await createLiquidationEvent(contracts)
-
-        await updateTroveSnapshots(contracts, users, "before")
-        await updateStabilityPoolUserSnapshots(contracts, users, "before")
-
-        await withdrawCollateralGainToTroves(contracts, users)
-
-        await updateTroveSnapshots(contracts, users, "after")
-        await updateStabilityPoolUserSnapshots(contracts, users, "after")
-
-        users.forEach((user) => {
-          expectCorrectCollateralGain(user)
-        })
-      })
-
-      const expectCorrectCollateralGainWithEqualDeposits = () =>
-        users.forEach((user) => {
-          expectCorrectCollateralGain(user)
-          expect(user.trove.collateral.after).to.equal(
-            users[0].trove.collateral.after,
-          )
-        })
-
-      it("withdrawCollateralGainToTrove(): Depositors with equal initial deposit withdraw correct collateral Gain after one liquidation", async () => {
-        await openTrovesAndProvideStability(contracts, users, "10,000", "200")
-
-        await createLiquidationEvent(contracts)
-
-        await updateTroveSnapshots(contracts, users, "before")
-        await updateStabilityPoolUserSnapshots(contracts, users, "before")
-
-        await withdrawCollateralGainToTroves(contracts, users)
-
-        await updateTroveSnapshots(contracts, users, "after")
-        await updateStabilityPoolUserSnapshots(contracts, users, "after")
-
-        expectCorrectCollateralGainWithEqualDeposits()
-      })
-
-      it("withdrawCollateralGainToTrove():  Depositors with equal initial deposit withdraw correct collateral Gain after three identical liquidations", async () => {
-        await openTrovesAndProvideStability(contracts, users, "10,000", "200")
-
-        await createLiquidationEvent(contracts)
-        await createLiquidationEvent(contracts)
-        await createLiquidationEvent(contracts)
-
-        await updateTroveSnapshots(contracts, users, "before")
-        await updateStabilityPoolUserSnapshots(contracts, users, "before")
-
-        await withdrawCollateralGainToTroves(contracts, users)
-
-        await updateTroveSnapshots(contracts, users, "after")
-        await updateStabilityPoolUserSnapshots(contracts, users, "after")
-
-        expectCorrectCollateralGainWithEqualDeposits()
-      })
-
-      it("withdrawCollateralGainToTrove(): Depositors with equal initial deposit withdraw correct collateral Gain after two liquidations of increasing MUSD", async () => {
-        await openTrovesAndProvideStability(contracts, users, "10,000", "200")
-
-        await createLiquidationEvent(contracts, "5,000")
-        await createLiquidationEvent(contracts, "8,000")
-        await createLiquidationEvent(contracts, "11,000")
-
-        await updateTroveSnapshots(contracts, users, "before")
-        await updateStabilityPoolUserSnapshots(contracts, users, "before")
-
-        await withdrawCollateralGainToTroves(contracts, users)
-
-        await updateTroveSnapshots(contracts, users, "after")
-        await updateStabilityPoolUserSnapshots(contracts, users, "after")
-
-        expectCorrectCollateralGainWithEqualDeposits()
-      })
-
-      const expectCorrectCollateralGainWithVaryingDeposits = () =>
-        users.forEach((user, i) => {
-          expectCorrectCollateralGain(user)
-
-          // Each subsequent user deposited more, and so should receive more collateral
-          if (i < users.length - 1) {
-            expect(users[i].trove.collateral.after).to.be.lessThan(
-              users[i + 1].trove.collateral.after,
-            )
-          }
-        })
-
-      it("withdrawCollateralGainToTrove(): Depositors with varying deposits withdraw correct collateral Gain after two identical liquidations", async () => {
-        await openTroveAndProvideStability(contracts, bob, "10,000", "200")
-        await openTroveAndProvideStability(contracts, carol, "20,000", "200")
-        await openTroveAndProvideStability(contracts, dennis, "30,000", "200")
-
-        await createLiquidationEvent(contracts)
-        await createLiquidationEvent(contracts)
-
-        await updateTroveSnapshots(contracts, users, "before")
-        await updateStabilityPoolUserSnapshots(contracts, users, "before")
-
-        await withdrawCollateralGainToTroves(contracts, users)
-
-        await updateTroveSnapshots(contracts, users, "after")
-        await updateStabilityPoolUserSnapshots(contracts, users, "after")
-
-        expectCorrectCollateralGainWithVaryingDeposits()
-      })
-
-      it("withdrawCollateralGainToTrove(): Depositors with varying deposits withdraw correct collateral Gain after three identical liquidations", async () => {
-        await openTroveAndProvideStability(contracts, bob, "10,000", "200")
-        await openTroveAndProvideStability(contracts, carol, "20,000", "200")
-        await openTroveAndProvideStability(contracts, dennis, "30,000", "200")
-
-        await createLiquidationEvent(contracts)
-        await createLiquidationEvent(contracts)
-        await createLiquidationEvent(contracts)
-
-        await updateTroveSnapshots(contracts, users, "before")
-        await updateStabilityPoolUserSnapshots(contracts, users, "before")
-
-        await withdrawCollateralGainToTroves(contracts, users)
-
-        await updateTroveSnapshots(contracts, users, "after")
-        await updateStabilityPoolUserSnapshots(contracts, users, "after")
-
-        expectCorrectCollateralGainWithVaryingDeposits()
-      })
-
-      it("withdrawCollateralGainToTrove(): Depositors with varying deposits withdraw correct collateral Gain after three varying liquidations", async () => {
-        await openTroveAndProvideStability(contracts, bob, "10,000", "200")
-        await openTroveAndProvideStability(contracts, carol, "20,000", "200")
-        await openTroveAndProvideStability(contracts, dennis, "30,000", "200")
-
-        await createLiquidationEvent(contracts, "4,500")
-        await createLiquidationEvent(contracts, "7,000")
-        await createLiquidationEvent(contracts, "12,345")
-
-        await updateTroveSnapshots(contracts, users, "before")
-        await updateStabilityPoolUserSnapshots(contracts, users, "before")
-
-        await withdrawCollateralGainToTroves(contracts, users)
-
-        await updateTroveSnapshots(contracts, users, "after")
-        await updateStabilityPoolUserSnapshots(contracts, users, "after")
-
-        expectCorrectCollateralGainWithVaryingDeposits()
-      })
-
-      it("withdrawCollateralGainToTrove(): B, C, D Deposit -> 2 liquidations -> E deposits -> 1 liquidation. All deposits and liquidations = $2000.  B, C, D, E withdraw correct collateral Gain", async () => {
-        await openTrovesAndProvideStability(contracts, users, "2000", "200")
-
-        await createLiquidationEvent(contracts, "2000")
-        await createLiquidationEvent(contracts, "2000")
-
-        await openTroveAndProvideStability(contracts, eric, "2000", "200")
-
-        await createLiquidationEvent(contracts, "2000")
-
-        const allUsers = [...users, eric]
-        await updateTroveSnapshots(contracts, allUsers, "before")
-        await updateStabilityPoolUserSnapshots(contracts, allUsers, "before")
-
-        await withdrawCollateralGainToTroves(contracts, allUsers)
-
-        await updateTroveSnapshots(contracts, allUsers, "after")
-        await updateStabilityPoolUserSnapshots(contracts, allUsers, "after")
-
-        expectCorrectCollateralGainWithEqualDeposits()
-        expectCorrectCollateralGain(eric)
-        expect(eric.trove.collateral.after).to.be.lessThan(
-          bob.trove.collateral.after,
-        )
-      })
-
-      it("withdrawCollateralGainToTrove(): B, C, D Deposit -> 2 liquidations -> E deposits -> 2 liquidations. All deposits and liquidations = $2000.  B, C, D, E withdraw correct collateral Gain", async () => {
-        // The whale provides so that the pool is not fully offset.
-        await provideToSP(contracts, whale, "20,000")
-        await openTrovesAndProvideStability(contracts, users, "2000", "200")
-
-        await createLiquidationEvent(contracts, "2000")
-        await createLiquidationEvent(contracts, "2000")
-
-        await openTroveAndProvideStability(contracts, eric, "2000", "200")
-
-        await createLiquidationEvent(contracts, "2000")
-        await createLiquidationEvent(contracts, "2000")
-
-        const allUsers = [...users, eric]
-        await updateTroveSnapshots(contracts, allUsers, "before")
-        await updateStabilityPoolUserSnapshots(contracts, allUsers, "before")
-
-        await withdrawCollateralGainToTroves(contracts, allUsers)
-
-        await updateTroveSnapshots(contracts, allUsers, "after")
-        await updateStabilityPoolUserSnapshots(contracts, allUsers, "after")
-
-        expectCorrectCollateralGainWithEqualDeposits()
-        expectCorrectCollateralGain(eric)
-        expect(eric.trove.collateral.after).to.be.lessThan(
-          bob.trove.collateral.after,
-        )
-      })
-
-      it("withdrawCollateralGainToTrove(): B, C, D Deposit -> 2 liquidations -> E deposits -> 2 liquidations. Various deposit and liquidation vals.  B, C, D, E withdraw correct collateral Gain", async () => {
-        await provideToSP(contracts, whale, to1e18("20,000"))
-        await Promise.all(
-          [
-            { user: bob, amount: "5,000" },
-            { user: carol, amount: "40,929" },
-            { user: dennis, amount: "61,123" },
-          ].map(({ user, amount }) =>
-            openTroveAndProvideStability(contracts, user, amount, "200"),
-          ),
-        )
-
-        await createLiquidationEvent(contracts, "2000")
-        await createLiquidationEvent(contracts, "3456")
-
-        await openTroveAndProvideStability(contracts, eric, "2000", "200")
-
-        await createLiquidationEvent(contracts, "8899")
-        await createLiquidationEvent(contracts, "11234")
-
-        const allUsers = [...users, eric]
-        await updateTroveSnapshots(contracts, allUsers, "before")
-        await updateStabilityPoolUserSnapshots(contracts, allUsers, "before")
-
-        await withdrawCollateralGainToTroves(contracts, allUsers)
-
-        await updateTroveSnapshots(contracts, allUsers, "after")
-        await updateStabilityPoolUserSnapshots(contracts, allUsers, "after")
-
-        expectCorrectCollateralGainWithVaryingDeposits()
-        expectCorrectCollateralGain(eric)
-        expect(eric.trove.collateral.after).to.be.lessThan(
-          bob.trove.collateral.after,
-        )
-      })
-
-      it("withdrawCollateralGainToTrove(): B, C, D, E deposit -> 2 liquidations -> E withdraws -> 2 liquidations. All deposits and liquidations = $2000.  B, C, D, E withdraw correct collateral Gain", async () => {
-        // The whale provides so that the pool is not fully offset.
-        await provideToSP(contracts, whale, "20,000")
-
-        const allUsers = [...users, eric]
-        await openTrovesAndProvideStability(contracts, allUsers, "2000", "200")
-
-        await createLiquidationEvent(contracts)
-        await createLiquidationEvent(contracts)
-
-        await updateTroveSnapshot(contracts, eric, "before")
-        await updateStabilityPoolUserSnapshot(contracts, eric, "before")
-
-        await withdrawCollateralGainToTrove(contracts, eric)
-
-        await updateTroveSnapshot(contracts, eric, "after")
-        await updateStabilityPoolUserSnapshot(contracts, eric, "after")
-
-        await createLiquidationEvent(contracts)
-        await createLiquidationEvent(contracts)
-
-        await updateTroveSnapshots(contracts, users, "before")
-        await updateStabilityPoolUserSnapshots(contracts, users, "before")
-
-        await withdrawCollateralGainToTroves(contracts, users)
-
-        await updateTroveSnapshots(contracts, users, "after")
-        await updateStabilityPoolUserSnapshots(contracts, users, "after")
-
-        expectCorrectCollateralGainWithEqualDeposits()
-        expectCorrectCollateralGain(eric)
-        expect(eric.trove.collateral.after).to.be.lessThan(
-          bob.trove.collateral.after,
-        )
-      })
-
-      it("withdrawCollateralGainToTrove(): B, C, D, E deposit -> 2 liquidations -> E withdraws -> 2 liquidations. Various deposit and liquidation vals. A, B, C, D withdraw correct collateral Gain", async () => {
-        // The whale provides so that the pool is not fully offset.
-        await provideToSP(contracts, whale, "20,000")
-
-        await Promise.all(
-          [
-            { user: bob, amount: "5,000" },
-            { user: carol, amount: "40,929" },
-            { user: dennis, amount: "61,123" },
-            { user: eric, amount: "81,123" },
-          ].map(({ user, amount }) =>
-            openTroveAndProvideStability(contracts, user, amount, "200"),
-          ),
-        )
-
-        await createLiquidationEvent(contracts, "2000")
-        await createLiquidationEvent(contracts, "3456")
-
-        await updateTroveSnapshot(contracts, eric, "before")
-        await updateStabilityPoolUserSnapshot(contracts, eric, "before")
-
-        await withdrawCollateralGainToTrove(contracts, eric)
-
-        await updateTroveSnapshot(contracts, eric, "after")
-        await updateStabilityPoolUserSnapshot(contracts, eric, "after")
-
-        await createLiquidationEvent(contracts, "5678")
-        await createLiquidationEvent(contracts, "7890")
-
-        await updateTroveSnapshots(contracts, users, "before")
-        await updateStabilityPoolUserSnapshots(contracts, users, "before")
-
-        await withdrawCollateralGainToTroves(contracts, users)
-
-        await updateTroveSnapshots(contracts, users, "after")
-        await updateStabilityPoolUserSnapshots(contracts, users, "after")
-
-        expectCorrectCollateralGainWithVaryingDeposits()
-        expectCorrectCollateralGain(eric)
-      })
-
-      it("withdrawCollateralGainToTrove(): Depositor withdraws correct compounded deposit after liquidation empties the pool", async () => {
-        await provideToSP(contracts, whale, "5,000")
-
-        // Empty the pool
-        await createLiquidationEvent(contracts, "6,000")
-
-        await updateTroveSnapshot(contracts, whale, "before")
-        await updateStabilityPoolUserSnapshot(contracts, whale, "before")
-        await updatePendingSnapshot(contracts, whale, "before")
-
-        await withdrawCollateralGainToTrove(contracts, whale)
-
-        await updateTroveSnapshot(contracts, whale, "after")
-        await updateStabilityPoolUserSnapshot(contracts, whale, "after")
-        await updatePendingSnapshot(contracts, whale, "after")
-
-        expect(whale.stabilityPool.deposit.after).to.equal(
-          whale.stabilityPool.compoundedDeposit.before,
-        )
-        expect(whale.stabilityPool.collateralGain.after).to.equal(0n)
-        expect(whale.trove.collateral.after).to.equal(
-          whale.trove.collateral.before +
-            whale.pending.collateral.before +
-            whale.stabilityPool.collateralGain.before,
-        )
-      })
-
-      it("withdrawCollateralGainToTrove(): single deposit fully offset. After subsequent liquidations, depositor withdraws *only* the collateral Gain from one liquidation", async () => {
-        await provideToSP(contracts, whale, "5,000")
-
-        // Empty the pool
-        await createLiquidationEvent(contracts, "6,000")
-
-        const collateralGain =
-          await contracts.stabilityPool.getDepositorCollateralGain(whale.wallet)
-
-        await createLiquidationEvent(contracts)
-        await createLiquidationEvent(contracts)
-
-        await updateTroveSnapshot(contracts, whale, "before")
-        await updateStabilityPoolUserSnapshot(contracts, whale, "before")
-        await updatePendingSnapshot(contracts, whale, "before")
-
-        await withdrawCollateralGainToTrove(contracts, whale)
-
-        await updateTroveSnapshot(contracts, whale, "after")
-        await updateStabilityPoolUserSnapshot(contracts, whale, "after")
-        await updatePendingSnapshot(contracts, whale, "after")
-
-        expect(whale.stabilityPool.collateralGain.before).to.equal(
-          collateralGain,
-        )
-        expect(whale.stabilityPool.deposit.after).to.equal(
-          whale.stabilityPool.compoundedDeposit.before,
-        )
-        expect(whale.stabilityPool.collateralGain.after).to.equal(0n)
-        expect(whale.trove.collateral.after).to.equal(
-          whale.trove.collateral.before +
-            whale.pending.collateral.before +
-            whale.stabilityPool.collateralGain.before,
-        )
-      })
-
-      it("withdrawCollateralGainToTrove(): deposit spans one scale factor change: Single depositor withdraws correct collateral Gain after one liquidation", async () => {
-        // Add just enough MUSD to increase the scale
-        await provideToSP(contracts, whale, to1e18("10250") + 500000n)
-
-        await createLiquidationEvent(contracts, "10,000")
-
-        await updateStabilityPoolUserSnapshot(contracts, whale, "before")
-        await updateTroveSnapshot(contracts, whale, "before")
-        await updateStabilityPoolSnapshot(contracts, state, "before")
-
-        await withdrawCollateralGainToTrove(contracts, whale)
-
-        await updateStabilityPoolUserSnapshot(contracts, whale, "after")
-        await updateTroveSnapshot(contracts, whale, "after")
-
-        expect(state.stabilityPool.currentScale.before).to.equal(1n)
-        expect(whale.stabilityPool.deposit.after).to.equal(
-          whale.stabilityPool.compoundedDeposit.before,
-        )
-        expect(whale.stabilityPool.collateralGain.after).to.equal(0n)
-        expect(whale.trove.collateral.after).to.equal(
-          whale.trove.collateral.before +
-            whale.stabilityPool.collateralGain.before,
-        )
-      })
-
-      it("withdrawCollateralGainToTrove(): Several deposits of varying amounts span one scale factor change. Depositors withdraw correct compounded deposit and collateral Gain after one liquidation", async () => {
-        // Add just enough MUSD to increase the scale
-        await provideToSP(contracts, whale, to1e18("5250") + 500000n)
-
-        await openTroveAndProvideStability(contracts, bob, "3,000", "200")
-        await openTroveAndProvideStability(contracts, carol, "2,000", "200")
-
-        await createLiquidationEvent(contracts, "10,000")
-
-        const allUsers = [bob, carol, whale]
-        await updateStabilityPoolUserSnapshots(contracts, allUsers, "before")
-        await updateTroveSnapshots(contracts, allUsers, "before")
-        await updateStabilityPoolSnapshot(contracts, state, "before")
-
-        await withdrawCollateralGainToTroves(contracts, allUsers)
-
-        await updateStabilityPoolUserSnapshots(contracts, allUsers, "after")
-        await updateTroveSnapshots(contracts, allUsers, "after")
-
-        expect(state.stabilityPool.currentScale.before).to.equal(1n)
-        users.forEach((user) => {
-          expect(user.stabilityPool.deposit.after).to.equal(
-            user.stabilityPool.compoundedDeposit.before,
-          )
-          expect(user.stabilityPool.collateralGain.after).to.equal(0n)
-          expect(user.trove.collateral.after).to.equal(
-            user.trove.collateral.before +
-              user.stabilityPool.collateralGain.before,
-          )
-        })
-      })
-
-      it("withdrawCollateralGainToTrove(): 2 depositors can withdraw after each receiving half of a pool-emptying liquidation", async () => {
-        const allUsers = [bob, carol]
-
-        await openTrovesAndProvideStability(
-          contracts,
-          allUsers,
-          "10,000",
-          "200",
-        )
-
-        await createLiquidationEvent(contracts, "30,000")
-
-        await updatePendingSnapshots(contracts, allUsers, "before")
-        await updateStabilityPoolUserSnapshots(contracts, allUsers, "before")
-        await updateTroveSnapshots(contracts, allUsers, "before")
-
-        await withdrawCollateralGainToTroves(contracts, allUsers)
-
-        await updateStabilityPoolUserSnapshots(contracts, allUsers, "after")
-        await updateTroveSnapshots(contracts, allUsers, "after")
-
-        allUsers.forEach((user) => {
-          expect(user.stabilityPool.compoundedDeposit.before).to.equal(0n)
-          expect(user.stabilityPool.collateralGain.before).to.be.greaterThan(0n)
-
-          expect(user.stabilityPool.compoundedDeposit.after).to.equal(0n)
-          expect(user.stabilityPool.collateralGain.after).to.equal(0n)
-
-          expect(user.trove.collateral.after).to.equal(
-            user.trove.collateral.before +
-              user.pending.collateral.before +
-              user.stabilityPool.collateralGain.before,
-          )
-          expect(user.trove.debt.after).to.equal(
-            user.trove.debt.before + user.pending.debt.before,
-          )
-        })
-      })
-
-      it("withdrawCollateralGainToTrove(): Large liquidated coll/debt, deposits and BTC price", async () => {
-        // collateral:USD price is $2 billion per BTC
-        await contracts.mockAggregator.setPrice(2n * 10n ** 27n)
-
-        const allUsers = [bob, carol]
-        const amount = 1n * 10n ** 27n // $ 1 billion
-        await openTrovesAndProvideStability(contracts, allUsers, amount, "200")
-
-        await createLiquidationEvent(contracts, amount)
-
-        await updateStabilityPoolUserSnapshots(contracts, allUsers, "before")
-        await updateTroveSnapshots(contracts, allUsers, "before")
-
-        await withdrawCollateralGainToTroves(contracts, allUsers)
-
-        await updateStabilityPoolUserSnapshots(contracts, allUsers, "after")
-        await updateTroveSnapshots(contracts, allUsers, "after")
-
-        allUsers.forEach((user) => {
-          expect(user.stabilityPool.collateralGain.before).to.be.greaterThan(0n)
-          expect(user.stabilityPool.collateralGain.after).to.equal(0n)
-
-          expect(user.trove.collateral.after).to.equal(
-            user.trove.collateral.before +
-              user.stabilityPool.collateralGain.before,
-          )
-          expect(user.trove.debt.after).to.equal(user.trove.debt.before)
-        })
-      })
-
-      it("withdrawCollateralGainToTrove(): Small liquidated coll/debt, large deposits and collateral price", async () => {
-        // collateral:USD price is $2 billion per BTC
-        await contracts.mockAggregator.setPrice(2n * 10n ** 27n)
-
-        const allUsers = [bob, carol]
-        const amount = 1n * 10n ** 27n // $ 1 billion
-        await openTrovesAndProvideStability(contracts, allUsers, amount, "200")
-
-        await createLiquidationEvent(contracts, "2,000")
-
-        await updateStabilityPoolUserSnapshots(contracts, allUsers, "before")
-        await updateTroveSnapshots(contracts, allUsers, "before")
-
-        await withdrawCollateralGainToTroves(contracts, allUsers)
-
-        await updateStabilityPoolUserSnapshots(contracts, allUsers, "after")
-        await updateTroveSnapshots(contracts, allUsers, "after")
-
-        allUsers.forEach((user) => {
-          expect(user.stabilityPool.collateralGain.before).to.be.greaterThan(0n)
-          expect(user.stabilityPool.collateralGain.after).to.equal(0n)
-
-          expect(user.trove.collateral.after).to.equal(
-            user.trove.collateral.before +
-              user.stabilityPool.collateralGain.before,
-          )
-          expect(user.trove.debt.after).to.equal(user.trove.debt.before)
-        })
-      })
-    })
-
-    /**
-     *
-     * Fees
-     *
-     */
-    context("Fees", () => {})
-
-    /**
-     *
-     * State change in other contracts
-     *
-     */
-    context("State change in other contracts", () => {})
   })
 
   describe("Rounding Errors", () => {

--- a/solidity/test/normal/TroveManager.test.ts
+++ b/solidity/test/normal/TroveManager.test.ts
@@ -251,14 +251,785 @@ describe("TroveManager in Normal Mode", () => {
   })
 
   describe("liquidate()", () => {
-    /**
-     *
-     * Expected Reverts
-     *
-     */
+    it("removes the Trove's stake from the total stakes", async () => {
+      await setupTroves()
+      await updateTroveSnapshot(contracts, alice, "before")
+      await updateTroveSnapshot(contracts, bob, "before")
+      await updateTroveManagerSnapshot(contracts, state, "before")
+
+      expect(state.troveManager.stakes.before).to.equal(
+        alice.trove.stake.before + bob.trove.stake.before,
+      )
+
+      // price drops reducing Alice's ICR below MCR
+      await dropPriceAndLiquidate(contracts, alice)
+
+      await updateTroveManagerSnapshot(contracts, state, "after")
+      expect(state.troveManager.stakes.after).to.equal(bob.trove.stake.before)
+    })
+
+    it("Removes the correct trove from the TroveOwners array, and moves the last array element to the new empty slot", async () => {
+      await setupTroves()
+      // Open additional troves
+      await openTrove(contracts, {
+        musdAmount: "5000",
+        ICR: "218",
+        sender: carol.wallet,
+      })
+      await openTrove(contracts, {
+        musdAmount: "5000",
+        ICR: "216",
+        sender: dennis.wallet,
+      })
+      await openTrove(contracts, {
+        musdAmount: "5000",
+        ICR: "214",
+        sender: eric.wallet,
+      })
+
+      /*
+       Our TroveOwners array should now be: [Alice, Bob, Carol, Dennis, Eric].
+       Note they are not sorted by ICR but by insertion order.
+      */
+      await updateTroveManagerSnapshot(contracts, state, "before")
+      expect(state.troveManager.troves.before).to.equal(5)
+
+      // Drop the price to lower ICRs below MCR and close Carol's trove
+      await dropPriceAndLiquidate(contracts, carol)
+
+      // Check that carol no longer has an active trove
+      expect(await contracts.sortedTroves.contains(carol.wallet)).to.equal(
+        false,
+      )
+
+      // Check that the TroveOwners array has been updated correctly
+      await updateTroveManagerSnapshot(contracts, state, "after")
+      expect(state.troveManager.troves.after).to.equal(4)
+
+      /* After Carol is removed from the array, the last element (Eric's address) should have been moved to fill the
+       * empty slot left by Carol. The TroveOwners array should now be: [Bob, Alice, Eric, Dennis] */
+      const troveOwners = await Promise.all(
+        [0, 1, 2, 3].map((index) => contracts.troveManager.TroveOwners(index)),
+      )
+
+      expect(troveOwners).to.deep.equal([
+        addresses.alice,
+        addresses.bob,
+        addresses.eric,
+        addresses.dennis,
+      ])
+
+      // Check that the correct indices are recorded on the active trove structs
+      await updateTroveSnapshots(contracts, [alice, bob, eric, dennis], "after")
+
+      expect(alice.trove.arrayIndex.after).to.equal(0)
+      expect(bob.trove.arrayIndex.after).to.equal(1)
+      expect(eric.trove.arrayIndex.after).to.equal(2)
+      expect(dennis.trove.arrayIndex.after).to.equal(3)
+    })
+
+    it("Given the same price and no other trove changes, complete Pool offsets restore the TCR to its prior value after liquidation of multiple defaulters", async () => {
+      await setupTroves()
+      // Approve up to $10k to be sent to the stability pool for Bob.
+      await provideToSP(contracts, bob, to1e18("10,000"))
+
+      await updateTroveManagerSnapshot(contracts, state, "before")
+
+      // Open additional troves with low enough ICRs that they will default on a small price drop
+      await openTrove(contracts, {
+        musdAmount: "1800",
+        ICR: "120",
+        sender: carol.wallet,
+      })
+      await openTrove(contracts, {
+        musdAmount: "2000",
+        ICR: "120",
+        sender: dennis.wallet,
+      })
+
+      // price drops reducing ICRs below MCR
+      const price = await contracts.priceFeed.fetchPrice()
+      await contracts.mockAggregator.setPrice((price * 80n) / 100n)
+
+      // liquidate defaulters
+      await contracts.troveManager.liquidate(carol.wallet.address)
+      await contracts.troveManager.liquidate(dennis.wallet.address)
+
+      // Check defaulters are removed
+      expect(await contracts.sortedTroves.contains(carol.wallet)).to.equal(
+        false,
+      )
+      expect(await contracts.sortedTroves.contains(dennis.wallet)).to.equal(
+        false,
+      )
+
+      // Price bounces back
+      await contracts.mockAggregator.setPrice(price)
+
+      // Check TCR is restored
+      await updateTroveManagerSnapshot(contracts, state, "after")
+      expect(state.troveManager.TCR.after).to.equal(
+        state.troveManager.TCR.before,
+      )
+    })
+
+    it("Pool offsets increase the TCR", async () => {
+      await setupTroves()
+      await provideToSP(contracts, bob, to1e18("10,000"))
+
+      // Open additional troves with low enough ICRs that they will default on a small price drop
+      await openTrove(contracts, {
+        musdAmount: "1800",
+        ICR: "120",
+        sender: carol.wallet,
+      })
+      await openTrove(contracts, {
+        musdAmount: "2000",
+        ICR: "120",
+        sender: dennis.wallet,
+      })
+      await openTrove(contracts, {
+        musdAmount: "3000",
+        ICR: "120",
+        sender: eric.wallet,
+      })
+
+      // price drops reducing ICRs below MCR
+      const price = await contracts.priceFeed.fetchPrice()
+      await contracts.mockAggregator.setPrice((price * 80n) / 100n)
+
+      // Check TCR improves with each liquidation that is offset with Pool
+      const tcrBefore = await getTCR(contracts)
+      await contracts.troveManager.liquidate(carol.wallet.address)
+      const tcr2 = await getTCR(contracts)
+      expect(tcr2).to.be.greaterThan(tcrBefore)
+
+      await contracts.troveManager.liquidate(dennis.wallet.address)
+      const tcr3 = await getTCR(contracts)
+      expect(tcr3).to.be.greaterThan(tcr2)
+
+      await contracts.troveManager.liquidate(eric.wallet.address)
+      const tcr4 = await getTCR(contracts)
+      expect(tcr4).to.be.greaterThan(tcr3)
+    })
+
+    it("a pure redistribution reduces the TCR only as a result of compensation", async () => {
+      await setupTroves()
+      await openTrove(contracts, {
+        musdAmount: "1800",
+        ICR: "120",
+        sender: carol.wallet,
+      })
+
+      // price drops reducing ICR below MCR
+      const price = await contracts.priceFeed.fetchPrice()
+      const newPrice = (price * 80n) / 100n
+      await contracts.mockAggregator.setPrice(newPrice)
+
+      const tcrBefore = await getTCR(contracts)
+      const entireSystemCollBefore =
+        await contracts.troveManager.getEntireSystemColl()
+      const entireSystemDebtBefore =
+        await contracts.troveManager.getEntireSystemDebt()
+
+      expect(
+        (entireSystemCollBefore * newPrice) / entireSystemDebtBefore,
+      ).to.equal(tcrBefore)
+
+      // Check TCR does not decrease with each liquidation
+      const liquidationTx = await contracts.troveManager.liquidate(
+        carol.wallet.address,
+      )
+      const { collGasCompensation } =
+        await getEmittedLiquidationValues(liquidationTx)
+
+      const tcrAfter = await getTCR(contracts)
+
+      const remainingColl =
+        (entireSystemCollBefore - collGasCompensation) * newPrice
+
+      expect(remainingColl).to.equal(
+        (await contracts.troveManager.getEntireSystemColl()) * newPrice,
+      )
+
+      const remainingDebt = entireSystemDebtBefore
+      expect(remainingDebt).to.equal(
+        await contracts.troveManager.getEntireSystemDebt(),
+      )
+
+      expect(tcrAfter).to.equal(remainingColl / remainingDebt)
+    })
+
+    it("does not affect the SP deposit or collateral gain when called on an SP depositor's address that has no trove", async () => {
+      await setupTroves()
+      const spDeposit = to1e18(10000)
+
+      // Bob sends tokens to Dennis, who has no trove
+      await contracts.musd.connect(bob.wallet).approve(dennis.wallet, spDeposit)
+      const allowance = await contracts.musd.allowance(
+        bob.wallet.address,
+        dennis.wallet.address,
+      )
+      expect(allowance).to.equal(spDeposit)
+      await contracts.musd
+        .connect(bob.wallet)
+        .transfer(dennis.wallet, spDeposit, { from: bob.wallet })
+
+      // Dennis provides MUSD to SP
+      await provideToSP(contracts, dennis, spDeposit)
+
+      // Alice gets liquidated
+      await dropPriceAndLiquidate(contracts, alice)
+
+      // Dennis' SP deposit has absorbed Carol's debt, and he has received her liquidated collateral
+      await updateStabilityPoolUserSnapshot(contracts, dennis, "before")
+
+      // Attempt to liquidate Dennis
+      await expect(
+        contracts.troveManager.liquidate(dennis.wallet.address),
+      ).to.be.revertedWith("TroveManager: Trove does not exist or is closed")
+
+      // Check Dennis' SP deposit does not change after liquidation attempt
+      await updateStabilityPoolUserSnapshot(contracts, dennis, "after")
+      expect(dennis.stabilityPool.compoundedDeposit.after).to.equal(
+        dennis.stabilityPool.compoundedDeposit.before,
+      )
+      expect(dennis.stabilityPool.collateralGain.after).to.equal(
+        dennis.stabilityPool.collateralGain.before,
+      )
+    })
+
+    it("does not liquidate a SP depositor's trove with ICR > 110%, and does not affect their SP deposit or collateral gain", async () => {
+      await setupTroves()
+      const spDeposit = to1e18(10000)
+      await provideToSP(contracts, bob, spDeposit)
+
+      // liquidate Alice
+      const { newPrice } = await dropPriceAndLiquidate(contracts, alice)
+
+      // check Bob's ICR > MCR
+      expect(
+        await contracts.troveManager.getCurrentICR(bob.address, newPrice),
+      ).to.be.greaterThan(await contracts.troveManager.MCR())
+
+      // check Bob's SP deposit and collateral gain before liquidation
+      await updateStabilityPoolUserSnapshot(contracts, bob, "before")
+
+      // Attempt to liquidate Bob
+      await expect(
+        contracts.troveManager.liquidate(bob.wallet.address),
+      ).to.be.revertedWith("TroveManager: nothing to liquidate")
+
+      // Check that Bob's SP deposit and collateral gain have not changed
+      await updateStabilityPoolUserSnapshot(contracts, bob, "after")
+
+      expect(bob.stabilityPool.compoundedDeposit.after).to.equal(
+        bob.stabilityPool.compoundedDeposit.before,
+      )
+      expect(bob.stabilityPool.collateralGain.after).to.equal(
+        bob.stabilityPool.collateralGain.before,
+      )
+    })
+
+    it("liquidates a SP depositor's trove with ICR < 110%, and the liquidation correctly impacts their SP deposit and collateral gain", async () => {
+      // Open three troves: Alice, Bob, Carol
+      await openTrove(contracts, {
+        musdAmount: "50000",
+        ICR: "800",
+        sender: alice.wallet,
+      })
+      await openTrove(contracts, {
+        musdAmount: "1000000",
+        ICR: "2000",
+        sender: bob.wallet,
+      })
+
+      await openTrove(contracts, {
+        musdAmount: "2000",
+        ICR: "200",
+        sender: carol.wallet,
+      })
+
+      await updateTroveSnapshot(contracts, carol, "before")
+      await updateTroveSnapshot(contracts, alice, "before")
+
+      // Alice deposits into the stability pool
+      const aliceSPDeposit = to1e18(25000)
+      await provideToSP(contracts, alice, aliceSPDeposit)
+      await updateStabilityPoolUserSnapshot(contracts, alice, "before")
+
+      // Price drops, carol gets liquidated
+      await dropPriceAndLiquidate(contracts, carol)
+
+      // Alice's deposit should decrease by Carol's debt
+      await updateStabilityPoolUserSnapshot(contracts, alice, "after")
+      expect(alice.stabilityPool.compoundedDeposit.after).to.be.closeTo(
+        aliceSPDeposit - carol.trove.debt.before,
+        1000000n,
+      )
+
+      // Alice's collateral gain should increase by Carol's collateral less the liquidation fee
+      expect(alice.stabilityPool.collateralGain.after).to.be.closeTo(
+        applyLiquidationFee(carol.trove.collateral.before),
+        1000n,
+      )
+
+      // Bob deposits into the stability pool
+      const bobSPDeposit = to1e18(50000)
+      await provideToSP(contracts, bob, bobSPDeposit)
+
+      // Price drops, Alice gets liquidated
+      await updateTroveSnapshot(contracts, alice, "after")
+      await dropPriceAndLiquidate(contracts, alice)
+
+      // Alice's new deposit should decrease by her share of her own debt
+      const totalDeposits =
+        alice.stabilityPool.compoundedDeposit.after + bobSPDeposit
+      const aliceShareOfDebt =
+        (alice.trove.debt.after * alice.stabilityPool.compoundedDeposit.after) /
+        totalDeposits
+      const aliceExpectedDeposit =
+        alice.stabilityPool.compoundedDeposit.after - aliceShareOfDebt
+      const aliceDepositFinal =
+        await contracts.stabilityPool.getCompoundedMUSDDeposit(alice.wallet)
+      expect(aliceDepositFinal).to.be.closeTo(aliceExpectedDeposit, 1000000n)
+
+      // Alice's new collateral gain should increase by her share of her own collateral less the liquidation fee
+      const aliceCollateralShare =
+        (applyLiquidationFee(alice.trove.collateral.after) *
+          alice.stabilityPool.compoundedDeposit.after) /
+        totalDeposits
+      const aliceExpectedCollateralGain =
+        alice.stabilityPool.collateralGain.after + aliceCollateralShare
+      const aliceCollateralGainFinal =
+        await contracts.stabilityPool.getDepositorCollateralGain(alice.wallet)
+      expect(aliceCollateralGainFinal).to.be.closeTo(
+        aliceExpectedCollateralGain,
+        1000000n,
+      )
+
+      // Bob's new deposit should decrease by his share of Alice's debt
+      const bobShareOfDebt =
+        (alice.trove.debt.after * bobSPDeposit) / totalDeposits
+      const bobExpectedDeposit = bobSPDeposit - bobShareOfDebt
+      await updateStabilityPoolUserSnapshot(contracts, bob, "after")
+      expect(bobExpectedDeposit).to.be.closeTo(
+        bob.stabilityPool.compoundedDeposit.after,
+        1000000n,
+      )
+      // Bob's new collateral gain should increase by his share of Alice's collateral less the liquidation fee
+      const bobCollateralShare =
+        (applyLiquidationFee(alice.trove.collateral.after) * bobSPDeposit) /
+        totalDeposits
+      expect(bob.stabilityPool.collateralGain.after).to.be.closeTo(
+        bobCollateralShare,
+        1000000n,
+      )
+    })
+
+    it("updates the snapshots of total stakes and total collateral", async () => {
+      await setupTroves()
+      await updateTroveSnapshot(contracts, alice, "before")
+      await updateTroveSnapshot(contracts, bob, "before") // not strictly necessary but for completeness
+
+      expect(await contracts.troveManager.totalStakesSnapshot()).to.equal(0n)
+      expect(await contracts.troveManager.totalCollateralSnapshot()).to.equal(
+        0n,
+      )
+
+      // Drop the price to lower ICRs below MCR and close Alice's trove
+      await dropPriceAndLiquidate(contracts, alice)
+
+      // Total stakes should be equal to Bob's stake
+      await updateTroveSnapshot(contracts, bob, "after")
+      expect(await contracts.troveManager.totalStakesSnapshot()).to.equal(
+        bob.trove.stake.after,
+      )
+
+      /*
+       Total collateral should be equal to Bob's collateral plus his pending collateral reward (Alice's collateral less liquidation fee)
+       earned from the liquidation of Alice's trove
+      */
+      const expectedCollateral =
+        bob.trove.collateral.after +
+        applyLiquidationFee(alice.trove.collateral.before)
+      expect(await contracts.troveManager.totalCollateralSnapshot()).to.equal(
+        expectedCollateral,
+      )
+    })
+
+    it("updates the L_Collateral and L_MUSDDebt reward-per-unit-staked totals", async () => {
+      await setupTroves()
+      await openTrove(contracts, {
+        musdAmount: "5000",
+        ICR: "111",
+        sender: carol.wallet,
+      })
+
+      await updateTroveSnapshot(contracts, alice, "before")
+      await updateTroveSnapshot(contracts, bob, "before")
+      await updateTroveSnapshot(contracts, carol, "before")
+
+      // Drop the price to lower Carol's ICR below MCR and close Carol's trove
+      await contracts.mockAggregator.setPrice(to1e18(49000))
+      await contracts.troveManager.liquidate(carol.wallet.address)
+      expect(await contracts.sortedTroves.contains(carol.wallet)).to.equal(
+        false,
+      )
+
+      // Carol's collateral less the liquidation fee and MUSD should be added to the default pool
+      const liquidatedColl = to1e18(
+        applyLiquidationFee(carol.trove.collateral.before),
+      )
+      const remainingColl =
+        bob.trove.collateral.before + alice.trove.collateral.before
+      const expectedLCollateralAfterCarolLiquidated =
+        liquidatedColl / remainingColl
+      expect(await contracts.troveManager.L_Collateral()).to.equal(
+        expectedLCollateralAfterCarolLiquidated,
+      )
+
+      const expectedLMUSDDebtAfterCarolLiquidated =
+        to1e18(carol.trove.debt.before) / remainingColl
+      expect(await contracts.troveManager.L_MUSDDebt()).to.equal(
+        expectedLMUSDDebtAfterCarolLiquidated,
+      )
+
+      // Alice now withdraws MUSD, bring her ICR to 1.11
+      const { increasedTotalDebt } = await adjustTroveToICR(
+        contracts,
+        alice.wallet,
+        1111111111111111111n,
+      )
+
+      // price drops again, reducing Alice's ICR below MCR
+      await contracts.mockAggregator.setPrice(to1e18(40000))
+
+      // Close Alice's Trove
+      await contracts.troveManager.liquidate(alice.wallet.address)
+      expect(await contracts.sortedTroves.contains(alice.wallet)).to.equal(
+        false,
+      )
+
+      /*
+       * Alice's pending reward was applied to her trove before liquidation.  We account for that here using the previous
+       * L_Collateral value computed after Carol's liquidation.
+       */
+      const aliceCollWithReward = to1e18(
+        applyLiquidationFee(
+          alice.trove.collateral.before +
+            (alice.trove.collateral.before *
+              expectedLCollateralAfterCarolLiquidated) /
+              to1e18(1),
+        ),
+      )
+
+      // Bob now has all the active stake.  We now add the reward-per-unit-staked from Alice's liquidation to the L_Collateral.
+      const expectedLCollateralAfterAliceLiquidated =
+        expectedLCollateralAfterCarolLiquidated +
+        aliceCollWithReward / bob.trove.collateral.before
+
+      expect(await contracts.troveManager.L_Collateral()).to.equal(
+        expectedLCollateralAfterAliceLiquidated,
+      )
+
+      // Apply Alice's pending debt rewards and calculate the new LMUSDDebt
+      const expectedLMUSDDebtAfterAliceLiquidated =
+        expectedLMUSDDebtAfterCarolLiquidated +
+        ((alice.trove.debt.before +
+          increasedTotalDebt +
+          (alice.trove.collateral.before *
+            expectedLMUSDDebtAfterCarolLiquidated) /
+            to1e18(1)) *
+          to1e18(1)) /
+          bob.trove.collateral.before
+
+      const tolerance = 100n
+      expect(await contracts.troveManager.L_MUSDDebt()).to.be.closeTo(
+        expectedLMUSDDebtAfterAliceLiquidated,
+        tolerance,
+      )
+    })
+
+    it("closes a Trove that has ICR < MCR", async () => {
+      await setupTroves()
+      // Alice's Trove has ICR = 4, which is above the MCR
+      await updateTroveSnapshot(contracts, alice, "before")
+      expect(alice.trove.icr.before).to.equal(to1e18(4))
+
+      const mcr = (await contracts.troveManager.MCR()).toString()
+      expect(mcr).to.equal(to1e18(1.1))
+
+      const targetICR = 1111111111111111111n
+
+      // Alice increases debt to lower her ICR to 1.111111111111111111
+      await adjustTroveToICR(contracts, alice.wallet, targetICR)
+
+      await updateTroveSnapshot(contracts, alice, "after")
+      expect(alice.trove.icr.after).to.equal(targetICR)
+
+      // price drops reducing Alice's ICR below MCR
+      const newPrice = to1e18(1000)
+      await contracts.mockAggregator.setPrice(newPrice)
+
+      alice.trove.icr.after = await contracts.troveManager.getCurrentICR(
+        addresses.alice,
+        newPrice,
+      )
+      expect(alice.trove.icr.after).to.be.lt(mcr)
+
+      // close trove
+      await contracts.troveManager.liquidate(alice.wallet.address)
+
+      // check the Trove is successfully closed, and removed from sortedList
+      await updateTroveSnapshot(contracts, alice, "after")
+      expect(alice.trove.status.after).to.equal(3) // status enum 3 corresponds to "Closed by liquidation"
+
+      const aliceTroveIsInSortedList = await contracts.sortedTroves.contains(
+        alice.wallet.address,
+      )
+
+      expect(aliceTroveIsInSortedList).to.equal(false)
+    })
+
+    it("Liquidates undercollateralized trove if there are two troves in the system", async () => {
+      await setupTroves()
+      await updateTroveSnapshot(contracts, alice, "before")
+      await updateTroveSnapshot(contracts, bob, "before")
+
+      // price drops reducing Alice's ICR below MCR
+      await contracts.mockAggregator.setPrice(to1e18(1000))
+
+      await updateTroveSnapshot(contracts, alice, "after")
+      await updateTroveSnapshot(contracts, bob, "after")
+      expect(alice.trove.icr.after).to.be.lt(to1e18(1.1))
+
+      expect(await contracts.troveManager.getTroveOwnersCount()).to.equal(2)
+
+      // Close trove
+      await contracts.troveManager.liquidate(alice.wallet.address)
+
+      // Check Alice's trove is removed, and bob remains
+      expect(await contracts.troveManager.getTroveOwnersCount()).to.equal(1)
+      expect(
+        await contracts.sortedTroves.contains(alice.wallet.address),
+      ).to.equal(false)
+      expect(
+        await contracts.sortedTroves.contains(bob.wallet.address),
+      ).to.equal(true)
+    })
+
+    it("does nothing if trove has >= 110% ICR", async () => {
+      await setupTroves()
+      await updateTroveManagerSnapshot(contracts, state, "before")
+
+      // Attempt to liquidate Alice
+      await expect(
+        contracts.troveManager.liquidate(alice.wallet.address),
+      ).to.be.revertedWith("TroveManager: nothing to liquidate")
+
+      // Check Alice and Bob are still active
+      expect(
+        await contracts.sortedTroves.contains(alice.wallet.address),
+      ).to.equal(true)
+      expect(
+        await contracts.sortedTroves.contains(bob.wallet.address),
+      ).to.equal(true)
+
+      await updateTroveManagerSnapshot(contracts, state, "after")
+      expect(state.troveManager.troves.before).to.equal(
+        state.troveManager.troves.after,
+      )
+
+      expect(state.troveManager.TCR.before).to.equal(
+        state.troveManager.TCR.after,
+      )
+    })
+
+    it("liquidates based on entire collateral/debt (including pending rewards), not raw collateral/debt", async () => {
+      await openTrove(contracts, {
+        musdAmount: "2000",
+        ICR: "400",
+        sender: alice.wallet,
+      })
+      await openTrove(contracts, {
+        musdAmount: "2000",
+        ICR: "221",
+        sender: bob.wallet,
+      })
+      await openTrove(contracts, {
+        musdAmount: "2000",
+        ICR: "200",
+        sender: carol.wallet,
+      })
+      await openTrove(contracts, {
+        musdAmount: "2000",
+        ICR: "200",
+        sender: dennis.wallet,
+      })
+
+      // Drop the price
+      const currentPrice = await contracts.priceFeed.fetchPrice()
+      await contracts.mockAggregator.setPrice(currentPrice / 2n)
+
+      // Before liquidation, Alice and Bob are above MCR, Carol is below
+      await updateTroveSnapshot(contracts, alice, "before")
+      await updateTroveSnapshot(contracts, bob, "before")
+      await updateTroveSnapshot(contracts, carol, "before")
+
+      const mcr = await contracts.troveManager.MCR()
+      expect(alice.trove.icr.before).to.be.above(mcr)
+      expect(bob.trove.icr.before).to.be.above(mcr)
+      expect(carol.trove.icr.before).to.be.below(mcr)
+
+      // Liquidate Dennis, his collateral and debt should be distributed between the others
+      await contracts.troveManager.liquidate(dennis.address)
+
+      await updateTroveSnapshot(contracts, alice, "after")
+      await updateTroveSnapshot(contracts, bob, "after")
+      await updateTroveSnapshot(contracts, carol, "after")
+      expect(alice.trove.icr.after).to.be.above(mcr)
+      expect(bob.trove.icr.after).to.be.below(mcr)
+      expect(carol.trove.icr.after).to.be.below(mcr)
+
+      // Bob's ICR including pending rewards is below the MCR, but his raw coll and debt have not changed
+      expect(bob.trove.debt.after).to.equal(bob.trove.debt.before)
+      expect(bob.trove.collateral.after).to.equal(bob.trove.collateral.before)
+
+      // Whale (Eric) enters the system, ensuring we don't go into recovery mode
+      await openTrove(contracts, {
+        musdAmount: "10,000",
+        ICR: "1000",
+        sender: eric.wallet,
+      })
+
+      // Attempt to Liquidate Alice, Bob, and Carol
+      await expect(
+        contracts.troveManager.liquidate(alice.wallet.address),
+      ).to.be.revertedWith("TroveManager: nothing to liquidate")
+      await contracts.troveManager.liquidate(bob.address)
+      await contracts.troveManager.liquidate(carol.address)
+
+      // Check Alice stays active, Bob and Carol get liquidated
+      expect(await contracts.sortedTroves.contains(alice.address)).to.equal(
+        true,
+      )
+      expect(await contracts.sortedTroves.contains(bob.address)).to.equal(false)
+      expect(await contracts.sortedTroves.contains(carol.address)).to.equal(
+        false,
+      )
+
+      // Check Trove statuses - Alice should be active (1), B and C are closed by liquidation (3)
+      expect(
+        await contracts.troveManager.getTroveStatus(alice.address),
+      ).to.equal(1)
+      expect(await contracts.troveManager.getTroveStatus(bob.address)).to.equal(
+        3,
+      )
+      expect(
+        await contracts.troveManager.getTroveStatus(carol.address),
+      ).to.equal(3)
+    })
+
+    it("does not alter the liquidated user's token balance", async () => {
+      await setupTroves()
+      await dropPriceAndLiquidate(contracts, alice)
+      expect(await contracts.musd.balanceOf(alice.wallet)).to.equal(
+        to1e18("5200"),
+      )
+    })
+
+    it("decreases ActivePool collateral and MUSDDebt by correct amounts", async () => {
+      await setupTroves()
+      await updateTroveSnapshot(contracts, alice, "before")
+      await updateTroveSnapshot(contracts, bob, "before")
+
+      // check ActivePool collateral
+      await updateContractsSnapshot(
+        contracts,
+        state,
+        "activePool",
+        "before",
+        addresses,
+      )
+      const expectedCollateralBefore =
+        alice.trove.collateral.before + bob.trove.collateral.before
+      expect(state.activePool.collateral.before).to.equal(
+        expectedCollateralBefore,
+      )
+      expect(state.activePool.btc.before).to.equal(expectedCollateralBefore)
+
+      // check MUSD Debt
+      expect(state.activePool.debt.before).to.equal(
+        alice.trove.debt.before + bob.trove.debt.before,
+      )
+
+      /* Close Alice's Trove. Should liquidate her collateral and MUSD,
+       * leaving Bob’s collateral and MUSD debt in the ActivePool. */
+      await dropPriceAndLiquidate(contracts, alice)
+
+      await updateContractsSnapshot(
+        contracts,
+        state,
+        "activePool",
+        "after",
+        addresses,
+      )
+
+      expect(state.activePool.collateral.after).to.equal(
+        bob.trove.collateral.before,
+      )
+      expect(state.activePool.btc.after).to.equal(bob.trove.collateral.before)
+
+      // check ActivePool MUSD debt
+      expect(state.activePool.debt.after).to.equal(bob.trove.debt.before)
+    })
+
+    it("increases DefaultPool collateral and MUSD debt by correct amounts", async () => {
+      await setupTroves()
+      await updateTroveSnapshot(contracts, alice, "before")
+      await updateTroveSnapshot(contracts, bob, "before")
+      await updateContractsSnapshot(
+        contracts,
+        state,
+        "defaultPool",
+        "before",
+        addresses,
+      )
+
+      // check DefaultPool collateral
+      expect(state.defaultPool.collateral.before).to.equal(0n)
+      expect(state.defaultPool.btc.before).to.equal(0n)
+
+      // check MUSD Debt
+      expect(state.defaultPool.debt.before).to.equal(0n)
+
+      await dropPriceAndLiquidate(contracts, alice)
+
+      // DefaultPool collateral should increase by Alice's collateral less the liquidation fee
+      await updateContractsSnapshot(
+        contracts,
+        state,
+        "defaultPool",
+        "after",
+        addresses,
+      )
+      const expectedDefaultPoolCollateral = applyLiquidationFee(
+        alice.trove.collateral.before,
+      )
+      expect(state.defaultPool.collateral.after).to.equal(
+        expectedDefaultPoolCollateral,
+      )
+      expect(state.defaultPool.btc.after).to.equal(
+        expectedDefaultPoolCollateral,
+      )
+
+      // DefaultPool total debt after should increase by Alice's total debt
+      expect(state.defaultPool.debt.after).to.equal(alice.trove.debt.before)
+    })
 
     context("Expected Reverts", () => {
-      it("liquidate(): reverts if trove has been closed", async () => {
+      it("reverts if trove has been closed", async () => {
         await setupTroves()
         await updateTroveSnapshot(contracts, alice, "before")
 
@@ -276,856 +1047,248 @@ describe("TroveManager in Normal Mode", () => {
         ).to.be.revertedWith("TroveManager: Trove does not exist or is closed")
       })
     })
-
-    /**
-     *
-     * Emitted Events
-     *
-     */
-
-    context("Emitted Events", () => {})
-
-    /**
-     *
-     * System State Changes
-     *
-     */
-
-    context("System State Changes", () => {
-      it("liquidate(): removes the Trove's stake from the total stakes", async () => {
-        await setupTroves()
-        await updateTroveSnapshot(contracts, alice, "before")
-        await updateTroveSnapshot(contracts, bob, "before")
-        await updateTroveManagerSnapshot(contracts, state, "before")
-
-        expect(state.troveManager.stakes.before).to.equal(
-          alice.trove.stake.before + bob.trove.stake.before,
-        )
-
-        // price drops reducing Alice's ICR below MCR
-        await dropPriceAndLiquidate(contracts, alice)
-
-        await updateTroveManagerSnapshot(contracts, state, "after")
-        expect(state.troveManager.stakes.after).to.equal(bob.trove.stake.before)
-      })
-
-      it("liquidate(): Removes the correct trove from the TroveOwners array, and moves the last array element to the new empty slot", async () => {
-        await setupTroves()
-        // Open additional troves
-        await openTrove(contracts, {
-          musdAmount: "5000",
-          ICR: "218",
-          sender: carol.wallet,
-        })
-        await openTrove(contracts, {
-          musdAmount: "5000",
-          ICR: "216",
-          sender: dennis.wallet,
-        })
-        await openTrove(contracts, {
-          musdAmount: "5000",
-          ICR: "214",
-          sender: eric.wallet,
-        })
-
-        /*
-         Our TroveOwners array should now be: [Alice, Bob, Carol, Dennis, Eric].
-         Note they are not sorted by ICR but by insertion order.
-        */
-        await updateTroveManagerSnapshot(contracts, state, "before")
-        expect(state.troveManager.troves.before).to.equal(5)
-
-        // Drop the price to lower ICRs below MCR and close Carol's trove
-        await dropPriceAndLiquidate(contracts, carol)
-
-        // Check that carol no longer has an active trove
-        expect(await contracts.sortedTroves.contains(carol.wallet)).to.equal(
-          false,
-        )
-
-        // Check that the TroveOwners array has been updated correctly
-        await updateTroveManagerSnapshot(contracts, state, "after")
-        expect(state.troveManager.troves.after).to.equal(4)
-
-        /* After Carol is removed from the array, the last element (Eric's address) should have been moved to fill the
-         * empty slot left by Carol. The TroveOwners array should now be: [Bob, Alice, Eric, Dennis] */
-        const troveOwners = await Promise.all(
-          [0, 1, 2, 3].map((index) =>
-            contracts.troveManager.TroveOwners(index),
-          ),
-        )
-
-        expect(troveOwners).to.deep.equal([
-          addresses.alice,
-          addresses.bob,
-          addresses.eric,
-          addresses.dennis,
-        ])
-
-        // Check that the correct indices are recorded on the active trove structs
-        await updateTroveSnapshots(
-          contracts,
-          [alice, bob, eric, dennis],
-          "after",
-        )
-
-        expect(alice.trove.arrayIndex.after).to.equal(0)
-        expect(bob.trove.arrayIndex.after).to.equal(1)
-        expect(eric.trove.arrayIndex.after).to.equal(2)
-        expect(dennis.trove.arrayIndex.after).to.equal(3)
-      })
-
-      it(
-        "liquidate(): Given the same price and no other trove changes, " +
-          "complete Pool offsets restore the TCR to its prior value after liquidation of multiple defaulters",
-        async () => {
-          await setupTroves()
-          // Approve up to $10k to be sent to the stability pool for Bob.
-          await provideToSP(contracts, bob, to1e18("10,000"))
-
-          await updateTroveManagerSnapshot(contracts, state, "before")
-
-          // Open additional troves with low enough ICRs that they will default on a small price drop
-          await openTrove(contracts, {
-            musdAmount: "1800",
-            ICR: "120",
-            sender: carol.wallet,
-          })
-          await openTrove(contracts, {
-            musdAmount: "2000",
-            ICR: "120",
-            sender: dennis.wallet,
-          })
-
-          // price drops reducing ICRs below MCR
-          const price = await contracts.priceFeed.fetchPrice()
-          await contracts.mockAggregator.setPrice((price * 80n) / 100n)
-
-          // liquidate defaulters
-          await contracts.troveManager.liquidate(carol.wallet.address)
-          await contracts.troveManager.liquidate(dennis.wallet.address)
-
-          // Check defaulters are removed
-          expect(await contracts.sortedTroves.contains(carol.wallet)).to.equal(
-            false,
-          )
-          expect(await contracts.sortedTroves.contains(dennis.wallet)).to.equal(
-            false,
-          )
-
-          // Price bounces back
-          await contracts.mockAggregator.setPrice(price)
-
-          // Check TCR is restored
-          await updateTroveManagerSnapshot(contracts, state, "after")
-          expect(state.troveManager.TCR.after).to.equal(
-            state.troveManager.TCR.before,
-          )
-        },
-      )
-
-      it("liquidate(): Pool offsets increase the TCR", async () => {
-        await setupTroves()
-        await provideToSP(contracts, bob, to1e18("10,000"))
-
-        // Open additional troves with low enough ICRs that they will default on a small price drop
-        await openTrove(contracts, {
-          musdAmount: "1800",
-          ICR: "120",
-          sender: carol.wallet,
-        })
-        await openTrove(contracts, {
-          musdAmount: "2000",
-          ICR: "120",
-          sender: dennis.wallet,
-        })
-        await openTrove(contracts, {
-          musdAmount: "3000",
-          ICR: "120",
-          sender: eric.wallet,
-        })
-
-        // price drops reducing ICRs below MCR
-        const price = await contracts.priceFeed.fetchPrice()
-        await contracts.mockAggregator.setPrice((price * 80n) / 100n)
-
-        // Check TCR improves with each liquidation that is offset with Pool
-        const tcrBefore = await getTCR(contracts)
-        await contracts.troveManager.liquidate(carol.wallet.address)
-        const tcr2 = await getTCR(contracts)
-        expect(tcr2).to.be.greaterThan(tcrBefore)
-
-        await contracts.troveManager.liquidate(dennis.wallet.address)
-        const tcr3 = await getTCR(contracts)
-        expect(tcr3).to.be.greaterThan(tcr2)
-
-        await contracts.troveManager.liquidate(eric.wallet.address)
-        const tcr4 = await getTCR(contracts)
-        expect(tcr4).to.be.greaterThan(tcr3)
-      })
-
-      it("liquidate(): a pure redistribution reduces the TCR only as a result of compensation", async () => {
-        await setupTroves()
-        await openTrove(contracts, {
-          musdAmount: "1800",
-          ICR: "120",
-          sender: carol.wallet,
-        })
-
-        // price drops reducing ICR below MCR
-        const price = await contracts.priceFeed.fetchPrice()
-        const newPrice = (price * 80n) / 100n
-        await contracts.mockAggregator.setPrice(newPrice)
-
-        const tcrBefore = await getTCR(contracts)
-        const entireSystemCollBefore =
-          await contracts.troveManager.getEntireSystemColl()
-        const entireSystemDebtBefore =
-          await contracts.troveManager.getEntireSystemDebt()
-
-        expect(
-          (entireSystemCollBefore * newPrice) / entireSystemDebtBefore,
-        ).to.equal(tcrBefore)
-
-        // Check TCR does not decrease with each liquidation
-        const liquidationTx = await contracts.troveManager.liquidate(
-          carol.wallet.address,
-        )
-        const { collGasCompensation } =
-          await getEmittedLiquidationValues(liquidationTx)
-
-        const tcrAfter = await getTCR(contracts)
-
-        const remainingColl =
-          (entireSystemCollBefore - collGasCompensation) * newPrice
-
-        expect(remainingColl).to.equal(
-          (await contracts.troveManager.getEntireSystemColl()) * newPrice,
-        )
-
-        const remainingDebt = entireSystemDebtBefore
-        expect(remainingDebt).to.equal(
-          await contracts.troveManager.getEntireSystemDebt(),
-        )
-
-        expect(tcrAfter).to.equal(remainingColl / remainingDebt)
-      })
-
-      it("liquidate(): does not affect the SP deposit or collateral gain when called on an SP depositor's address that has no trove", async () => {
-        await setupTroves()
-        const spDeposit = to1e18(10000)
-
-        // Bob sends tokens to Dennis, who has no trove
-        await contracts.musd
-          .connect(bob.wallet)
-          .approve(dennis.wallet, spDeposit)
-        const allowance = await contracts.musd.allowance(
-          bob.wallet.address,
-          dennis.wallet.address,
-        )
-        expect(allowance).to.equal(spDeposit)
-        await contracts.musd
-          .connect(bob.wallet)
-          .transfer(dennis.wallet, spDeposit, { from: bob.wallet })
-
-        // Dennis provides MUSD to SP
-        await provideToSP(contracts, dennis, spDeposit)
-
-        // Alice gets liquidated
-        await dropPriceAndLiquidate(contracts, alice)
-
-        // Dennis' SP deposit has absorbed Carol's debt, and he has received her liquidated collateral
-        await updateStabilityPoolUserSnapshot(contracts, dennis, "before")
-
-        // Attempt to liquidate Dennis
-        await expect(
-          contracts.troveManager.liquidate(dennis.wallet.address),
-        ).to.be.revertedWith("TroveManager: Trove does not exist or is closed")
-
-        // Check Dennis' SP deposit does not change after liquidation attempt
-        await updateStabilityPoolUserSnapshot(contracts, dennis, "after")
-        expect(dennis.stabilityPool.compoundedDeposit.after).to.equal(
-          dennis.stabilityPool.compoundedDeposit.before,
-        )
-        expect(dennis.stabilityPool.collateralGain.after).to.equal(
-          dennis.stabilityPool.collateralGain.before,
-        )
-      })
-
-      it("liquidate(): does not liquidate a SP depositor's trove with ICR > 110%, and does not affect their SP deposit or collateral gain", async () => {
-        await setupTroves()
-        const spDeposit = to1e18(10000)
-        await provideToSP(contracts, bob, spDeposit)
-
-        // liquidate Alice
-        const { newPrice } = await dropPriceAndLiquidate(contracts, alice)
-
-        // check Bob's ICR > MCR
-        expect(
-          await contracts.troveManager.getCurrentICR(bob.address, newPrice),
-        ).to.be.greaterThan(await contracts.troveManager.MCR())
-
-        // check Bob's SP deposit and collateral gain before liquidation
-        await updateStabilityPoolUserSnapshot(contracts, bob, "before")
-
-        // Attempt to liquidate Bob
-        await expect(
-          contracts.troveManager.liquidate(bob.wallet.address),
-        ).to.be.revertedWith("TroveManager: nothing to liquidate")
-
-        // Check that Bob's SP deposit and collateral gain have not changed
-        await updateStabilityPoolUserSnapshot(contracts, bob, "after")
-
-        expect(bob.stabilityPool.compoundedDeposit.after).to.equal(
-          bob.stabilityPool.compoundedDeposit.before,
-        )
-        expect(bob.stabilityPool.collateralGain.after).to.equal(
-          bob.stabilityPool.collateralGain.before,
-        )
-      })
-
-      it("liquidate(): liquidates a SP depositor's trove with ICR < 110%, and the liquidation correctly impacts their SP deposit and collateral gain", async () => {
-        // Open three troves: Alice, Bob, Carol
-        await openTrove(contracts, {
-          musdAmount: "50000",
-          ICR: "800",
-          sender: alice.wallet,
-        })
-        await openTrove(contracts, {
-          musdAmount: "1000000",
-          ICR: "2000",
-          sender: bob.wallet,
-        })
-
-        await openTrove(contracts, {
-          musdAmount: "2000",
-          ICR: "200",
-          sender: carol.wallet,
-        })
-
-        await updateTroveSnapshot(contracts, carol, "before")
-        await updateTroveSnapshot(contracts, alice, "before")
-
-        // Alice deposits into the stability pool
-        const aliceSPDeposit = to1e18(25000)
-        await provideToSP(contracts, alice, aliceSPDeposit)
-        await updateStabilityPoolUserSnapshot(contracts, alice, "before")
-
-        // Price drops, carol gets liquidated
-        await dropPriceAndLiquidate(contracts, carol)
-
-        // Alice's deposit should decrease by Carol's debt
-        await updateStabilityPoolUserSnapshot(contracts, alice, "after")
-        expect(alice.stabilityPool.compoundedDeposit.after).to.be.closeTo(
-          aliceSPDeposit - carol.trove.debt.before,
-          1000000n,
-        )
-
-        // Alice's collateral gain should increase by Carol's collateral less the liquidation fee
-        expect(alice.stabilityPool.collateralGain.after).to.be.closeTo(
-          applyLiquidationFee(carol.trove.collateral.before),
-          1000n,
-        )
-
-        // Bob deposits into the stability pool
-        const bobSPDeposit = to1e18(50000)
-        await provideToSP(contracts, bob, bobSPDeposit)
-
-        // Price drops, Alice gets liquidated
-        await updateTroveSnapshot(contracts, alice, "after")
-        await dropPriceAndLiquidate(contracts, alice)
-
-        // Alice's new deposit should decrease by her share of her own debt
-        const totalDeposits =
-          alice.stabilityPool.compoundedDeposit.after + bobSPDeposit
-        const aliceShareOfDebt =
-          (alice.trove.debt.after *
-            alice.stabilityPool.compoundedDeposit.after) /
-          totalDeposits
-        const aliceExpectedDeposit =
-          alice.stabilityPool.compoundedDeposit.after - aliceShareOfDebt
-        const aliceDepositFinal =
-          await contracts.stabilityPool.getCompoundedMUSDDeposit(alice.wallet)
-        expect(aliceDepositFinal).to.be.closeTo(aliceExpectedDeposit, 1000000n)
-
-        // Alice's new collateral gain should increase by her share of her own collateral less the liquidation fee
-        const aliceCollateralShare =
-          (applyLiquidationFee(alice.trove.collateral.after) *
-            alice.stabilityPool.compoundedDeposit.after) /
-          totalDeposits
-        const aliceExpectedCollateralGain =
-          alice.stabilityPool.collateralGain.after + aliceCollateralShare
-        const aliceCollateralGainFinal =
-          await contracts.stabilityPool.getDepositorCollateralGain(alice.wallet)
-        expect(aliceCollateralGainFinal).to.be.closeTo(
-          aliceExpectedCollateralGain,
-          1000000n,
-        )
-
-        // Bob's new deposit should decrease by his share of Alice's debt
-        const bobShareOfDebt =
-          (alice.trove.debt.after * bobSPDeposit) / totalDeposits
-        const bobExpectedDeposit = bobSPDeposit - bobShareOfDebt
-        await updateStabilityPoolUserSnapshot(contracts, bob, "after")
-        expect(bobExpectedDeposit).to.be.closeTo(
-          bob.stabilityPool.compoundedDeposit.after,
-          1000000n,
-        )
-        // Bob's new collateral gain should increase by his share of Alice's collateral less the liquidation fee
-        const bobCollateralShare =
-          (applyLiquidationFee(alice.trove.collateral.after) * bobSPDeposit) /
-          totalDeposits
-        expect(bob.stabilityPool.collateralGain.after).to.be.closeTo(
-          bobCollateralShare,
-          1000000n,
-        )
-      })
-
-      it("liquidate(): updates the snapshots of total stakes and total collateral", async () => {
-        await setupTroves()
-        await updateTroveSnapshot(contracts, alice, "before")
-        await updateTroveSnapshot(contracts, bob, "before") // not strictly necessary but for completeness
-
-        expect(await contracts.troveManager.totalStakesSnapshot()).to.equal(0n)
-        expect(await contracts.troveManager.totalCollateralSnapshot()).to.equal(
-          0n,
-        )
-
-        // Drop the price to lower ICRs below MCR and close Alice's trove
-        await dropPriceAndLiquidate(contracts, alice)
-
-        // Total stakes should be equal to Bob's stake
-        await updateTroveSnapshot(contracts, bob, "after")
-        expect(await contracts.troveManager.totalStakesSnapshot()).to.equal(
-          bob.trove.stake.after,
-        )
-
-        /*
-         Total collateral should be equal to Bob's collateral plus his pending collateral reward (Alice's collateral less liquidation fee)
-         earned from the liquidation of Alice's trove
-        */
-        const expectedCollateral =
-          bob.trove.collateral.after +
-          applyLiquidationFee(alice.trove.collateral.before)
-        expect(await contracts.troveManager.totalCollateralSnapshot()).to.equal(
-          expectedCollateral,
-        )
-      })
-
-      it("liquidate(): updates the L_Collateral and L_MUSDDebt reward-per-unit-staked totals", async () => {
-        await setupTroves()
-        await openTrove(contracts, {
-          musdAmount: "5000",
-          ICR: "111",
-          sender: carol.wallet,
-        })
-
-        await updateTroveSnapshot(contracts, alice, "before")
-        await updateTroveSnapshot(contracts, bob, "before")
-        await updateTroveSnapshot(contracts, carol, "before")
-
-        // Drop the price to lower Carol's ICR below MCR and close Carol's trove
-        await contracts.mockAggregator.setPrice(to1e18(49000))
-        await contracts.troveManager.liquidate(carol.wallet.address)
-        expect(await contracts.sortedTroves.contains(carol.wallet)).to.equal(
-          false,
-        )
-
-        // Carol's collateral less the liquidation fee and MUSD should be added to the default pool
-        const liquidatedColl = to1e18(
-          applyLiquidationFee(carol.trove.collateral.before),
-        )
-        const remainingColl =
-          bob.trove.collateral.before + alice.trove.collateral.before
-        const expectedLCollateralAfterCarolLiquidated =
-          liquidatedColl / remainingColl
-        expect(await contracts.troveManager.L_Collateral()).to.equal(
-          expectedLCollateralAfterCarolLiquidated,
-        )
-
-        const expectedLMUSDDebtAfterCarolLiquidated =
-          to1e18(carol.trove.debt.before) / remainingColl
-        expect(await contracts.troveManager.L_MUSDDebt()).to.equal(
-          expectedLMUSDDebtAfterCarolLiquidated,
-        )
-
-        // Alice now withdraws MUSD, bring her ICR to 1.11
-        const { increasedTotalDebt } = await adjustTroveToICR(
-          contracts,
-          alice.wallet,
-          1111111111111111111n,
-        )
-
-        // price drops again, reducing Alice's ICR below MCR
-        await contracts.mockAggregator.setPrice(to1e18(40000))
-
-        // Close Alice's Trove
-        await contracts.troveManager.liquidate(alice.wallet.address)
-        expect(await contracts.sortedTroves.contains(alice.wallet)).to.equal(
-          false,
-        )
-
-        /*
-         * Alice's pending reward was applied to her trove before liquidation.  We account for that here using the previous
-         * L_Collateral value computed after Carol's liquidation.
-         */
-        const aliceCollWithReward = to1e18(
-          applyLiquidationFee(
-            alice.trove.collateral.before +
-              (alice.trove.collateral.before *
-                expectedLCollateralAfterCarolLiquidated) /
-                to1e18(1),
-          ),
-        )
-
-        // Bob now has all the active stake.  We now add the reward-per-unit-staked from Alice's liquidation to the L_Collateral.
-        const expectedLCollateralAfterAliceLiquidated =
-          expectedLCollateralAfterCarolLiquidated +
-          aliceCollWithReward / bob.trove.collateral.before
-
-        expect(await contracts.troveManager.L_Collateral()).to.equal(
-          expectedLCollateralAfterAliceLiquidated,
-        )
-
-        // Apply Alice's pending debt rewards and calculate the new LMUSDDebt
-        const expectedLMUSDDebtAfterAliceLiquidated =
-          expectedLMUSDDebtAfterCarolLiquidated +
-          ((alice.trove.debt.before +
-            increasedTotalDebt +
-            (alice.trove.collateral.before *
-              expectedLMUSDDebtAfterCarolLiquidated) /
-              to1e18(1)) *
-            to1e18(1)) /
-            bob.trove.collateral.before
-
-        const tolerance = 100n
-        expect(await contracts.troveManager.L_MUSDDebt()).to.be.closeTo(
-          expectedLMUSDDebtAfterAliceLiquidated,
-          tolerance,
-        )
-      })
-    })
-
-    /**
-     *
-     * Individual Troves
-     *
-     */
-    context("Individual Troves", () => {
-      it("liquidate(): closes a Trove that has ICR < MCR", async () => {
-        await setupTroves()
-        // Alice's Trove has ICR = 4, which is above the MCR
-        await updateTroveSnapshot(contracts, alice, "before")
-        expect(alice.trove.icr.before).to.equal(to1e18(4))
-
-        const mcr = (await contracts.troveManager.MCR()).toString()
-        expect(mcr).to.equal(to1e18(1.1))
-
-        const targetICR = 1111111111111111111n
-
-        // Alice increases debt to lower her ICR to 1.111111111111111111
-        await adjustTroveToICR(contracts, alice.wallet, targetICR)
-
-        await updateTroveSnapshot(contracts, alice, "after")
-        expect(alice.trove.icr.after).to.equal(targetICR)
-
-        // price drops reducing Alice's ICR below MCR
-        const newPrice = to1e18(1000)
-        await contracts.mockAggregator.setPrice(newPrice)
-
-        alice.trove.icr.after = await contracts.troveManager.getCurrentICR(
-          addresses.alice,
-          newPrice,
-        )
-        expect(alice.trove.icr.after).to.be.lt(mcr)
-
-        // close trove
-        await contracts.troveManager.liquidate(alice.wallet.address)
-
-        // check the Trove is successfully closed, and removed from sortedList
-        await updateTroveSnapshot(contracts, alice, "after")
-        expect(alice.trove.status.after).to.equal(3) // status enum 3 corresponds to "Closed by liquidation"
-
-        const aliceTroveIsInSortedList = await contracts.sortedTroves.contains(
-          alice.wallet.address,
-        )
-
-        expect(aliceTroveIsInSortedList).to.equal(false)
-      })
-
-      it("liquidate(): Liquidates undercollateralized trove if there are two troves in the system", async () => {
-        await setupTroves()
-        await updateTroveSnapshot(contracts, alice, "before")
-        await updateTroveSnapshot(contracts, bob, "before")
-
-        // price drops reducing Alice's ICR below MCR
-        await contracts.mockAggregator.setPrice(to1e18(1000))
-
-        await updateTroveSnapshot(contracts, alice, "after")
-        await updateTroveSnapshot(contracts, bob, "after")
-        expect(alice.trove.icr.after).to.be.lt(to1e18(1.1))
-
-        expect(await contracts.troveManager.getTroveOwnersCount()).to.equal(2)
-
-        // Close trove
-        await contracts.troveManager.liquidate(alice.wallet.address)
-
-        // Check Alice's trove is removed, and bob remains
-        expect(await contracts.troveManager.getTroveOwnersCount()).to.equal(1)
-        expect(
-          await contracts.sortedTroves.contains(alice.wallet.address),
-        ).to.equal(false)
-        expect(
-          await contracts.sortedTroves.contains(bob.wallet.address),
-        ).to.equal(true)
-      })
-
-      it("liquidate(): does nothing if trove has >= 110% ICR", async () => {
-        await setupTroves()
-        await updateTroveManagerSnapshot(contracts, state, "before")
-
-        // Attempt to liquidate Alice
-        await expect(
-          contracts.troveManager.liquidate(alice.wallet.address),
-        ).to.be.revertedWith("TroveManager: nothing to liquidate")
-
-        // Check Alice and Bob are still active
-        expect(
-          await contracts.sortedTroves.contains(alice.wallet.address),
-        ).to.equal(true)
-        expect(
-          await contracts.sortedTroves.contains(bob.wallet.address),
-        ).to.equal(true)
-
-        await updateTroveManagerSnapshot(contracts, state, "after")
-        expect(state.troveManager.troves.before).to.equal(
-          state.troveManager.troves.after,
-        )
-
-        expect(state.troveManager.TCR.before).to.equal(
-          state.troveManager.TCR.after,
-        )
-      })
-
-      it("liquidate(): liquidates based on entire collateral/debt (including pending rewards), not raw collateral/debt", async () => {
-        await openTrove(contracts, {
-          musdAmount: "2000",
-          ICR: "400",
-          sender: alice.wallet,
-        })
-        await openTrove(contracts, {
-          musdAmount: "2000",
-          ICR: "221",
-          sender: bob.wallet,
-        })
-        await openTrove(contracts, {
-          musdAmount: "2000",
-          ICR: "200",
-          sender: carol.wallet,
-        })
-        await openTrove(contracts, {
-          musdAmount: "2000",
-          ICR: "200",
-          sender: dennis.wallet,
-        })
-
-        // Drop the price
-        const currentPrice = await contracts.priceFeed.fetchPrice()
-        await contracts.mockAggregator.setPrice(currentPrice / 2n)
-
-        // Before liquidation, Alice and Bob are above MCR, Carol is below
-        await updateTroveSnapshot(contracts, alice, "before")
-        await updateTroveSnapshot(contracts, bob, "before")
-        await updateTroveSnapshot(contracts, carol, "before")
-
-        const mcr = await contracts.troveManager.MCR()
-        expect(alice.trove.icr.before).to.be.above(mcr)
-        expect(bob.trove.icr.before).to.be.above(mcr)
-        expect(carol.trove.icr.before).to.be.below(mcr)
-
-        // Liquidate Dennis, his collateral and debt should be distributed between the others
-        await contracts.troveManager.liquidate(dennis.address)
-
-        await updateTroveSnapshot(contracts, alice, "after")
-        await updateTroveSnapshot(contracts, bob, "after")
-        await updateTroveSnapshot(contracts, carol, "after")
-        expect(alice.trove.icr.after).to.be.above(mcr)
-        expect(bob.trove.icr.after).to.be.below(mcr)
-        expect(carol.trove.icr.after).to.be.below(mcr)
-
-        // Bob's ICR including pending rewards is below the MCR, but his raw coll and debt have not changed
-        expect(bob.trove.debt.after).to.equal(bob.trove.debt.before)
-        expect(bob.trove.collateral.after).to.equal(bob.trove.collateral.before)
-
-        // Whale (Eric) enters the system, ensuring we don't go into recovery mode
-        await openTrove(contracts, {
-          musdAmount: "10,000",
-          ICR: "1000",
-          sender: eric.wallet,
-        })
-
-        // Attempt to Liquidate Alice, Bob, and Carol
-        await expect(
-          contracts.troveManager.liquidate(alice.wallet.address),
-        ).to.be.revertedWith("TroveManager: nothing to liquidate")
-        await contracts.troveManager.liquidate(bob.address)
-        await contracts.troveManager.liquidate(carol.address)
-
-        // Check Alice stays active, Bob and Carol get liquidated
-        expect(await contracts.sortedTroves.contains(alice.address)).to.equal(
-          true,
-        )
-        expect(await contracts.sortedTroves.contains(bob.address)).to.equal(
-          false,
-        )
-        expect(await contracts.sortedTroves.contains(carol.address)).to.equal(
-          false,
-        )
-
-        // Check Trove statuses - Alice should be active (1), B and C are closed by liquidation (3)
-        expect(
-          await contracts.troveManager.getTroveStatus(alice.address),
-        ).to.equal(1)
-        expect(
-          await contracts.troveManager.getTroveStatus(bob.address),
-        ).to.equal(3)
-        expect(
-          await contracts.troveManager.getTroveStatus(carol.address),
-        ).to.equal(3)
-      })
-    })
-
-    /**
-     *
-     * Balance changes
-     *
-     */
-
-    context("Balance changes", () => {
-      it("liquidate(): does not alter the liquidated user's token balance", async () => {
-        await setupTroves()
-        await dropPriceAndLiquidate(contracts, alice)
-        expect(await contracts.musd.balanceOf(alice.wallet)).to.equal(
-          to1e18("5200"),
-        )
-      })
-    })
-
-    /**
-     *
-     * Fees
-     *
-     */
-
-    context("Fees", () => {})
-
-    /**
-     *
-     * State change in other contracts
-     *
-     */
-
-    context("State change in other contracts", () => {
-      it("liquidate(): decreases ActivePool collateral and MUSDDebt by correct amounts", async () => {
-        await setupTroves()
-        await updateTroveSnapshot(contracts, alice, "before")
-        await updateTroveSnapshot(contracts, bob, "before")
-
-        // check ActivePool collateral
-        await updateContractsSnapshot(
-          contracts,
-          state,
-          "activePool",
-          "before",
-          addresses,
-        )
-        const expectedCollateralBefore =
-          alice.trove.collateral.before + bob.trove.collateral.before
-        expect(state.activePool.collateral.before).to.equal(
-          expectedCollateralBefore,
-        )
-        expect(state.activePool.btc.before).to.equal(expectedCollateralBefore)
-
-        // check MUSD Debt
-        expect(state.activePool.debt.before).to.equal(
-          alice.trove.debt.before + bob.trove.debt.before,
-        )
-
-        /* Close Alice's Trove. Should liquidate her collateral and MUSD,
-         * leaving Bob’s collateral and MUSD debt in the ActivePool. */
-        await dropPriceAndLiquidate(contracts, alice)
-
-        await updateContractsSnapshot(
-          contracts,
-          state,
-          "activePool",
-          "after",
-          addresses,
-        )
-
-        expect(state.activePool.collateral.after).to.equal(
-          bob.trove.collateral.before,
-        )
-        expect(state.activePool.btc.after).to.equal(bob.trove.collateral.before)
-
-        // check ActivePool MUSD debt
-        expect(state.activePool.debt.after).to.equal(bob.trove.debt.before)
-      })
-
-      it("liquidate(): increases DefaultPool collateral and MUSD debt by correct amounts", async () => {
-        await setupTroves()
-        await updateTroveSnapshot(contracts, alice, "before")
-        await updateTroveSnapshot(contracts, bob, "before")
-        await updateContractsSnapshot(
-          contracts,
-          state,
-          "defaultPool",
-          "before",
-          addresses,
-        )
-
-        // check DefaultPool collateral
-        expect(state.defaultPool.collateral.before).to.equal(0n)
-        expect(state.defaultPool.btc.before).to.equal(0n)
-
-        // check MUSD Debt
-        expect(state.defaultPool.debt.before).to.equal(0n)
-
-        await dropPriceAndLiquidate(contracts, alice)
-
-        // DefaultPool collateral should increase by Alice's collateral less the liquidation fee
-        await updateContractsSnapshot(
-          contracts,
-          state,
-          "defaultPool",
-          "after",
-          addresses,
-        )
-        const expectedDefaultPoolCollateral = applyLiquidationFee(
-          alice.trove.collateral.before,
-        )
-        expect(state.defaultPool.collateral.after).to.equal(
-          expectedDefaultPoolCollateral,
-        )
-        expect(state.defaultPool.btc.after).to.equal(
-          expectedDefaultPoolCollateral,
-        )
-
-        // DefaultPool total debt after should increase by Alice's total debt
-        expect(state.defaultPool.debt.after).to.equal(alice.trove.debt.before)
-      })
-    })
   })
 
   describe("liquidateTroves()", () => {
-    /**
-     *
-     * Expected Reverts
-     *
-     */
+    it("A liquidation sequence containing Pool offsets increases the TCR", async () => {
+      await setupTroves()
+
+      // Open a couple more troves with the same ICR as Alice
+      await openTrove(contracts, {
+        musdAmount: "2000",
+        ICR: "400",
+        sender: carol.wallet,
+      })
+      await openTrove(contracts, {
+        musdAmount: "2000",
+        ICR: "400",
+        sender: dennis.wallet,
+      })
+
+      // Bob provides funds to SP
+      await provideToSP(contracts, bob, to1e18("10,000"))
+
+      // Drop the price to make everyone but Bob eligible for liquidation and snapshot the TCR
+      await dropPrice(contracts, alice)
+      await updateTroveManagerSnapshot(contracts, state, "before")
+
+      // Perform liquidation and check that TCR has improved
+      await contracts.troveManager.liquidateTroves(4)
+      await updateTroveManagerSnapshot(contracts, state, "after")
+      expect(state.troveManager.TCR.after).to.be.greaterThan(
+        state.troveManager.TCR.before,
+      )
+    })
+
+    it("A liquidation sequence of pure redistributions decreases the TCR, due to gas compensation, but up to 0.5%", async () => {
+      await setupTroves()
+
+      // Open a couple more troves with the same ICR as Alice
+      await openTrove(contracts, {
+        musdAmount: "2000",
+        ICR: "400",
+        sender: carol.wallet,
+      })
+      await openTrove(contracts, {
+        musdAmount: "2000",
+        ICR: "400",
+        sender: dennis.wallet,
+      })
+
+      // Drop the price to make everyone but Bob eligible for liquidation and snapshot the TCR
+      await dropPrice(contracts, alice)
+      await updateTroveManagerSnapshot(contracts, state, "before")
+
+      // Perform liquidation and check that TCR has decreased
+      await contracts.troveManager.liquidateTroves(4)
+      await updateTroveManagerSnapshot(contracts, state, "after")
+      expect(state.troveManager.TCR.before).to.be.greaterThan(
+        state.troveManager.TCR.after,
+      )
+
+      // Check that the TCR has decreased by no more than the liquidation fee
+      expect(state.troveManager.TCR.after).to.be.greaterThanOrEqual(
+        applyLiquidationFee(state.troveManager.TCR.before),
+      )
+    })
+
+    it("liquidates a Trove that was skipped in a previous liquidation and has pending rewards", async () => {
+      await setupTrovesLiquidateWithSkip()
+
+      // Drop the price so that Dennis is at risk for liquidation
+      await dropPrice(contracts, dennis)
+      await updateTroveSnapshots(contracts, [bob, dennis], "after")
+
+      // Liquidate 2 troves, Dennis should get liquidated and Bob should remain
+      await contracts.troveManager.liquidateTroves(2)
+      expect(
+        await contracts.sortedTroves.contains(dennis.wallet.address),
+      ).to.equal(false)
+      expect(
+        await contracts.sortedTroves.contains(bob.wallet.address),
+      ).to.equal(true)
+    })
+
+    it("closes every Trove with ICR < MCR, when n > number of undercollateralized troves", async () => {
+      await testLiquidateICRLessThanMCR(() =>
+        contracts.troveManager.liquidateTroves(5),
+      )
+    })
+
+    it("liquidates up to (but no more than) the requested number of undercollateralized troves", async () => {
+      await testLiquidateOnly(() => contracts.troveManager.liquidateTroves(2))
+    })
+
+    it("liquidates based on entire/collateral debt (including pending rewards), not raw collateral/debt", async () => {
+      await openTrove(contracts, {
+        musdAmount: "2000",
+        ICR: "400",
+        sender: alice.wallet,
+      })
+
+      // Open a trove for Bob, then two troves with slightly lower ICRs for Carol and Dennis
+      await openTrove(contracts, {
+        musdAmount: "2000",
+        ICR: "200.01",
+        sender: bob.wallet,
+      })
+      await openTrove(contracts, {
+        musdAmount: "2000",
+        ICR: "200",
+        sender: carol.wallet,
+      })
+      await openTrove(contracts, {
+        musdAmount: "2000",
+        ICR: "200",
+        sender: dennis.wallet,
+      })
+
+      // Drop the price so that Carol and Dennis are at risk for liquidation, but do not liquidate anyone yet
+      const newPrice = await dropPrice(contracts, dennis)
+
+      // Check that Bob's ICR is above the MCR after the price drop and before liquidation
+      await updateTroveSnapshot(contracts, bob, "before")
+      const mcr = await contracts.troveManager.MCR()
+      expect(bob.trove.icr.before).to.be.greaterThan(mcr)
+
+      // Liquidate Dennis, creating rewards for everyone
+      await contracts.troveManager.liquidate(dennis.wallet)
+
+      // Check that Bob's ICR is below the MCR following liquidation
+      await updateTroveSnapshot(contracts, bob, "after")
+      expect(bob.trove.icr.after).to.be.lessThan(mcr)
+
+      // Check that Bob's raw ICR (debt and coll less pending rewards) is above the MCR
+      const rawICR =
+        (bob.trove.collateral.after * newPrice) / bob.trove.debt.after
+      expect(rawICR).to.be.greaterThan(mcr)
+
+      // Attempt to liquidate all troves
+      await contracts.troveManager.liquidateTroves(3)
+
+      // Check that Alice stays active and Carol and Bob get liquidated
+      expect(await checkTroveActive(contracts, alice)).to.equal(true)
+      expect(await checkTroveClosedByLiquidation(contracts, bob)).to.equal(true)
+      expect(await checkTroveClosedByLiquidation(contracts, carol)).to.equal(
+        true,
+      )
+    })
+
+    it("does not affect the liquidated user's token balances", async () => {
+      await setupTroves()
+      await updateWalletSnapshot(contracts, alice, "before")
+      await updateWalletSnapshot(contracts, bob, "before")
+
+      // Attempt to liquidate both troves, only Alice gets liquidated
+      await dropPrice(contracts, alice)
+      await contracts.troveManager.liquidateTroves(2)
+      await updateWalletSnapshot(contracts, alice, "after")
+      await updateWalletSnapshot(contracts, bob, "after")
+
+      // Balances should remain unchanged except for gas compensation
+      expect(alice.musd.after).to.equal(alice.musd.before + to1e18("200"))
+      expect(bob.musd.after).to.equal(bob.musd.before)
+    })
+
+    it("Liquidating troves with SP deposits correctly impacts their SP deposit and collateral gain", async () => {
+      // Open three troves: Alice, Bob, Carol
+      await openTrove(contracts, {
+        musdAmount: "2000",
+        ICR: "200",
+        sender: alice.wallet,
+      })
+      await openTrove(contracts, {
+        musdAmount: "2000",
+        ICR: "200",
+        sender: bob.wallet,
+      })
+      await openTrove(contracts, {
+        musdAmount: "20000",
+        ICR: "2000",
+        sender: carol.wallet,
+      })
+
+      // All deposit into the stability pool
+      const aliceDeposit = to1e18("500")
+      const bobDeposit = to1e18("1000")
+      const carolDeposit = to1e18("3000")
+      await provideToSP(contracts, alice, aliceDeposit)
+      await provideToSP(contracts, bob, bobDeposit)
+      await provideToSP(contracts, carol, carolDeposit)
+
+      await updateTroveSnapshots(contracts, [alice, bob, carol], "before")
+
+      // Price drops so we can liquidate Alice and Bob
+      await dropPriceAndLiquidate(contracts, alice, false)
+
+      await updateStabilityPoolUserSnapshots(
+        contracts,
+        [alice, bob, carol],
+        "before",
+      )
+
+      // Liquidate
+      await contracts.troveManager.liquidateTroves(2)
+
+      // Check that each user's deposit has decreased by their share of the total liquidated debt
+      const totalDeposits = aliceDeposit + bobDeposit + carolDeposit
+      const liquidatedDebt = alice.trove.debt.before + bob.trove.debt.before
+      await updateStabilityPoolUserSnapshots(
+        contracts,
+        [alice, bob, carol],
+        "after",
+      )
+
+      expect(
+        aliceDeposit - (liquidatedDebt * aliceDeposit) / totalDeposits,
+      ).to.be.closeTo(alice.stabilityPool.compoundedDeposit.after, 1000)
+      expect(
+        bobDeposit - (liquidatedDebt * bobDeposit) / totalDeposits,
+      ).to.be.closeTo(bob.stabilityPool.compoundedDeposit.after, 1000)
+      expect(
+        carolDeposit - (liquidatedDebt * carolDeposit) / totalDeposits,
+      ).to.be.closeTo(carol.stabilityPool.compoundedDeposit.after, 10000)
+
+      // Check that each user's collateral gain has increased by their share of the total liquidated collateral
+      const liquidatedColl = applyLiquidationFee(
+        alice.trove.collateral.before + bob.trove.collateral.before,
+      )
+      expect((liquidatedColl * aliceDeposit) / totalDeposits).to.be.closeTo(
+        alice.stabilityPool.collateralGain.after,
+        1000,
+      )
+      expect((liquidatedColl * bobDeposit) / totalDeposits).to.be.closeTo(
+        bob.stabilityPool.collateralGain.after,
+        1000,
+      )
+      expect((liquidatedColl * carolDeposit) / totalDeposits).to.be.closeTo(
+        carol.stabilityPool.collateralGain.after,
+        10000,
+      ) // TODO Determine correct error tolerance
+    })
 
     context("Expected Reverts", () => {
-      it("liquidateTroves(): does nothing if all troves have ICR > 110%", async () => {
+      it("does nothing if all troves have ICR > 110%", async () => {
         await setupTroves()
         await updateTroveManagerSnapshot(contracts, state, "before")
         await expect(
@@ -1140,7 +1303,7 @@ describe("TroveManager in Normal Mode", () => {
         )
       })
 
-      it("liquidateTroves(): reverts if n = 0", async () => {
+      it("reverts if n = 0", async () => {
         await setupTroves()
         // Drop the price so Alice is eligible for liquidation but do not perform the liquidation yet
         await dropPrice(contracts, alice)
@@ -1149,304 +1312,131 @@ describe("TroveManager in Normal Mode", () => {
         ).to.be.revertedWith("TroveManager: nothing to liquidate")
       })
     })
-
-    /**
-     *
-     * Emitted Events
-     *
-     */
-
-    context("Emitted Events", () => {})
-
-    /**
-     *
-     * System State Changes
-     *
-     */
-
-    context("System State Changes", () => {
-      it("liquidateTroves(): A liquidation sequence containing Pool offsets increases the TCR", async () => {
-        await setupTroves()
-
-        // Open a couple more troves with the same ICR as Alice
-        await openTrove(contracts, {
-          musdAmount: "2000",
-          ICR: "400",
-          sender: carol.wallet,
-        })
-        await openTrove(contracts, {
-          musdAmount: "2000",
-          ICR: "400",
-          sender: dennis.wallet,
-        })
-
-        // Bob provides funds to SP
-        await provideToSP(contracts, bob, to1e18("10,000"))
-
-        // Drop the price to make everyone but Bob eligible for liquidation and snapshot the TCR
-        await dropPrice(contracts, alice)
-        await updateTroveManagerSnapshot(contracts, state, "before")
-
-        // Perform liquidation and check that TCR has improved
-        await contracts.troveManager.liquidateTroves(4)
-        await updateTroveManagerSnapshot(contracts, state, "after")
-        expect(state.troveManager.TCR.after).to.be.greaterThan(
-          state.troveManager.TCR.before,
-        )
-      })
-
-      it("liquidateTroves(): A liquidation sequence of pure redistributions decreases the TCR, due to gas compensation, but up to 0.5%", async () => {
-        await setupTroves()
-
-        // Open a couple more troves with the same ICR as Alice
-        await openTrove(contracts, {
-          musdAmount: "2000",
-          ICR: "400",
-          sender: carol.wallet,
-        })
-        await openTrove(contracts, {
-          musdAmount: "2000",
-          ICR: "400",
-          sender: dennis.wallet,
-        })
-
-        // Drop the price to make everyone but Bob eligible for liquidation and snapshot the TCR
-        await dropPrice(contracts, alice)
-        await updateTroveManagerSnapshot(contracts, state, "before")
-
-        // Perform liquidation and check that TCR has decreased
-        await contracts.troveManager.liquidateTroves(4)
-        await updateTroveManagerSnapshot(contracts, state, "after")
-        expect(state.troveManager.TCR.before).to.be.greaterThan(
-          state.troveManager.TCR.after,
-        )
-
-        // Check that the TCR has decreased by no more than the liquidation fee
-        expect(state.troveManager.TCR.after).to.be.greaterThanOrEqual(
-          applyLiquidationFee(state.troveManager.TCR.before),
-        )
-      })
-    })
-
-    /**
-     *
-     * Individual Troves
-     *
-     */
-
-    context("Individual Troves", () => {
-      it("liquidateTroves(): liquidates a Trove that was skipped in a previous liquidation and has pending rewards", async () => {
-        await setupTrovesLiquidateWithSkip()
-
-        // Drop the price so that Dennis is at risk for liquidation
-        await dropPrice(contracts, dennis)
-        await updateTroveSnapshots(contracts, [bob, dennis], "after")
-
-        // Liquidate 2 troves, Dennis should get liquidated and Bob should remain
-        await contracts.troveManager.liquidateTroves(2)
-        expect(
-          await contracts.sortedTroves.contains(dennis.wallet.address),
-        ).to.equal(false)
-        expect(
-          await contracts.sortedTroves.contains(bob.wallet.address),
-        ).to.equal(true)
-      })
-
-      it("liquidateTroves(): closes every Trove with ICR < MCR, when n > number of undercollateralized troves", async () => {
-        await testLiquidateICRLessThanMCR(() =>
-          contracts.troveManager.liquidateTroves(5),
-        )
-      })
-
-      it("liquidateTroves(): liquidates up to (but no more than) the requested number of undercollateralized troves", async () => {
-        await testLiquidateOnly(() => contracts.troveManager.liquidateTroves(2))
-      })
-
-      it("liquidateTroves(): liquidates based on entire/collateral debt (including pending rewards), not raw collateral/debt", async () => {
-        await openTrove(contracts, {
-          musdAmount: "2000",
-          ICR: "400",
-          sender: alice.wallet,
-        })
-
-        // Open a trove for Bob, then two troves with slightly lower ICRs for Carol and Dennis
-        await openTrove(contracts, {
-          musdAmount: "2000",
-          ICR: "200.01",
-          sender: bob.wallet,
-        })
-        await openTrove(contracts, {
-          musdAmount: "2000",
-          ICR: "200",
-          sender: carol.wallet,
-        })
-        await openTrove(contracts, {
-          musdAmount: "2000",
-          ICR: "200",
-          sender: dennis.wallet,
-        })
-
-        // Drop the price so that Carol and Dennis are at risk for liquidation, but do not liquidate anyone yet
-        const newPrice = await dropPrice(contracts, dennis)
-
-        // Check that Bob's ICR is above the MCR after the price drop and before liquidation
-        await updateTroveSnapshot(contracts, bob, "before")
-        const mcr = await contracts.troveManager.MCR()
-        expect(bob.trove.icr.before).to.be.greaterThan(mcr)
-
-        // Liquidate Dennis, creating rewards for everyone
-        await contracts.troveManager.liquidate(dennis.wallet)
-
-        // Check that Bob's ICR is below the MCR following liquidation
-        await updateTroveSnapshot(contracts, bob, "after")
-        expect(bob.trove.icr.after).to.be.lessThan(mcr)
-
-        // Check that Bob's raw ICR (debt and coll less pending rewards) is above the MCR
-        const rawICR =
-          (bob.trove.collateral.after * newPrice) / bob.trove.debt.after
-        expect(rawICR).to.be.greaterThan(mcr)
-
-        // Attempt to liquidate all troves
-        await contracts.troveManager.liquidateTroves(3)
-
-        // Check that Alice stays active and Carol and Bob get liquidated
-        expect(await checkTroveActive(contracts, alice)).to.equal(true)
-        expect(await checkTroveClosedByLiquidation(contracts, bob)).to.equal(
-          true,
-        )
-        expect(await checkTroveClosedByLiquidation(contracts, carol)).to.equal(
-          true,
-        )
-      })
-    })
-
-    /**
-     *
-     * Balance changes
-     *
-     */
-
-    context("Balance changes", () => {
-      it("liquidateTroves(): does not affect the liquidated user's token balances", async () => {
-        await setupTroves()
-        await updateWalletSnapshot(contracts, alice, "before")
-        await updateWalletSnapshot(contracts, bob, "before")
-
-        // Attempt to liquidate both troves, only Alice gets liquidated
-        await dropPrice(contracts, alice)
-        await contracts.troveManager.liquidateTroves(2)
-        await updateWalletSnapshot(contracts, alice, "after")
-        await updateWalletSnapshot(contracts, bob, "after")
-
-        // Balances should remain unchanged except for gas compensation
-        expect(alice.musd.after).to.equal(alice.musd.before + to1e18("200"))
-        expect(bob.musd.after).to.equal(bob.musd.before)
-      })
-    })
-
-    /**
-     *
-     * Fees
-     *
-     */
-
-    context("Fees", () => {})
-
-    /**
-     *
-     * State change in other contracts
-     *
-     */
-
-    context("State change in other contracts", () => {
-      it("liquidateTroves(): Liquidating troves with SP deposits correctly impacts their SP deposit and collateral gain", async () => {
-        // Open three troves: Alice, Bob, Carol
-        await openTrove(contracts, {
-          musdAmount: "2000",
-          ICR: "200",
-          sender: alice.wallet,
-        })
-        await openTrove(contracts, {
-          musdAmount: "2000",
-          ICR: "200",
-          sender: bob.wallet,
-        })
-        await openTrove(contracts, {
-          musdAmount: "20000",
-          ICR: "2000",
-          sender: carol.wallet,
-        })
-
-        // All deposit into the stability pool
-        const aliceDeposit = to1e18("500")
-        const bobDeposit = to1e18("1000")
-        const carolDeposit = to1e18("3000")
-        await provideToSP(contracts, alice, aliceDeposit)
-        await provideToSP(contracts, bob, bobDeposit)
-        await provideToSP(contracts, carol, carolDeposit)
-
-        await updateTroveSnapshots(contracts, [alice, bob, carol], "before")
-
-        // Price drops so we can liquidate Alice and Bob
-        await dropPriceAndLiquidate(contracts, alice, false)
-
-        await updateStabilityPoolUserSnapshots(
-          contracts,
-          [alice, bob, carol],
-          "before",
-        )
-
-        // Liquidate
-        await contracts.troveManager.liquidateTroves(2)
-
-        // Check that each user's deposit has decreased by their share of the total liquidated debt
-        const totalDeposits = aliceDeposit + bobDeposit + carolDeposit
-        const liquidatedDebt = alice.trove.debt.before + bob.trove.debt.before
-        await updateStabilityPoolUserSnapshots(
-          contracts,
-          [alice, bob, carol],
-          "after",
-        )
-
-        expect(
-          aliceDeposit - (liquidatedDebt * aliceDeposit) / totalDeposits,
-        ).to.be.closeTo(alice.stabilityPool.compoundedDeposit.after, 1000)
-        expect(
-          bobDeposit - (liquidatedDebt * bobDeposit) / totalDeposits,
-        ).to.be.closeTo(bob.stabilityPool.compoundedDeposit.after, 1000)
-        expect(
-          carolDeposit - (liquidatedDebt * carolDeposit) / totalDeposits,
-        ).to.be.closeTo(carol.stabilityPool.compoundedDeposit.after, 10000)
-
-        // Check that each user's collateral gain has increased by their share of the total liquidated collateral
-        const liquidatedColl = applyLiquidationFee(
-          alice.trove.collateral.before + bob.trove.collateral.before,
-        )
-        expect((liquidatedColl * aliceDeposit) / totalDeposits).to.be.closeTo(
-          alice.stabilityPool.collateralGain.after,
-          1000,
-        )
-        expect((liquidatedColl * bobDeposit) / totalDeposits).to.be.closeTo(
-          bob.stabilityPool.collateralGain.after,
-          1000,
-        )
-        expect((liquidatedColl * carolDeposit) / totalDeposits).to.be.closeTo(
-          carol.stabilityPool.collateralGain.after,
-          10000,
-        ) // TODO Determine correct error tolerance
-      })
-    })
   })
 
   describe("batchLiquidateTroves()", () => {
-    /**
-     *
-     * Expected Reverts
-     *
-     */
+    it("liquidates a Trove that was skipped in a previous liquidation and has pending rewards", async () => {
+      await setupTrovesLiquidateWithSkip()
+      // attempt to liquidate Alice, Bob, and Dennis. Bob and Dennis are skipped
+      await contracts.troveManager.liquidateTroves(3)
+
+      // Drop the price so that Dennis is at risk for liquidation
+      await dropPrice(contracts, dennis)
+      await updateTroveSnapshots(contracts, [bob, dennis], "after")
+
+      // Liquidate 2 troves, Dennis should get liquidated and Bob should remain
+      await contracts.troveManager.batchLiquidateTroves([
+        bob.wallet,
+        dennis.wallet,
+      ])
+      expect(
+        await contracts.sortedTroves.contains(dennis.wallet.address),
+      ).to.equal(false)
+      expect(
+        await contracts.sortedTroves.contains(bob.wallet.address),
+      ).to.equal(true)
+    })
+
+    it("closes every trove with ICR < MCR in the given array", async () => {
+      await testLiquidateICRLessThanMCR(() =>
+        contracts.troveManager.batchLiquidateTroves([
+          alice.wallet,
+          bob.wallet,
+          carol.wallet,
+          dennis.wallet,
+          eric.wallet,
+        ]),
+      )
+    })
+
+    it("does not liquidate troves that are not in the given array", async () => {
+      await testLiquidateOnly(() =>
+        contracts.troveManager.batchLiquidateTroves([
+          carol.wallet,
+          dennis.wallet,
+        ]),
+      )
+    })
+
+    it("does not close troves with ICR >= MCR in the given array", async () => {
+      await setupTroves()
+
+      // Open a trove with lower ICR
+      await openTrove(contracts, {
+        musdAmount: "20000",
+        ICR: "200",
+        sender: carol.wallet,
+      })
+
+      // Drop price to make only Carol eligible for liquidation
+      await dropPrice(contracts, carol)
+
+      // Attempt to liquidate everyone
+      await contracts.troveManager.batchLiquidateTroves([
+        alice.wallet,
+        bob.wallet,
+        carol.wallet,
+      ])
+
+      expect(await checkTroveActive(contracts, alice)).to.equal(true)
+      expect(await checkTroveActive(contracts, bob)).to.equal(true)
+      expect(await checkTroveClosedByLiquidation(contracts, carol)).to.equal(
+        true,
+      )
+    })
+
+    it("skips if trove is non-existent", async () => {
+      await setupTroves()
+
+      // Drop price so we can liquidate everyone as Bob has the highest ICR
+      await dropPrice(contracts, bob)
+
+      // Attempt to liquidate Alice, Bob, and Carol (who has no trove)
+      await contracts.troveManager.batchLiquidateTroves([
+        alice.wallet,
+        bob.wallet,
+        carol.wallet,
+      ])
+
+      // Check that Carol's trove is non-existent
+      expect(await checkTroveStatus(contracts, carol, 0n, false)).to.equal(true)
+    })
+
+    it("skips if a trove has been closed", async () => {
+      await setupTroves()
+      await openTrove(contracts, {
+        musdAmount: "2000",
+        ICR: "200",
+        sender: carol.wallet,
+      })
+
+      // Send MUSD to Carol so she can close her trove
+      await contracts.musd
+        .connect(bob.wallet)
+        .transfer(carol.address, to1e18("1000"))
+
+      await contracts.borrowerOperations.connect(carol.wallet).closeTrove()
+
+      // Drop the price so Alice and Carol would be eligible for liquidation but not bob
+      await dropPrice(contracts, alice)
+      await contracts.troveManager.batchLiquidateTroves([
+        alice.wallet,
+        bob.wallet,
+        carol.wallet,
+      ])
+
+      // Check Carol's trove is closed by user
+      expect(await checkTroveStatus(contracts, carol, 2n, false)).to.equal(true)
+
+      // Bob is active and Alice is closed by liquidation
+      expect(await checkTroveActive(contracts, bob)).to.equal(true)
+      expect(await checkTroveClosedByLiquidation(contracts, alice)).to.equal(
+        true,
+      )
+    })
 
     context("Expected Reverts", () => {
-      it("batchLiquidateTroves(): reverts if array is empty", async () => {
+      it("reverts if array is empty", async () => {
         await setupTroves()
         await dropPrice(contracts, alice)
         await expect(
@@ -1456,329 +1446,98 @@ describe("TroveManager in Normal Mode", () => {
         )
       })
     })
-
-    /**
-     *
-     * Emitted Events
-     *
-     */
-
-    context("Emitted Events", () => {})
-
-    /**
-     *
-     * System State Changes
-     *
-     */
-
-    context("System State Changes", () => {})
-
-    /**
-     *
-     * Individual Troves
-     *
-     */
-
-    context("Individual Troves", () => {
-      it("batchLiquidateTroves(): liquidates a Trove that was skipped in a previous liquidation and has pending rewards", async () => {
-        await setupTrovesLiquidateWithSkip()
-        // attempt to liquidate Alice, Bob, and Dennis. Bob and Dennis are skipped
-        await contracts.troveManager.liquidateTroves(3)
-
-        // Drop the price so that Dennis is at risk for liquidation
-        await dropPrice(contracts, dennis)
-        await updateTroveSnapshots(contracts, [bob, dennis], "after")
-
-        // Liquidate 2 troves, Dennis should get liquidated and Bob should remain
-        await contracts.troveManager.batchLiquidateTroves([
-          bob.wallet,
-          dennis.wallet,
-        ])
-        expect(
-          await contracts.sortedTroves.contains(dennis.wallet.address),
-        ).to.equal(false)
-        expect(
-          await contracts.sortedTroves.contains(bob.wallet.address),
-        ).to.equal(true)
-      })
-
-      it("batchLiquidateTroves(): closes every trove with ICR < MCR in the given array", async () => {
-        await testLiquidateICRLessThanMCR(() =>
-          contracts.troveManager.batchLiquidateTroves([
-            alice.wallet,
-            bob.wallet,
-            carol.wallet,
-            dennis.wallet,
-            eric.wallet,
-          ]),
-        )
-      })
-
-      it("batchLiquidateTroves(): does not liquidate troves that are not in the given array", async () => {
-        await testLiquidateOnly(() =>
-          contracts.troveManager.batchLiquidateTroves([
-            carol.wallet,
-            dennis.wallet,
-          ]),
-        )
-      })
-
-      it("batchLiquidateTroves(): does not close troves with ICR >= MCR in the given array", async () => {
-        await setupTroves()
-
-        // Open a trove with lower ICR
-        await openTrove(contracts, {
-          musdAmount: "20000",
-          ICR: "200",
-          sender: carol.wallet,
-        })
-
-        // Drop price to make only Carol eligible for liquidation
-        await dropPrice(contracts, carol)
-
-        // Attempt to liquidate everyone
-        await contracts.troveManager.batchLiquidateTroves([
-          alice.wallet,
-          bob.wallet,
-          carol.wallet,
-        ])
-
-        expect(await checkTroveActive(contracts, alice)).to.equal(true)
-        expect(await checkTroveActive(contracts, bob)).to.equal(true)
-        expect(await checkTroveClosedByLiquidation(contracts, carol)).to.equal(
-          true,
-        )
-      })
-
-      it("batchLiquidateTroves(): skips if trove is non-existent", async () => {
-        await setupTroves()
-
-        // Drop price so we can liquidate everyone as Bob has the highest ICR
-        await dropPrice(contracts, bob)
-
-        // Attempt to liquidate Alice, Bob, and Carol (who has no trove)
-        await contracts.troveManager.batchLiquidateTroves([
-          alice.wallet,
-          bob.wallet,
-          carol.wallet,
-        ])
-
-        // Check that Carol's trove is non-existent
-        expect(await checkTroveStatus(contracts, carol, 0n, false)).to.equal(
-          true,
-        )
-      })
-
-      it("batchLiquidateTroves(): skips if a trove has been closed", async () => {
-        await setupTroves()
-        await openTrove(contracts, {
-          musdAmount: "2000",
-          ICR: "200",
-          sender: carol.wallet,
-        })
-
-        // Send MUSD to Carol so she can close her trove
-        await contracts.musd
-          .connect(bob.wallet)
-          .transfer(carol.address, to1e18("1000"))
-
-        await contracts.borrowerOperations.connect(carol.wallet).closeTrove()
-
-        // Drop the price so Alice and Carol would be eligible for liquidation but not bob
-        await dropPrice(contracts, alice)
-        await contracts.troveManager.batchLiquidateTroves([
-          alice.wallet,
-          bob.wallet,
-          carol.wallet,
-        ])
-
-        // Check Carol's trove is closed by user
-        expect(await checkTroveStatus(contracts, carol, 2n, false)).to.equal(
-          true,
-        )
-
-        // Bob is active and Alice is closed by liquidation
-        expect(await checkTroveActive(contracts, bob)).to.equal(true)
-        expect(await checkTroveClosedByLiquidation(contracts, alice)).to.equal(
-          true,
-        )
-      })
-    })
-
-    /**
-     *
-     * Balance changes
-     *
-     */
-
-    context("Balance changes", () => {})
-
-    /**
-     *
-     * Fees
-     *
-     */
-
-    context("Fees", () => {})
-
-    /**
-     *
-     * State change in other contracts
-     *
-     */
-
-    context("State change in other contracts", () => {})
   })
 
   describe("getRedemptionHints()", () => {
-    /**
-     *
-     * Expected Reverts
-     *
-     */
-
-    context("Expected Reverts", () => {})
-
-    /**
-     *
-     * Emitted Events
-     *
-     */
-
-    context("Emitted Events", () => {})
-
-    /**
-     *
-     * System State Changes
-     *
-     */
-
-    context("System State Changes", () => {})
-
-    /**
-     *
-     * Individual Troves
-     *
-     */
-
-    context("Individual Troves", () => {
-      it("getRedemptionHints(): gets the address of the first Trove and the final ICR of the last Trove involved in a redemption", async () => {
-        // Open Troves for Alice and Bob
-        const { totalDebt, musdAmount, collateral } = await openTrove(
-          contracts,
-          {
-            musdAmount: "2100",
-            ICR: "310",
-            sender: alice.wallet,
-          },
-        )
-        await openTrove(contracts, {
-          musdAmount: "2000",
-          ICR: "290",
-          sender: bob.wallet,
-        })
-        await openTrove(contracts, {
-          musdAmount: "2000",
-          ICR: "250",
-          sender: carol.wallet,
-        })
-
-        await openTrove(contracts, {
-          musdAmount: "2000",
-          ICR: "120",
-          sender: dennis.wallet,
-        })
-
-        // Drop the price so that Dennis has an ICR below MCR, she should be untouched by redemptions
-        const price = await dropPrice(contracts, dennis)
-
-        await updateTroveSnapshots(
-          contracts,
-          [alice, bob, carol, dennis],
-          "before",
-        )
-
-        const partialRedemptionAmount = to1e18("100")
-        const redemptionAmount =
-          carol.trove.debt.before +
-          bob.trove.debt.before +
-          partialRedemptionAmount
-
-        const maxRedeemableMUSD =
-          totalDebt - musdAmount - partialRedemptionAmount + to1e18("200") // Partial redemption amount + 200 MUSD for gas comp
-        const netMUSDdebt = totalDebt - to1e18("200")
-        const newColl = collateral - to1e18(maxRedeemableMUSD) / price
-
-        const newDebt = netMUSDdebt - maxRedeemableMUSD
-        const compositeDebt = newDebt + to1e18("200")
-
-        const nominalICR = (newColl * to1e18("100")) / compositeDebt
-
-        const { firstRedemptionHint, partialRedemptionHintNICR } =
-          await contracts.hintHelpers.getRedemptionHints(
-            redemptionAmount,
-            price,
-            0,
-          )
-
-        expect(firstRedemptionHint).to.equal(carol.address)
-        expect(partialRedemptionHintNICR).to.equal(nominalICR)
+    it("gets the address of the first Trove and the final ICR of the last Trove involved in a redemption", async () => {
+      // Open Troves for Alice and Bob
+      const { totalDebt, musdAmount, collateral } = await openTrove(contracts, {
+        musdAmount: "2100",
+        ICR: "310",
+        sender: alice.wallet,
+      })
+      await openTrove(contracts, {
+        musdAmount: "2000",
+        ICR: "290",
+        sender: bob.wallet,
+      })
+      await openTrove(contracts, {
+        musdAmount: "2000",
+        ICR: "250",
+        sender: carol.wallet,
       })
 
-      it("getRedemptionHints(): returns 0 as partialRedemptionHintNICR when reaching _maxIterations", async () => {
-        // Open three troves
-        await openTrove(contracts, {
-          musdAmount: "25000",
-          ICR: "300",
-          sender: alice.wallet,
-        })
-        await openTrove(contracts, {
-          musdAmount: "15000",
-          ICR: "250",
-          sender: bob.wallet,
-        })
-        await openTrove(contracts, {
-          musdAmount: "5000",
-          ICR: "200",
-          sender: carol.wallet,
-        })
-
-        const price = await contracts.priceFeed.fetchPrice()
-
-        // Try to redeem 10k MUSD.  At least 2 iterations should be needed for total redemption of the given amount.
-        const { partialRedemptionHintNICR } =
-          await contracts.hintHelpers.getRedemptionHints(
-            to1e18("10,000"),
-            price,
-            1,
-          )
-
-        expect(partialRedemptionHintNICR).to.equal(0)
+      await openTrove(contracts, {
+        musdAmount: "2000",
+        ICR: "120",
+        sender: dennis.wallet,
       })
 
-      /**
-       *
-       * Balance changes
-       *
-       */
+      // Drop the price so that Dennis has an ICR below MCR, she should be untouched by redemptions
+      const price = await dropPrice(contracts, dennis)
 
-      context("Balance changes", () => {})
+      await updateTroveSnapshots(
+        contracts,
+        [alice, bob, carol, dennis],
+        "before",
+      )
 
-      /**
-       *
-       * Fees
-       *
-       */
+      const partialRedemptionAmount = to1e18("100")
+      const redemptionAmount =
+        carol.trove.debt.before +
+        bob.trove.debt.before +
+        partialRedemptionAmount
 
-      context("Fees", () => {})
+      const maxRedeemableMUSD =
+        totalDebt - musdAmount - partialRedemptionAmount + to1e18("200") // Partial redemption amount + 200 MUSD for gas comp
+      const netMUSDdebt = totalDebt - to1e18("200")
+      const newColl = collateral - to1e18(maxRedeemableMUSD) / price
 
-      /**
-       *
-       * State change in other contracts
-       *
-       */
+      const newDebt = netMUSDdebt - maxRedeemableMUSD
+      const compositeDebt = newDebt + to1e18("200")
 
-      context("State change in other contracts", () => {})
+      const nominalICR = (newColl * to1e18("100")) / compositeDebt
+
+      const { firstRedemptionHint, partialRedemptionHintNICR } =
+        await contracts.hintHelpers.getRedemptionHints(
+          redemptionAmount,
+          price,
+          0,
+        )
+
+      expect(firstRedemptionHint).to.equal(carol.address)
+      expect(partialRedemptionHintNICR).to.equal(nominalICR)
+    })
+
+    it("returns 0 as partialRedemptionHintNICR when reaching _maxIterations", async () => {
+      // Open three troves
+      await openTrove(contracts, {
+        musdAmount: "25000",
+        ICR: "300",
+        sender: alice.wallet,
+      })
+      await openTrove(contracts, {
+        musdAmount: "15000",
+        ICR: "250",
+        sender: bob.wallet,
+      })
+      await openTrove(contracts, {
+        musdAmount: "5000",
+        ICR: "200",
+        sender: carol.wallet,
+      })
+
+      const price = await contracts.priceFeed.fetchPrice()
+
+      // Try to redeem 10k MUSD.  At least 2 iterations should be needed for total redemption of the given amount.
+      const { partialRedemptionHintNICR } =
+        await contracts.hintHelpers.getRedemptionHints(
+          to1e18("10,000"),
+          price,
+          1,
+        )
+
+      expect(partialRedemptionHintNICR).to.equal(0)
     })
   })
 
@@ -1881,14 +1640,636 @@ describe("TroveManager in Normal Mode", () => {
         )
     }
 
-    /**
-     *
-     * Expected Reverts
-     *
-     */
+    it("ends the redemption sequence when the token redemption request has been filled", async () => {
+      await setupRedemptionTroves()
+
+      const redemptionAmount = to1e18("2010") // Redeem an amount equal to Alice's net debt
+
+      await contracts.troveManager
+        .connect(dennis.wallet)
+        .redeemCollateral(
+          redemptionAmount,
+          alice.address,
+          alice.address,
+          alice.address,
+          0,
+          0,
+          to1e18("1"),
+          NO_GAS,
+        )
+
+      await updateTroveSnapshots(
+        contracts,
+        [alice, bob, carol, dennis],
+        "after",
+      )
+
+      expect(alice.trove.debt.after).to.equal(0n)
+
+      const otherUsers = [bob, carol, dennis]
+
+      // Debt should remain unchanged for other troves
+      const debtChanges = await Promise.all(
+        otherUsers.map(
+          (user) => user.trove.debt.after - user.trove.debt.before === 0n,
+        ),
+      )
+      expect(debtChanges.every(Boolean)).to.equal(true)
+
+      // Other troves should still be active
+      const stillActive = await Promise.all(
+        otherUsers.map((user) => checkTroveActive(contracts, user)),
+      )
+      expect(stillActive.every(Boolean)).to.equal(true)
+
+      // Alice's trove should be closed by redemption
+      expect(await checkTroveClosedByRedemption(contracts, alice)).to.equal(
+        true,
+      )
+    })
+
+    it("ends the redemption sequence when max iterations have been reached", async () => {
+      await setupRedemptionTroves()
+
+      const redemptionAmount = to1e18("6030") // Redeem an amount equal to Alice, Bob, and Carol's net debt
+
+      await contracts.troveManager.connect(dennis.wallet).redeemCollateral(
+        redemptionAmount,
+        alice.address,
+        alice.address,
+        alice.address,
+        0,
+        2, // Max redemptions set to 2, so we will stop after Bob's trove
+        to1e18("1"),
+        NO_GAS,
+      )
+
+      await updateTroveSnapshots(
+        contracts,
+        [alice, bob, carol, dennis],
+        "after",
+      )
+
+      expect(alice.trove.debt.after).to.equal(0n)
+      expect(bob.trove.debt.after).to.equal(0n)
+
+      const otherUsers = [carol, dennis]
+
+      // Debt should remain unchanged for other troves
+      const debtChanges = await Promise.all(
+        otherUsers.map(
+          (user) => user.trove.debt.after - user.trove.debt.before === 0n,
+        ),
+      )
+      expect(debtChanges.every(Boolean)).to.equal(true)
+
+      // Other troves should still be active
+      const stillActive = await Promise.all(
+        otherUsers.map((user) => checkTroveActive(contracts, user)),
+      )
+      expect(stillActive.every(Boolean)).to.equal(true)
+
+      // Alice and Bob's troves should be closed by redemption
+      expect(await checkTroveClosedByRedemption(contracts, alice)).to.equal(
+        true,
+      )
+      expect(await checkTroveClosedByRedemption(contracts, bob)).to.equal(true)
+    })
+
+    it("performs partial redemption if resultant debt is > minimum net debt", async () => {
+      await setupRedemptionTroves()
+
+      const redemptionAmount = to1e18("4120") // Alice and Bob's net debt + 100 MUSD
+      await performRedemption(contracts, dennis, dennis, redemptionAmount)
+
+      // Check that Alice and Bob's troves are closed by redemption
+      expect(await checkTroveClosedByRedemption(contracts, alice)).to.equal(
+        true,
+      )
+      expect(await checkTroveClosedByRedemption(contracts, bob)).to.equal(true)
+
+      // Check that Carol's trove is still active
+      expect(await checkTroveActive(contracts, carol)).to.equal(true)
+
+      // Check that Carol's debt has been reduced by 100 MUSD because of the partial redemption
+      await updateTroveSnapshot(contracts, carol, "after")
+      expect(carol.trove.debt.after - carol.trove.debt.before).to.equal(
+        to1e18("-100"),
+      )
+    })
+
+    it("doesn't perform partial redemption if resultant debt would be < minimum net debt", async () => {
+      await setupRedemptionTroves()
+
+      // Alice and Bob's net debt + 300 MUSD.  A partial redemption of 300 MUSD would put Carol below minimum net debt
+      const redemptionAmount = to1e18("4320")
+
+      await performRedemption(contracts, dennis, dennis, redemptionAmount)
+
+      // Check that Alice and Bob's troves are closed by redemption
+      expect(await checkTroveClosedByRedemption(contracts, alice)).to.equal(
+        true,
+      )
+      expect(await checkTroveClosedByRedemption(contracts, bob)).to.equal(true)
+
+      // Check that Carol's trove is still active
+      expect(await checkTroveActive(contracts, carol)).to.equal(true)
+
+      // Check that Carol's debt is untouched because no partial redemption was performed
+      await updateTroveSnapshot(contracts, carol, "after")
+      expect(carol.trove.debt.after - carol.trove.debt.before).to.equal(0n)
+    })
+
+    it("doesnt perform the final partial redemption in the sequence if the hint is out-of-date", async () => {
+      await setupRedemptionTroves()
+
+      // Dennis plans to redeem Alice and Bob's troves, plus a partial redemption from Carol
+      const aliceAndBobNetDebt = to1e18("4020")
+      const partialRedemptionAmount = to1e18("100")
+
+      const redemptionAmount = aliceAndBobNetDebt + partialRedemptionAmount
+      const price = await contracts.priceFeed.fetchPrice()
+
+      // Calculate Dennis's hints
+      const {
+        firstRedemptionHint,
+        partialRedemptionHintNICR,
+        upperPartialRedemptionHint,
+        lowerPartialRedemptionHint,
+      } = await getRedemptionHints(contracts, dennis, redemptionAmount, price)
+
+      const {
+        firstRedemptionHint: f,
+        partialRedemptionHintNICR: p,
+        upperPartialRedemptionHint: u,
+        lowerPartialRedemptionHint: l,
+      } = await getRedemptionHints(contracts, dennis, to1e18("10"), price)
+
+      // Carol redeems 10 MUSD from Alice's trove ahead of Dennis's redemption
+      await contracts.troveManager
+        .connect(carol.wallet)
+        .redeemCollateral(to1e18("10"), f, u, l, p, 0, to1e18("1"), NO_GAS)
+
+      // Dennis tries to redeem with outdated hint
+      await contracts.troveManager
+        .connect(dennis.wallet)
+        .redeemCollateral(
+          redemptionAmount,
+          firstRedemptionHint,
+          upperPartialRedemptionHint,
+          lowerPartialRedemptionHint,
+          partialRedemptionHintNICR,
+          0,
+          to1e18("1"),
+          NO_GAS,
+        )
+
+      // Check that Carol's debt is untouched because no partial redemption was performed
+      await updateTroveSnapshot(contracts, carol, "after")
+      expect(carol.trove.debt.after - carol.trove.debt.before).to.equal(0n)
+    })
+
+    it("doesn't touch Troves with ICR < 110%", async () => {
+      await setupRedemptionTroves()
+
+      // Drop the price so that Alice's trove is below MCR
+      await dropPrice(contracts, alice)
+      const redemptionAmount = to1e18("100")
+
+      await performRedemption(contracts, dennis, dennis, redemptionAmount)
+
+      await updateTroveSnapshots(contracts, [alice], "after")
+
+      // Alice's trove should be untouched
+      expect(alice.trove.debt.after - alice.trove.debt.before).to.equal(0n)
+      expect(
+        alice.trove.collateral.after - alice.trove.collateral.before,
+      ).to.equal(0n)
+    })
+
+    it("finds the last Trove with ICR == 110% even if there is more than one", async () => {
+      // Open 3 troves with the same ICR
+      const users = [alice, bob, carol]
+
+      // Sum the total debt of all 3 troves
+      const sumTotalDebt = await users.reduce(async (acc, user) => {
+        const { totalDebt } = await openTrove(contracts, {
+          musdAmount: "2000",
+          ICR: "200",
+          sender: user.wallet,
+        })
+        return (await acc) + totalDebt
+      }, Promise.resolve(0n))
+
+      // Open a trove for Dennis with a slightly lower ICR
+      await openTrove(contracts, {
+        musdAmount: "20000",
+        ICR: "180",
+        sender: dennis.wallet,
+      })
+
+      // Open a trove for Eric that will keep us out of recovery mode
+      await openTrove(contracts, {
+        musdAmount: "20000",
+        ICR: "2000",
+        sender: eric.wallet,
+      })
+
+      await updateTroveSnapshot(contracts, dennis, "before")
+
+      // Drop price to put the first 3 troves at 110 ICR
+      await dropPrice(contracts, alice, to1e18("110"))
+
+      // Try to trick redeemCollateral with hint that doesn't point to the last Trove with ICR == 110
+      await contracts.troveManager.connect(dennis.wallet).redeemCollateral(
+        sumTotalDebt,
+        carol.address, // last trove with ICR == 110 should be Alice
+        "0x0000000000000000000000000000000000000000",
+        "0x0000000000000000000000000000000000000000",
+        0,
+        0,
+        to1e18("1"),
+        NO_GAS,
+      )
+
+      await updateTroveSnapshot(contracts, dennis, "after")
+
+      // Check that all Troves with ICR === 110 have been closed
+      const closedByRedemption = await Promise.all(
+        users.map((user) => checkTroveClosedByRedemption(contracts, user)),
+      )
+      expect(closedByRedemption.every(Boolean)).to.equal(true)
+
+      // Check that Dennis's trove has not been touched
+      expect(dennis.trove.debt.after).to.equal(dennis.trove.debt.before)
+    })
+
+    it("a full redemption (leaving trove with 0 debt), closes the trove", async () => {
+      await setupRedemptionTroves()
+      await performRedemption(contracts, dennis, dennis, to1e18("2010")) // Full redemption on Alice's trove
+      expect(await checkTroveClosedByRedemption(contracts, alice)).to.equal(
+        true,
+      )
+    })
+
+    it("cancels the provided MUSD with debt from Troves with the lowest ICRs and sends an equivalent amount of collateral", async () => {
+      await setupRedemptionTroves()
+
+      const redemptionAmount = to1e18("200")
+      const price = await contracts.priceFeed.fetchPrice()
+
+      const redemptionTx = await performRedemption(
+        contracts,
+        dennis,
+        dennis,
+        redemptionAmount,
+      )
+
+      await checkCollateralAndDebtValues(redemptionTx, redemptionAmount, price)
+    })
+
+    it("has the same functionality with invalid first hint, zero address", async () => {
+      await setupRedemptionTroves()
+
+      const redemptionAmount = to1e18("200")
+      const price = await contracts.priceFeed.fetchPrice()
+
+      const redemptionTx = await performRedemption(
+        contracts,
+        dennis,
+        dennis,
+        redemptionAmount,
+      )
+
+      await checkCollateralAndDebtValues(redemptionTx, redemptionAmount, price)
+    })
+
+    it("has the same functionality with invalid first hint, non-existent trove", async () => {
+      await setupRedemptionTroves()
+
+      const redemptionAmount = to1e18("200")
+      const price = await contracts.priceFeed.fetchPrice()
+
+      const {
+        partialRedemptionHintNICR,
+        upperPartialRedemptionHint,
+        lowerPartialRedemptionHint,
+      } = await getRedemptionHints(contracts, dennis, redemptionAmount, price)
+
+      const redemptionTx = await contracts.troveManager
+        .connect(dennis.wallet)
+        .redeemCollateral(
+          redemptionAmount,
+          eric.address, // Invalid first hint
+          upperPartialRedemptionHint,
+          lowerPartialRedemptionHint,
+          partialRedemptionHintNICR,
+          0,
+          to1e18("1"),
+          NO_GAS,
+        )
+
+      await checkCollateralAndDebtValues(redemptionTx, redemptionAmount, price)
+    })
+
+    it("has the same functionality with invalid first hint, trove below MCR", async () => {
+      await setupRedemptionTroves()
+
+      // Increase the price to start Eric
+      const price = await contracts.priceFeed.fetchPrice()
+      await contracts.mockAggregator.setPrice(price * 2n)
+      await openTrove(contracts, {
+        musdAmount: "5000",
+        ICR: "200",
+        sender: eric.wallet,
+      })
+
+      // Drop the price back to the initial price to put Eric below MCR
+      await contracts.mockAggregator.setPrice(price)
+
+      const redemptionAmount = to1e18("200")
+
+      const {
+        partialRedemptionHintNICR,
+        upperPartialRedemptionHint,
+        lowerPartialRedemptionHint,
+      } = await getRedemptionHints(contracts, dennis, redemptionAmount, price)
+
+      const redemptionTx = await contracts.troveManager
+        .connect(dennis.wallet)
+        .redeemCollateral(
+          redemptionAmount,
+          eric.address, // Invalid first hint, eric is below mcr
+          upperPartialRedemptionHint,
+          lowerPartialRedemptionHint,
+          partialRedemptionHintNICR,
+          0,
+          to1e18("1"),
+          NO_GAS,
+        )
+
+      await checkCollateralAndDebtValues(redemptionTx, redemptionAmount, price)
+    })
+
+    it("caller can redeem their entire MUSDToken balance", async () => {
+      await setupRedemptionTroves()
+      await updateWalletSnapshot(contracts, dennis, "before")
+
+      await performRedemption(contracts, dennis, dennis, dennis.musd.before)
+
+      await updateWalletSnapshot(contracts, dennis, "after")
+      expect(dennis.musd.after).to.equal(0n)
+    })
+
+    it("a redemption that closes a trove leaves the trove's collateral surplus (collateral - collateral drawn) available for the trove owner to claim", async () => {
+      await setupRedemptionTroves()
+
+      await updateTroveSnapshot(contracts, alice, "before")
+      await updateWalletSnapshot(contracts, alice, "before")
+
+      // Fully redeem Alice's trove
+      const redemptionAmount = to1e18("2010")
+      await performRedemption(contracts, dennis, dennis, redemptionAmount)
+
+      // Alice claims collateral surplus
+      await contracts.borrowerOperations
+        .connect(alice.wallet)
+        .claimCollateral({ gasPrice: 0 })
+
+      await updateWalletSnapshot(contracts, alice, "after")
+
+      // Alice's collateral surplus should be equal to the difference between the collateral needed to cancel her debt and her total collateral
+      const price = await contracts.priceFeed.fetchPrice()
+      const collNeeded = to1e18(redemptionAmount) / price
+
+      expect(
+        alice.btc.before + alice.trove.collateral.before - alice.btc.after,
+      ).to.be.closeTo(collNeeded, 1000n)
+    })
+
+    it("a redemption that closes a trove leaves the trove's collateral surplus available for the trove owner after re-opening trove", async () => {
+      await setupRedemptionTroves()
+
+      // Fully redeem Alice's trove
+      const redemptionAmount = to1e18("2010")
+
+      await updateTroveSnapshot(contracts, alice, "before")
+      const price = await contracts.priceFeed.fetchPrice()
+      const collNeeded = to1e18(redemptionAmount) / price
+      const collateralSurplus = alice.trove.collateral.before - collNeeded
+      await performRedemption(contracts, dennis, dennis, redemptionAmount)
+
+      // Open a new trove
+      await openTrove(contracts, {
+        musdAmount: "2000",
+        ICR: "200",
+        sender: alice.wallet,
+      })
+
+      await updateWalletSnapshot(contracts, alice, "before")
+
+      // Claim collateral surplus
+      await contracts.borrowerOperations
+        .connect(alice.wallet)
+        .claimCollateral({ gasPrice: 0 })
+
+      // Check that Alice's balance after is equal to her balance before claiming collateral plus the calculated surplus
+      await updateWalletSnapshot(contracts, alice, "after")
+      expect(alice.btc.after).to.equal(alice.btc.before + collateralSurplus)
+    })
+
+    it("succeeds if fee is less than max fee percentage", async () => {
+      // Open identical troves for everyone but Dennis
+      const users = [alice, bob, carol, dennis]
+      await Promise.all(
+        users.slice(0, -1).map((user) =>
+          openTrove(contracts, {
+            musdAmount: "20000",
+            ICR: "200",
+            sender: user.wallet,
+          }),
+        ),
+      )
+
+      // Open a trove for Dennis with slightly lower ICR
+      await openTrove(contracts, {
+        musdAmount: "40000",
+        ICR: "195",
+        sender: dennis.wallet,
+      })
+
+      // Calculate the fee for redeeming 1/10 of the total supply
+      const totalSupply = await contracts.musd.totalSupply()
+      const attemptedRedemptionAmount = totalSupply / 10n
+      const price = await contracts.priceFeed.fetchPrice()
+      const collNeeded = to1e18(attemptedRedemptionAmount) / price
+      const fee =
+        await contracts.troveManager.getRedemptionFeeWithDecay(collNeeded)
+      const baseRate = await contracts.troveManager.baseRate()
+      const feePercentage = (to1e18(fee) / collNeeded) * 1000n + baseRate
+      const feePercentageNumber = Number(feePercentage) / Number(1e18)
+
+      // Attempt to redeem with a fee 1% more than the calculated fee
+      const redemptionTx = await redeemWithFee(
+        feePercentageNumber + 1,
+        attemptedRedemptionAmount,
+      )
+      const receipt = await redemptionTx.wait()
+
+      // Check that the redemption succeeded
+      expect(receipt?.status).to.equal(1)
+    })
+
+    it("a redemption made when base rate is zero increases the base rate", async () => {
+      await setupRedemptionTroves()
+
+      await setBaseRate(contracts, to1e18("0"))
+
+      await performRedemption(contracts, dennis, dennis, to1e18("100"))
+
+      expect(await contracts.troveManager.baseRate()).to.be.gt(0)
+    })
+
+    it("a redemption made when base rate is non-zero increases the base rate, for negligible time passed", async () => {
+      await setupRedemptionTroves()
+
+      const initialBaseRate = to1e18("0.1")
+      await setBaseRate(contracts, initialBaseRate)
+
+      await performRedemption(contracts, dennis, dennis, to1e18("100"))
+
+      expect(await contracts.troveManager.baseRate()).to.be.gt(initialBaseRate)
+    })
+
+    it("lastFeeOpTime doesn't update if less time than decay interval has passed since the last fee operation", async () => {
+      await setupRedemptionTroves()
+
+      const initialBaseRate = to1e18("0.1")
+      await setBaseRate(contracts, initialBaseRate)
+
+      await performRedemption(contracts, dennis, dennis, to1e18("100"))
+
+      const lastFeeOpTime = await contracts.troveManager.lastFeeOperationTime()
+      await fastForwardTime(45)
+      await performRedemption(contracts, dennis, dennis, to1e18("100"))
+
+      expect(await contracts.troveManager.lastFeeOperationTime()).to.equal(
+        lastFeeOpTime,
+      )
+    })
+
+    it("a redemption made at zero base rate sends a non-zero CollateralFee to PCV contract", async () => {
+      await setBaseRate(contracts, to1e18("0"))
+
+      await setupRedemptionTroves()
+
+      await performRedemption(contracts, dennis, dennis, to1e18("100"))
+      await updatePCVSnapshot(contracts, state, "after")
+
+      expect(state.pcv.collateral.after).to.be.greaterThan(0n)
+    })
+
+    it("a redemption made at non-zero base rate sends a non-zero CollateralFee to PCV contract", async () => {
+      await setBaseRate(contracts, to1e18("0.1"))
+
+      await setupRedemptionTroves()
+
+      await performRedemption(contracts, dennis, dennis, to1e18("100"))
+      await updatePCVSnapshot(contracts, state, "after")
+
+      expect(state.pcv.collateral.after).to.be.greaterThan(0n)
+    })
+
+    it("a redemption made at zero base increases the collateral-fees in PCV contract", async () => {
+      await setBaseRate(contracts, to1e18("0"))
+
+      await setupRedemptionTroves()
+      await updatePCVSnapshot(contracts, state, "before")
+
+      await performRedemption(contracts, dennis, dennis, to1e18("100"))
+      await updatePCVSnapshot(contracts, state, "after")
+
+      expect(state.pcv.collateral.after).to.be.greaterThan(
+        state.pcv.collateral.before,
+      )
+    })
+
+    it("a redemption sends the collateral remainder (CollateralDrawn - CollateralFee) to the redeemer", async () => {
+      await setupRedemptionTroves()
+
+      await updateWalletSnapshot(contracts, dennis, "before")
+      const redemptionAmount = to1e18("100")
+      const redemptionTx = await performRedemption(
+        contracts,
+        dennis,
+        dennis,
+        redemptionAmount,
+      )
+
+      const { collateralSent, collateralFee } =
+        await getEmittedRedemptionValues(redemptionTx)
+
+      const remainder = collateralSent - collateralFee
+
+      await updateWalletSnapshot(contracts, dennis, "after")
+      expect(dennis.btc.after - dennis.btc.before).to.equal(remainder)
+    })
+
+    it("doesn't affect the Stability Pool deposits or collateral gain of redeemed-from troves", async () => {
+      await setupRedemptionTroves()
+
+      // Deposit to stability pool
+      await provideToSP(contracts, bob, to1e18("1000"))
+
+      // Liquidate Alice
+      await dropPriceAndLiquidate(contracts, alice)
+      await updateStabilityPoolUserSnapshot(contracts, bob, "before")
+
+      // Redeem collateral from Bob's trove
+      await performRedemption(contracts, dennis, dennis, to1e18("100"))
+
+      // Check that the Stability Pool deposits and collateral gain are unchanged
+      await updateStabilityPoolUserSnapshot(contracts, bob, "after")
+      expect(bob.stabilityPool.collateralGain.after).to.equal(
+        bob.stabilityPool.collateralGain.before,
+      )
+      expect(bob.stabilityPool.compoundedDeposit.after).to.equal(
+        bob.stabilityPool.compoundedDeposit.before,
+      )
+    })
+
+    it("value of issued collateral == face value of redeemed MUSD (assuming 1 MUSD has value of $1)", async () => {
+      await setupRedemptionTroves()
+
+      await updateContractsSnapshot(
+        contracts,
+        state,
+        "activePool",
+        "before",
+        addresses,
+      )
+
+      const redemptionAmount = to1e18("100")
+      await performRedemption(contracts, dennis, dennis, redemptionAmount)
+
+      const price = await contracts.priceFeed.fetchPrice()
+      const collNeeded = to1e18(redemptionAmount) / price
+
+      await updateContractsSnapshot(
+        contracts,
+        state,
+        "activePool",
+        "after",
+        addresses,
+      )
+
+      expect(
+        state.activePool.collateral.before - state.activePool.collateral.after,
+      ).to.equal(collNeeded)
+    })
 
     context("Expected Reverts", () => {
-      it("redeemCollateral(): reverts when TCR < MCR", async () => {
+      it("reverts when TCR < MCR", async () => {
         const users = [alice, bob, carol, dennis]
         await Promise.all(
           users.slice(0, -1).map((user) =>
@@ -1916,7 +2297,7 @@ describe("TroveManager in Normal Mode", () => {
         ).to.be.revertedWith("TroveManager: Cannot redeem when TCR < MCR")
       })
 
-      it("redeemCollateral(): reverts when argument _amount is 0", async () => {
+      it("reverts when argument _amount is 0", async () => {
         await setupRedemptionTroves()
 
         await expect(
@@ -1924,7 +2305,7 @@ describe("TroveManager in Normal Mode", () => {
         ).to.be.revertedWith("TroveManager: Amount must be greater than zero")
       })
 
-      it("redeemCollateral(): reverts if max fee > 100%", async () => {
+      it("reverts if max fee > 100%", async () => {
         await setupRedemptionTroves()
 
         await expect(redeemWithFee(101)).to.be.revertedWith(
@@ -1932,7 +2313,7 @@ describe("TroveManager in Normal Mode", () => {
         )
       })
 
-      it("redeemCollateral(): reverts if max fee < 0.5%", async () => {
+      it("reverts if max fee < 0.5%", async () => {
         await setupRedemptionTroves()
 
         await expect(redeemWithFee(0.49)).to.be.revertedWith(
@@ -1940,7 +2321,7 @@ describe("TroveManager in Normal Mode", () => {
         )
       })
 
-      it("redeemCollateral(): reverts if fee exceeds max fee percentage", async () => {
+      it("reverts if fee exceeds max fee percentage", async () => {
         // Open identical troves for everyone but Dennis
         const users = [alice, bob, carol, dennis]
         await Promise.all(
@@ -1978,7 +2359,7 @@ describe("TroveManager in Normal Mode", () => {
         ).to.be.revertedWith("Fee exceeded provided maximum")
       })
 
-      it("redeemCollateral(): reverts when requested redemption amount exceeds caller's MUSD token balance", async () => {
+      it("reverts when requested redemption amount exceeds caller's MUSD token balance", async () => {
         await setupRedemptionTroves()
         await updateWalletSnapshot(contracts, dennis, "before")
 
@@ -1989,7 +2370,7 @@ describe("TroveManager in Normal Mode", () => {
         )
       })
 
-      it.skip("redeemCollateral(): reverts if caller tries to redeem more than the outstanding system debt", async () => {
+      it.skip("reverts if caller tries to redeem more than the outstanding system debt", async () => {
         /*
          This test reverts but not for the reason expected.  Instead, it says there is only one trove left.
          It also seems like this could be simplified by just grabbing the total debt of the system
@@ -2042,7 +2423,7 @@ describe("TroveManager in Normal Mode", () => {
         }
       })
 
-      it("redeemCollateral(): reverts if fee eats up all returned collateral", async () => {
+      it("reverts if fee eats up all returned collateral", async () => {
         await setupRedemptionTroves()
         await updateTroveSnapshot(contracts, alice, "before")
 
@@ -2058,14 +2439,8 @@ describe("TroveManager in Normal Mode", () => {
       })
     })
 
-    /**
-     *
-     * Emitted Events
-     *
-     */
-
     context("Emitted Events", () => {
-      it("redeemCollateral(): emits correct debt and coll values in each redeemed trove's TroveUpdated event", async () => {
+      it("emits correct debt and coll values in each redeemed trove's TroveUpdated event", async () => {
         await setupRedemptionTroves()
         await updateTroveSnapshot(contracts, bob, "before")
 
@@ -2106,704 +2481,10 @@ describe("TroveManager in Normal Mode", () => {
         expect(bobColl).to.equal(bob.trove.collateral.before - collNeeded)
       })
     })
-
-    /**
-     *
-     * System State Changes
-     *
-     */
-
-    context("System State Changes", () => {})
-
-    /**
-     *
-     * Individual Troves
-     *
-     */
-
-    context("Individual Troves", () => {
-      it("redeemCollateral(): ends the redemption sequence when the token redemption request has been filled", async () => {
-        await setupRedemptionTroves()
-
-        const redemptionAmount = to1e18("2010") // Redeem an amount equal to Alice's net debt
-
-        await contracts.troveManager
-          .connect(dennis.wallet)
-          .redeemCollateral(
-            redemptionAmount,
-            alice.address,
-            alice.address,
-            alice.address,
-            0,
-            0,
-            to1e18("1"),
-            NO_GAS,
-          )
-
-        await updateTroveSnapshots(
-          contracts,
-          [alice, bob, carol, dennis],
-          "after",
-        )
-
-        expect(alice.trove.debt.after).to.equal(0n)
-
-        const otherUsers = [bob, carol, dennis]
-
-        // Debt should remain unchanged for other troves
-        const debtChanges = await Promise.all(
-          otherUsers.map(
-            (user) => user.trove.debt.after - user.trove.debt.before === 0n,
-          ),
-        )
-        expect(debtChanges.every(Boolean)).to.equal(true)
-
-        // Other troves should still be active
-        const stillActive = await Promise.all(
-          otherUsers.map((user) => checkTroveActive(contracts, user)),
-        )
-        expect(stillActive.every(Boolean)).to.equal(true)
-
-        // Alice's trove should be closed by redemption
-        expect(await checkTroveClosedByRedemption(contracts, alice)).to.equal(
-          true,
-        )
-      })
-
-      it("redeemCollateral(): ends the redemption sequence when max iterations have been reached", async () => {
-        await setupRedemptionTroves()
-
-        const redemptionAmount = to1e18("6030") // Redeem an amount equal to Alice, Bob, and Carol's net debt
-
-        await contracts.troveManager.connect(dennis.wallet).redeemCollateral(
-          redemptionAmount,
-          alice.address,
-          alice.address,
-          alice.address,
-          0,
-          2, // Max redemptions set to 2, so we will stop after Bob's trove
-          to1e18("1"),
-          NO_GAS,
-        )
-
-        await updateTroveSnapshots(
-          contracts,
-          [alice, bob, carol, dennis],
-          "after",
-        )
-
-        expect(alice.trove.debt.after).to.equal(0n)
-        expect(bob.trove.debt.after).to.equal(0n)
-
-        const otherUsers = [carol, dennis]
-
-        // Debt should remain unchanged for other troves
-        const debtChanges = await Promise.all(
-          otherUsers.map(
-            (user) => user.trove.debt.after - user.trove.debt.before === 0n,
-          ),
-        )
-        expect(debtChanges.every(Boolean)).to.equal(true)
-
-        // Other troves should still be active
-        const stillActive = await Promise.all(
-          otherUsers.map((user) => checkTroveActive(contracts, user)),
-        )
-        expect(stillActive.every(Boolean)).to.equal(true)
-
-        // Alice and Bob's troves should be closed by redemption
-        expect(await checkTroveClosedByRedemption(contracts, alice)).to.equal(
-          true,
-        )
-        expect(await checkTroveClosedByRedemption(contracts, bob)).to.equal(
-          true,
-        )
-      })
-
-      it("redeemCollateral(): performs partial redemption if resultant debt is > minimum net debt", async () => {
-        await setupRedemptionTroves()
-
-        const redemptionAmount = to1e18("4120") // Alice and Bob's net debt + 100 MUSD
-        await performRedemption(contracts, dennis, dennis, redemptionAmount)
-
-        // Check that Alice and Bob's troves are closed by redemption
-        expect(await checkTroveClosedByRedemption(contracts, alice)).to.equal(
-          true,
-        )
-        expect(await checkTroveClosedByRedemption(contracts, bob)).to.equal(
-          true,
-        )
-
-        // Check that Carol's trove is still active
-        expect(await checkTroveActive(contracts, carol)).to.equal(true)
-
-        // Check that Carol's debt has been reduced by 100 MUSD because of the partial redemption
-        await updateTroveSnapshot(contracts, carol, "after")
-        expect(carol.trove.debt.after - carol.trove.debt.before).to.equal(
-          to1e18("-100"),
-        )
-      })
-
-      it("redeemCollateral(): doesn't perform partial redemption if resultant debt would be < minimum net debt", async () => {
-        await setupRedemptionTroves()
-
-        // Alice and Bob's net debt + 300 MUSD.  A partial redemption of 300 MUSD would put Carol below minimum net debt
-        const redemptionAmount = to1e18("4320")
-
-        await performRedemption(contracts, dennis, dennis, redemptionAmount)
-
-        // Check that Alice and Bob's troves are closed by redemption
-        expect(await checkTroveClosedByRedemption(contracts, alice)).to.equal(
-          true,
-        )
-        expect(await checkTroveClosedByRedemption(contracts, bob)).to.equal(
-          true,
-        )
-
-        // Check that Carol's trove is still active
-        expect(await checkTroveActive(contracts, carol)).to.equal(true)
-
-        // Check that Carol's debt is untouched because no partial redemption was performed
-        await updateTroveSnapshot(contracts, carol, "after")
-        expect(carol.trove.debt.after - carol.trove.debt.before).to.equal(0n)
-      })
-
-      it("redeemCollateral(): doesnt perform the final partial redemption in the sequence if the hint is out-of-date", async () => {
-        await setupRedemptionTroves()
-
-        // Dennis plans to redeem Alice and Bob's troves, plus a partial redemption from Carol
-        const aliceAndBobNetDebt = to1e18("4020")
-        const partialRedemptionAmount = to1e18("100")
-
-        const redemptionAmount = aliceAndBobNetDebt + partialRedemptionAmount
-        const price = await contracts.priceFeed.fetchPrice()
-
-        // Calculate Dennis's hints
-        const {
-          firstRedemptionHint,
-          partialRedemptionHintNICR,
-          upperPartialRedemptionHint,
-          lowerPartialRedemptionHint,
-        } = await getRedemptionHints(contracts, dennis, redemptionAmount, price)
-
-        const {
-          firstRedemptionHint: f,
-          partialRedemptionHintNICR: p,
-          upperPartialRedemptionHint: u,
-          lowerPartialRedemptionHint: l,
-        } = await getRedemptionHints(contracts, dennis, to1e18("10"), price)
-
-        // Carol redeems 10 MUSD from Alice's trove ahead of Dennis's redemption
-        await contracts.troveManager
-          .connect(carol.wallet)
-          .redeemCollateral(to1e18("10"), f, u, l, p, 0, to1e18("1"), NO_GAS)
-
-        // Dennis tries to redeem with outdated hint
-        await contracts.troveManager
-          .connect(dennis.wallet)
-          .redeemCollateral(
-            redemptionAmount,
-            firstRedemptionHint,
-            upperPartialRedemptionHint,
-            lowerPartialRedemptionHint,
-            partialRedemptionHintNICR,
-            0,
-            to1e18("1"),
-            NO_GAS,
-          )
-
-        // Check that Carol's debt is untouched because no partial redemption was performed
-        await updateTroveSnapshot(contracts, carol, "after")
-        expect(carol.trove.debt.after - carol.trove.debt.before).to.equal(0n)
-      })
-
-      it("redeemCollateral(): doesn't touch Troves with ICR < 110%", async () => {
-        await setupRedemptionTroves()
-
-        // Drop the price so that Alice's trove is below MCR
-        await dropPrice(contracts, alice)
-        const redemptionAmount = to1e18("100")
-
-        await performRedemption(contracts, dennis, dennis, redemptionAmount)
-
-        await updateTroveSnapshots(contracts, [alice], "after")
-
-        // Alice's trove should be untouched
-        expect(alice.trove.debt.after - alice.trove.debt.before).to.equal(0n)
-        expect(
-          alice.trove.collateral.after - alice.trove.collateral.before,
-        ).to.equal(0n)
-      })
-
-      it("redeemCollateral(): finds the last Trove with ICR == 110% even if there is more than one", async () => {
-        // Open 3 troves with the same ICR
-        const users = [alice, bob, carol]
-
-        // Sum the total debt of all 3 troves
-        const sumTotalDebt = await users.reduce(async (acc, user) => {
-          const { totalDebt } = await openTrove(contracts, {
-            musdAmount: "2000",
-            ICR: "200",
-            sender: user.wallet,
-          })
-          return (await acc) + totalDebt
-        }, Promise.resolve(0n))
-
-        // Open a trove for Dennis with a slightly lower ICR
-        await openTrove(contracts, {
-          musdAmount: "20000",
-          ICR: "180",
-          sender: dennis.wallet,
-        })
-
-        // Open a trove for Eric that will keep us out of recovery mode
-        await openTrove(contracts, {
-          musdAmount: "20000",
-          ICR: "2000",
-          sender: eric.wallet,
-        })
-
-        await updateTroveSnapshot(contracts, dennis, "before")
-
-        // Drop price to put the first 3 troves at 110 ICR
-        await dropPrice(contracts, alice, to1e18("110"))
-
-        // Try to trick redeemCollateral with hint that doesn't point to the last Trove with ICR == 110
-        await contracts.troveManager.connect(dennis.wallet).redeemCollateral(
-          sumTotalDebt,
-          carol.address, // last trove with ICR == 110 should be Alice
-          "0x0000000000000000000000000000000000000000",
-          "0x0000000000000000000000000000000000000000",
-          0,
-          0,
-          to1e18("1"),
-          NO_GAS,
-        )
-
-        await updateTroveSnapshot(contracts, dennis, "after")
-
-        // Check that all Troves with ICR === 110 have been closed
-        const closedByRedemption = await Promise.all(
-          users.map((user) => checkTroveClosedByRedemption(contracts, user)),
-        )
-        expect(closedByRedemption.every(Boolean)).to.equal(true)
-
-        // Check that Dennis's trove has not been touched
-        expect(dennis.trove.debt.after).to.equal(dennis.trove.debt.before)
-      })
-
-      it("redeemCollateral(): a full redemption (leaving trove with 0 debt), closes the trove", async () => {
-        await setupRedemptionTroves()
-        await performRedemption(contracts, dennis, dennis, to1e18("2010")) // Full redemption on Alice's trove
-        expect(await checkTroveClosedByRedemption(contracts, alice)).to.equal(
-          true,
-        )
-      })
-    })
-
-    /**
-     *
-     * Balance changes
-     *
-     */
-
-    context("Balance changes", () => {
-      it("redeemCollateral(): cancels the provided MUSD with debt from Troves with the lowest ICRs and sends an equivalent amount of collateral", async () => {
-        await setupRedemptionTroves()
-
-        const redemptionAmount = to1e18("200")
-        const price = await contracts.priceFeed.fetchPrice()
-
-        const redemptionTx = await performRedemption(
-          contracts,
-          dennis,
-          dennis,
-          redemptionAmount,
-        )
-
-        await checkCollateralAndDebtValues(
-          redemptionTx,
-          redemptionAmount,
-          price,
-        )
-      })
-
-      it("redeemCollateral(): has the same functionality with invalid first hint, zero address", async () => {
-        await setupRedemptionTroves()
-
-        const redemptionAmount = to1e18("200")
-        const price = await contracts.priceFeed.fetchPrice()
-
-        const redemptionTx = await performRedemption(
-          contracts,
-          dennis,
-          dennis,
-          redemptionAmount,
-        )
-
-        await checkCollateralAndDebtValues(
-          redemptionTx,
-          redemptionAmount,
-          price,
-        )
-      })
-
-      it("redeemCollateral(): has the same functionality with invalid first hint, non-existent trove", async () => {
-        await setupRedemptionTroves()
-
-        const redemptionAmount = to1e18("200")
-        const price = await contracts.priceFeed.fetchPrice()
-
-        const {
-          partialRedemptionHintNICR,
-          upperPartialRedemptionHint,
-          lowerPartialRedemptionHint,
-        } = await getRedemptionHints(contracts, dennis, redemptionAmount, price)
-
-        const redemptionTx = await contracts.troveManager
-          .connect(dennis.wallet)
-          .redeemCollateral(
-            redemptionAmount,
-            eric.address, // Invalid first hint
-            upperPartialRedemptionHint,
-            lowerPartialRedemptionHint,
-            partialRedemptionHintNICR,
-            0,
-            to1e18("1"),
-            NO_GAS,
-          )
-
-        await checkCollateralAndDebtValues(
-          redemptionTx,
-          redemptionAmount,
-          price,
-        )
-      })
-
-      it("redeemCollateral(): has the same functionality with invalid first hint, trove below MCR", async () => {
-        await setupRedemptionTroves()
-
-        // Increase the price to start Eric
-        const price = await contracts.priceFeed.fetchPrice()
-        await contracts.mockAggregator.setPrice(price * 2n)
-        await openTrove(contracts, {
-          musdAmount: "5000",
-          ICR: "200",
-          sender: eric.wallet,
-        })
-
-        // Drop the price back to the initial price to put Eric below MCR
-        await contracts.mockAggregator.setPrice(price)
-
-        const redemptionAmount = to1e18("200")
-
-        const {
-          partialRedemptionHintNICR,
-          upperPartialRedemptionHint,
-          lowerPartialRedemptionHint,
-        } = await getRedemptionHints(contracts, dennis, redemptionAmount, price)
-
-        const redemptionTx = await contracts.troveManager
-          .connect(dennis.wallet)
-          .redeemCollateral(
-            redemptionAmount,
-            eric.address, // Invalid first hint, eric is below mcr
-            upperPartialRedemptionHint,
-            lowerPartialRedemptionHint,
-            partialRedemptionHintNICR,
-            0,
-            to1e18("1"),
-            NO_GAS,
-          )
-
-        await checkCollateralAndDebtValues(
-          redemptionTx,
-          redemptionAmount,
-          price,
-        )
-      })
-
-      it("redeemCollateral(): caller can redeem their entire MUSDToken balance", async () => {
-        await setupRedemptionTroves()
-        await updateWalletSnapshot(contracts, dennis, "before")
-
-        await performRedemption(contracts, dennis, dennis, dennis.musd.before)
-
-        await updateWalletSnapshot(contracts, dennis, "after")
-        expect(dennis.musd.after).to.equal(0n)
-      })
-
-      it("redeemCollateral(): a redemption that closes a trove leaves the trove's collateral surplus (collateral - collateral drawn) available for the trove owner to claim", async () => {
-        await setupRedemptionTroves()
-
-        await updateTroveSnapshot(contracts, alice, "before")
-        await updateWalletSnapshot(contracts, alice, "before")
-
-        // Fully redeem Alice's trove
-        const redemptionAmount = to1e18("2010")
-        await performRedemption(contracts, dennis, dennis, redemptionAmount)
-
-        // Alice claims collateral surplus
-        await contracts.borrowerOperations
-          .connect(alice.wallet)
-          .claimCollateral({ gasPrice: 0 })
-
-        await updateWalletSnapshot(contracts, alice, "after")
-
-        // Alice's collateral surplus should be equal to the difference between the collateral needed to cancel her debt and her total collateral
-        const price = await contracts.priceFeed.fetchPrice()
-        const collNeeded = to1e18(redemptionAmount) / price
-
-        expect(
-          alice.btc.before + alice.trove.collateral.before - alice.btc.after,
-        ).to.be.closeTo(collNeeded, 1000n)
-      })
-
-      it("redeemCollateral(): a redemption that closes a trove leaves the trove's collateral surplus available for the trove owner after re-opening trove", async () => {
-        await setupRedemptionTroves()
-
-        // Fully redeem Alice's trove
-        const redemptionAmount = to1e18("2010")
-
-        await updateTroveSnapshot(contracts, alice, "before")
-        const price = await contracts.priceFeed.fetchPrice()
-        const collNeeded = to1e18(redemptionAmount) / price
-        const collateralSurplus = alice.trove.collateral.before - collNeeded
-        await performRedemption(contracts, dennis, dennis, redemptionAmount)
-
-        // Open a new trove
-        await openTrove(contracts, {
-          musdAmount: "2000",
-          ICR: "200",
-          sender: alice.wallet,
-        })
-
-        await updateWalletSnapshot(contracts, alice, "before")
-
-        // Claim collateral surplus
-        await contracts.borrowerOperations
-          .connect(alice.wallet)
-          .claimCollateral({ gasPrice: 0 })
-
-        // Check that Alice's balance after is equal to her balance before claiming collateral plus the calculated surplus
-        await updateWalletSnapshot(contracts, alice, "after")
-        expect(alice.btc.after).to.equal(alice.btc.before + collateralSurplus)
-      })
-    })
-
-    /**
-     *
-     * Fees
-     *
-     */
-
-    context("Fees", () => {
-      it("redeemCollateral(): succeeds if fee is less than max fee percentage", async () => {
-        // Open identical troves for everyone but Dennis
-        const users = [alice, bob, carol, dennis]
-        await Promise.all(
-          users.slice(0, -1).map((user) =>
-            openTrove(contracts, {
-              musdAmount: "20000",
-              ICR: "200",
-              sender: user.wallet,
-            }),
-          ),
-        )
-
-        // Open a trove for Dennis with slightly lower ICR
-        await openTrove(contracts, {
-          musdAmount: "40000",
-          ICR: "195",
-          sender: dennis.wallet,
-        })
-
-        // Calculate the fee for redeeming 1/10 of the total supply
-        const totalSupply = await contracts.musd.totalSupply()
-        const attemptedRedemptionAmount = totalSupply / 10n
-        const price = await contracts.priceFeed.fetchPrice()
-        const collNeeded = to1e18(attemptedRedemptionAmount) / price
-        const fee =
-          await contracts.troveManager.getRedemptionFeeWithDecay(collNeeded)
-        const baseRate = await contracts.troveManager.baseRate()
-        const feePercentage = (to1e18(fee) / collNeeded) * 1000n + baseRate
-        const feePercentageNumber = Number(feePercentage) / Number(1e18)
-
-        // Attempt to redeem with a fee 1% more than the calculated fee
-        const redemptionTx = await redeemWithFee(
-          feePercentageNumber + 1,
-          attemptedRedemptionAmount,
-        )
-        const receipt = await redemptionTx.wait()
-
-        // Check that the redemption succeeded
-        expect(receipt?.status).to.equal(1)
-      })
-
-      it("redeemCollateral(): a redemption made when base rate is zero increases the base rate", async () => {
-        await setupRedemptionTroves()
-
-        await setBaseRate(contracts, to1e18("0"))
-
-        await performRedemption(contracts, dennis, dennis, to1e18("100"))
-
-        expect(await contracts.troveManager.baseRate()).to.be.gt(0)
-      })
-
-      it("redeemCollateral(): a redemption made when base rate is non-zero increases the base rate, for negligible time passed", async () => {
-        await setupRedemptionTroves()
-
-        const initialBaseRate = to1e18("0.1")
-        await setBaseRate(contracts, initialBaseRate)
-
-        await performRedemption(contracts, dennis, dennis, to1e18("100"))
-
-        expect(await contracts.troveManager.baseRate()).to.be.gt(
-          initialBaseRate,
-        )
-      })
-
-      it("redeemCollateral(): lastFeeOpTime doesn't update if less time than decay interval has passed since the last fee operation", async () => {
-        await setupRedemptionTroves()
-
-        const initialBaseRate = to1e18("0.1")
-        await setBaseRate(contracts, initialBaseRate)
-
-        await performRedemption(contracts, dennis, dennis, to1e18("100"))
-
-        const lastFeeOpTime =
-          await contracts.troveManager.lastFeeOperationTime()
-        await fastForwardTime(45)
-        await performRedemption(contracts, dennis, dennis, to1e18("100"))
-
-        expect(await contracts.troveManager.lastFeeOperationTime()).to.equal(
-          lastFeeOpTime,
-        )
-      })
-
-      it("redeemCollateral(): a redemption made at zero base rate sends a non-zero CollateralFee to PCV contract", async () => {
-        await setBaseRate(contracts, to1e18("0"))
-
-        await setupRedemptionTroves()
-
-        await performRedemption(contracts, dennis, dennis, to1e18("100"))
-        await updatePCVSnapshot(contracts, state, "after")
-
-        expect(state.pcv.collateral.after).to.be.greaterThan(0n)
-      })
-
-      it("redeemCollateral(): a redemption made at non-zero base rate sends a non-zero CollateralFee to PCV contract", async () => {
-        await setBaseRate(contracts, to1e18("0.1"))
-
-        await setupRedemptionTroves()
-
-        await performRedemption(contracts, dennis, dennis, to1e18("100"))
-        await updatePCVSnapshot(contracts, state, "after")
-
-        expect(state.pcv.collateral.after).to.be.greaterThan(0n)
-      })
-
-      it("redeemCollateral(): a redemption made at zero base increases the collateral-fees in PCV contract", async () => {
-        await setBaseRate(contracts, to1e18("0"))
-
-        await setupRedemptionTroves()
-        await updatePCVSnapshot(contracts, state, "before")
-
-        await performRedemption(contracts, dennis, dennis, to1e18("100"))
-        await updatePCVSnapshot(contracts, state, "after")
-
-        expect(state.pcv.collateral.after).to.be.greaterThan(
-          state.pcv.collateral.before,
-        )
-      })
-
-      it("redeemCollateral(): a redemption sends the collateral remainder (CollateralDrawn - CollateralFee) to the redeemer", async () => {
-        await setupRedemptionTroves()
-
-        await updateWalletSnapshot(contracts, dennis, "before")
-        const redemptionAmount = to1e18("100")
-        const redemptionTx = await performRedemption(
-          contracts,
-          dennis,
-          dennis,
-          redemptionAmount,
-        )
-
-        const { collateralSent, collateralFee } =
-          await getEmittedRedemptionValues(redemptionTx)
-
-        const remainder = collateralSent - collateralFee
-
-        await updateWalletSnapshot(contracts, dennis, "after")
-        expect(dennis.btc.after - dennis.btc.before).to.equal(remainder)
-      })
-    })
-
-    /**
-     *
-     * State change in other contracts
-     *
-     */
-
-    context("State change in other contracts", () => {
-      it("redeemCollateral(): doesn't affect the Stability Pool deposits or collateral gain of redeemed-from troves", async () => {
-        await setupRedemptionTroves()
-
-        // Deposit to stability pool
-        await provideToSP(contracts, bob, to1e18("1000"))
-
-        // Liquidate Alice
-        await dropPriceAndLiquidate(contracts, alice)
-        await updateStabilityPoolUserSnapshot(contracts, bob, "before")
-
-        // Redeem collateral from Bob's trove
-        await performRedemption(contracts, dennis, dennis, to1e18("100"))
-
-        // Check that the Stability Pool deposits and collateral gain are unchanged
-        await updateStabilityPoolUserSnapshot(contracts, bob, "after")
-        expect(bob.stabilityPool.collateralGain.after).to.equal(
-          bob.stabilityPool.collateralGain.before,
-        )
-        expect(bob.stabilityPool.compoundedDeposit.after).to.equal(
-          bob.stabilityPool.compoundedDeposit.before,
-        )
-      })
-
-      it("redeemCollateral(): value of issued collateral == face value of redeemed MUSD (assuming 1 MUSD has value of $1)", async () => {
-        await setupRedemptionTroves()
-
-        await updateContractsSnapshot(
-          contracts,
-          state,
-          "activePool",
-          "before",
-          addresses,
-        )
-
-        const redemptionAmount = to1e18("100")
-        await performRedemption(contracts, dennis, dennis, redemptionAmount)
-
-        const price = await contracts.priceFeed.fetchPrice()
-        const collNeeded = to1e18(redemptionAmount) / price
-
-        await updateContractsSnapshot(
-          contracts,
-          state,
-          "activePool",
-          "after",
-          addresses,
-        )
-
-        expect(
-          state.activePool.collateral.before -
-            state.activePool.collateral.after,
-        ).to.equal(collNeeded)
-      })
-    })
   })
 
   describe("getPendingMUSDDebtReward()", () => {
-    it("getPendingMUSDDebtReward(): returns 0 if there is no pending MUSD reward", async () => {
+    it("returns 0 if there is no pending MUSD reward", async () => {
       await setupTroves()
       await openTrove(contracts, {
         musdAmount: "5000",
@@ -2819,7 +2500,7 @@ describe("TroveManager in Normal Mode", () => {
   })
 
   describe("getPendingCollateralReward()", () => {
-    it("getPendingCollateralReward(): returns 0 if there is no pending collateral reward", async () => {
+    it("returns 0 if there is no pending collateral reward", async () => {
       await setupTroves()
       await openTrove(contracts, {
         musdAmount: "5000",
@@ -2835,7 +2516,7 @@ describe("TroveManager in Normal Mode", () => {
   })
 
   describe("computeICR()", () => {
-    it("computeICR(): Returns 0 if trove's coll is worth 0", async () => {
+    it("Returns 0 if trove's coll is worth 0", async () => {
       const price = 0
       const coll = 1
       const debt = to1e18("100")
@@ -2844,12 +2525,12 @@ describe("TroveManager in Normal Mode", () => {
       ).to.equal(0)
     })
 
-    it.skip("computeICR(): Returns 2^256-1 for collateral:USD = 100, coll = 1 BTC/token, debt = 100 MUSD", async () => {
+    it.skip("Returns 2^256-1 for collateral:USD = 100, coll = 1 BTC/token, debt = 100 MUSD", async () => {
       // This seems designed to test an edge case where we would overflow but that edge case should no longer be possible
       // THUSD Test: https://github.com/Threshold-USD/dev/blob/develop/packages/contracts/test/TroveManagerTest.js#L4043
     })
 
-    it("computeICR(): returns correct ICR for a given collateral, debt, and price", async () => {
+    it("returns correct ICR for a given collateral, debt, and price", async () => {
       const price = to1e18("100")
       const coll = to1e18("200")
       const debt = to1e18("30")
@@ -2860,7 +2541,7 @@ describe("TroveManager in Normal Mode", () => {
       ).to.equal(expectedICR)
     })
 
-    it("computeICR(): returns 2^256-1 for non-zero coll and zero debt", async () => {
+    it("returns 2^256-1 for non-zero coll and zero debt", async () => {
       const price = to1e18("100")
       const coll = to1e18("200")
       const debt = 0n
@@ -2871,7 +2552,7 @@ describe("TroveManager in Normal Mode", () => {
   })
 
   describe("checkRecoveryMode()", () => {
-    it("checkRecoveryMode(): Returns true when TCR < 150%", async () => {
+    it("Returns true when TCR < 150%", async () => {
       await openTrove(contracts, {
         musdAmount: "5000",
         ICR: "200",
@@ -2886,7 +2567,7 @@ describe("TroveManager in Normal Mode", () => {
       ).to.equal(true)
     })
 
-    it("checkRecoveryMode(): Returns false when TCR == 150%", async () => {
+    it("Returns false when TCR == 150%", async () => {
       await openTrove(contracts, {
         musdAmount: "5000",
         ICR: "150",
@@ -2900,7 +2581,7 @@ describe("TroveManager in Normal Mode", () => {
       ).to.equal(false)
     })
 
-    it("checkRecoveryMode(): Returns false when TCR > 150%", async () => {
+    it("Returns false when TCR > 150%", async () => {
       await openTrove(contracts, {
         musdAmount: "5000",
         ICR: "151",
@@ -2914,7 +2595,7 @@ describe("TroveManager in Normal Mode", () => {
       ).to.equal(false)
     })
 
-    it("checkRecoveryMode(): Returns true when TCR == 0", async () => {
+    it("Returns true when TCR == 0", async () => {
       // Note that the original implementation had this (incorrectly) returning false
       // THUSD Test: https://github.com/Threshold-USD/dev/blob/develop/packages/contracts/test/TroveManagerTest.js#L4144
       await openTrove(contracts, {
@@ -2934,13 +2615,13 @@ describe("TroveManager in Normal Mode", () => {
   })
 
   describe("setMaxInterestRate()", () => {
-    /**
-     *
-     * Expected Reverts
-     *
-     */
+    it("sets the max interest rate", async () => {
+      await contracts.troveManager.connect(council.wallet).setMaxInterestRate(5)
+      expect(await contracts.troveManager.maxInterestRate()).to.equal(5)
+    })
+
     context("Expected Reverts", () => {
-      it("setMaxInterestRate(): reverts if a non-whitelisted address tries to set the maximum interest rate", async () => {
+      it("reverts if a non-whitelisted address tries to set the maximum interest rate", async () => {
         await expect(
           contracts.troveManager.connect(alice.wallet).setMaxInterestRate(1),
         ).to.be.revertedWith(
@@ -2949,13 +2630,8 @@ describe("TroveManager in Normal Mode", () => {
       })
     })
 
-    /**
-     *
-     * Emitted Events
-     *
-     */
     context("Emitted Events", () => {
-      it("setMaxInterestRate(): emits MaxInterestRateUpdated when the maximum interest rate is updated", async () => {
+      it("emits MaxInterestRateUpdated when the maximum interest rate is updated", async () => {
         await expect(
           contracts.troveManager.connect(council.wallet).setMaxInterestRate(50),
         )
@@ -2963,58 +2639,11 @@ describe("TroveManager in Normal Mode", () => {
           .withArgs(50)
       })
     })
-
-    /**
-     *
-     * System State Changes
-     *
-     */
-    context("System State Changes", () => {
-      it("setMaxInterestRate(): sets the max interest rate", async () => {
-        await contracts.troveManager
-          .connect(council.wallet)
-          .setMaxInterestRate(5)
-        expect(await contracts.troveManager.maxInterestRate()).to.equal(5)
-      })
-    })
-
-    /**
-     *
-     * Individual Troves
-     *
-     */
-    context("Individual Troves", () => {})
-
-    /**
-     *
-     * Balance changes
-     *
-     */
-    context("Balance changes", () => {})
-
-    /**
-     *
-     * Fees
-     *
-     */
-    context("Fees", () => {})
-
-    /**
-     *
-     * State change in other contracts
-     *
-     */
-    context("State change in other contracts", () => {})
   })
 
   describe("proposeInterestRate()", () => {
-    /**
-     *
-     * Expected Reverts
-     *
-     */
     context("Expected Reverts", () => {
-      it("proposeInterestRate(): reverts if the proposed rate exceeds the maximum interest rate", async () => {
+      it("reverts if the proposed rate exceeds the maximum interest rate", async () => {
         await expect(
           contracts.troveManager
             .connect(council.wallet)
@@ -3022,58 +2651,24 @@ describe("TroveManager in Normal Mode", () => {
         ).to.be.revertedWith("Interest rate exceeds the maximum interest rate")
       })
     })
-
-    /**
-     *
-     * Emitted Events
-     *
-     */
-    context("Emitted Events", () => {})
-
-    /**
-     *
-     * System State Changes
-     *
-     */
-    context("System State Changes", () => {})
-
-    /**
-     *
-     * Individual Troves
-     *
-     */
-    context("Individual Troves", () => {})
-
-    /**
-     *
-     * Balance changes
-     *
-     */
-    context("Balance changes", () => {})
-
-    /**
-     *
-     * Fees
-     *
-     */
-    context("Fees", () => {})
-
-    /**
-     *
-     * State change in other contracts
-     *
-     */
-    context("State change in other contracts", () => {})
   })
 
   describe("approveInterestRate()", () => {
-    /**
-     *
-     * Expected Reverts
-     *
-     */
+    it("requires two transactions to change the interest rate with a 7 day time delay", async () => {
+      await contracts.troveManager
+        .connect(council.wallet)
+        .proposeInterestRate(100)
+
+      // Simulate 7 days passing
+      const timeToIncrease = 7 * 24 * 60 * 60 // 7 days in seconds
+      await fastForwardTime(timeToIncrease)
+
+      await contracts.troveManager.connect(council.wallet).approveInterestRate()
+      expect(await contracts.troveManager.interestRate()).to.equal(100)
+    })
+
     context("Expected Reverts", () => {
-      it("approveInterestRate(): reverts if the time delay has not finished", async () => {
+      it("reverts if the time delay has not finished", async () => {
         await contracts.troveManager
           .connect(council.wallet)
           .proposeInterestRate(100)
@@ -3087,7 +2682,7 @@ describe("TroveManager in Normal Mode", () => {
         ).to.be.revertedWith("Proposal delay not met")
       })
 
-      it("approveInterestRate(): reverts if called by a non-governance address", async () => {
+      it("reverts if called by a non-governance address", async () => {
         await contracts.troveManager
           .connect(council.wallet)
           .proposeInterestRate(100)
@@ -3103,388 +2698,184 @@ describe("TroveManager in Normal Mode", () => {
         )
       })
     })
-
-    /**
-     *
-     * Emitted Events
-     *
-     */
-    context("Emitted Events", () => {})
-
-    /**
-     *
-     * System State Changes
-     *
-     */
-    context("System State Changes", () => {
-      it("approveInterestRate(): requires two transactions to change the interest rate with a 7 day time delay", async () => {
-        await contracts.troveManager
-          .connect(council.wallet)
-          .proposeInterestRate(100)
-
-        // Simulate 7 days passing
-        const timeToIncrease = 7 * 24 * 60 * 60 // 7 days in seconds
-        await fastForwardTime(timeToIncrease)
-
-        await contracts.troveManager
-          .connect(council.wallet)
-          .approveInterestRate()
-        expect(await contracts.troveManager.interestRate()).to.equal(100)
-      })
-    })
-
-    /**
-     *
-     * Individual Troves
-     *
-     */
-    context("Individual Troves", () => {})
-
-    /**
-     *
-     * Balance changes
-     *
-     */
-    context("Balance changes", () => {})
-
-    /**
-     *
-     * Fees
-     *
-     */
-    context("Fees", () => {})
-
-    /**
-     *
-     * State change in other contracts
-     *
-     */
-    context("State change in other contracts", () => {})
   })
 
   describe("calculateInterestOwed()", () => {
-    /**
-     *
-     * Expected Reverts
-     *
-     */
-    context("Expected Reverts", () => {})
+    it("should calculate the interest owed for a trove after 15 days", async () => {
+      const interest = await contracts.troveManager.calculateInterestOwed(
+        to1e18("10,250"),
+        100n,
+        0n,
+        1296000n, // 15 days in seconds
+      )
 
-    /**
-     *
-     * Emitted Events
-     *
-     */
-    context("Emitted Events", () => {})
-
-    /**
-     *
-     * System State Changes
-     *
-     */
-    context("System State Changes", () => {})
-
-    /**
-     *
-     * Individual Troves
-     *
-     */
-    context("Individual Troves", () => {
-      it("calculateInterestOwed(): should calculate the interest owed for a trove after 15 days", async () => {
-        const interest = await contracts.troveManager.calculateInterestOwed(
-          to1e18("10,250"),
-          100n,
-          0n,
-          1296000n, // 15 days in seconds
-        )
-
-        const expectedInterest = calculateInterestOwed(
-          to1e18("10,250"),
-          100,
-          0n,
-          1296000n, // 15 days in seconds
-        )
-        expect(interest).to.be.equal(expectedInterest)
-      })
-
-      it("calculateInterestOwed(): should calculate the interest owed for a trove after 30 days", async () => {
-        await setupTroveWithInterestRate(100, 30)
-        const interest = await contracts.troveManager.calculateInterestOwed(
-          to1e18("10,250"),
-          100n,
-          0n,
-          2592000n, // 30 days in seconds
-        )
-
-        const expectedInterest = calculateInterestOwed(
-          to1e18("10,250"),
-          100,
-          0n,
-          2592000n, // 15 days in seconds
-        )
-
-        expect(interest).to.be.equal(expectedInterest)
-      })
+      const expectedInterest = calculateInterestOwed(
+        to1e18("10,250"),
+        100,
+        0n,
+        1296000n, // 15 days in seconds
+      )
+      expect(interest).to.be.equal(expectedInterest)
     })
 
-    /**
-     *
-     * Balance changes
-     *
-     */
-    context("Balance changes", () => {})
+    it("should calculate the interest owed for a trove after 30 days", async () => {
+      await setupTroveWithInterestRate(100, 30)
+      const interest = await contracts.troveManager.calculateInterestOwed(
+        to1e18("10,250"),
+        100n,
+        0n,
+        2592000n, // 30 days in seconds
+      )
 
-    /**
-     *
-     * Fees
-     *
-     */
-    context("Fees", () => {})
+      const expectedInterest = calculateInterestOwed(
+        to1e18("10,250"),
+        100,
+        0n,
+        2592000n, // 15 days in seconds
+      )
 
-    /**
-     *
-     * State change in other contracts
-     *
-     */
-    context("State change in other contracts", () => {})
+      expect(interest).to.be.equal(expectedInterest)
+    })
   })
 
   describe("updateDebtWithInterest()", () => {
-    /**
-     *
-     * Expected Reverts
-     *
-     */
-    context("Expected Reverts", () => {})
+    it("should update the trove with interest owed and set the lastInterestUpdatedTime", async () => {
+      await setupTroveWithInterestRate(100, 30)
 
-    /**
-     *
-     * Emitted Events
-     *
-     */
-    context("Emitted Events", () => {})
+      await updateTroveSnapshot(contracts, alice, "before")
 
-    /**
-     *
-     * System State Changes
-     *
-     */
-    context("System State Changes", () => {})
+      await contracts.troveManager.updateDebtWithInterest(alice.wallet)
 
-    /**
-     *
-     * Individual Troves
-     *
-     */
-    context("Individual Troves", () => {
-      it("updateDebtWithInterest(): should update the trove with interest owed and set the lastInterestUpdatedTime", async () => {
-        await setupTroveWithInterestRate(100, 30)
+      await updateTroveSnapshot(contracts, alice, "after")
 
-        await updateTroveSnapshot(contracts, alice, "before")
+      expect(alice.trove.debt.after).to.equal(alice.trove.debt.before)
 
-        await contracts.troveManager.updateDebtWithInterest(alice.wallet)
+      const interestOwed = calculateInterestOwed(
+        to1e18("10,250"),
+        100,
+        alice.trove.lastInterestUpdateTime.before,
+        BigInt(await getLatestBlockTimestamp()),
+      )
 
-        await updateTroveSnapshot(contracts, alice, "after")
-
-        expect(alice.trove.debt.after).to.equal(alice.trove.debt.before)
-
-        const interestOwed = calculateInterestOwed(
-          to1e18("10,250"),
-          100,
-          alice.trove.lastInterestUpdateTime.before,
-          BigInt(await getLatestBlockTimestamp()),
-        )
-
-        expect(alice.trove.interestOwed.after).to.equal(
-          alice.trove.interestOwed.before + interestOwed,
-        )
-        expect(alice.trove.lastInterestUpdateTime.after).to.equal(
-          await getLatestBlockTimestamp(),
-        )
-      })
+      expect(alice.trove.interestOwed.after).to.equal(
+        alice.trove.interestOwed.before + interestOwed,
+      )
+      expect(alice.trove.lastInterestUpdateTime.after).to.equal(
+        await getLatestBlockTimestamp(),
+      )
     })
-
-    /**
-     *
-     * Balance changes
-     *
-     */
-    context("Balance changes", () => {})
-
-    /**
-     *
-     * Fees
-     *
-     */
-    context("Fees", () => {})
-
-    /**
-     *
-     * State change in other contracts
-     *
-     */
-    context("State change in other contracts", () => {})
   })
 
   describe("updateSystemInterest", () => {
-    /**
-     *
-     * Expected Reverts
-     *
-     */
-    context("Expected Reverts", () => {})
+    it("should update the system interest", async () => {
+      await setupTroveWithInterestRate(100, 30)
+      const { lastUpdatedTime } =
+        await contracts.troveManager.interestRateData(100)
+      await contracts.troveManager.updateSystemInterest(100)
 
-    /**
-     *
-     * Emitted Events
-     *
-     */
-    context("Emitted Events", () => {})
+      const { interest } = await contracts.troveManager.interestRateData(100)
 
-    /**
-     *
-     * System State Changes
-     *
-     */
-    context("System State Changes", () => {
-      it("updateSystemInterest(): should update the system interest", async () => {
-        await setupTroveWithInterestRate(100, 30)
-        const { lastUpdatedTime } =
-          await contracts.troveManager.interestRateData(100)
-        await contracts.troveManager.updateSystemInterest(100)
+      expect(interest).to.equal(
+        calculateInterestOwed(
+          to1e18(10250),
+          100,
+          lastUpdatedTime,
+          BigInt(await getLatestBlockTimestamp()),
+        ),
+      )
+    })
 
-        const { interest } = await contracts.troveManager.interestRateData(100)
+    it("should update the system interest after a previous update", async () => {
+      await setupTroveWithInterestRate(100, 30)
+      await contracts.troveManager.updateSystemInterest(100)
 
-        expect(interest).to.equal(
+      await fastForwardTime(30 * 24 * 60 * 60)
+      const { lastUpdatedTime, interest: initialInterest } =
+        await contracts.troveManager.interestRateData(100)
+      await contracts.troveManager.updateSystemInterest(100)
+
+      const { interest } = await contracts.troveManager.interestRateData(100)
+
+      expect(interest).to.equal(
+        initialInterest +
           calculateInterestOwed(
             to1e18(10250),
             100,
             lastUpdatedTime,
             BigInt(await getLatestBlockTimestamp()),
           ),
-        )
-      })
-
-      it("updateSystemInterest(): should update the system interest after a previous update", async () => {
-        await setupTroveWithInterestRate(100, 30)
-        await contracts.troveManager.updateSystemInterest(100)
-
-        await fastForwardTime(30 * 24 * 60 * 60)
-        const { lastUpdatedTime, interest: initialInterest } =
-          await contracts.troveManager.interestRateData(100)
-        await contracts.troveManager.updateSystemInterest(100)
-
-        const { interest } = await contracts.troveManager.interestRateData(100)
-
-        expect(interest).to.equal(
-          initialInterest +
-            calculateInterestOwed(
-              to1e18(10250),
-              100,
-              lastUpdatedTime,
-              BigInt(await getLatestBlockTimestamp()),
-            ),
-        )
-      })
-
-      it("updateSystemInterest(): should update the system interest with multiple troves", async () => {
-        await setupTroveWithInterestRate(100, 30)
-
-        await openTrove(contracts, {
-          sender: bob.wallet,
-          musdAmount: "20,000",
-        })
-        await updateTroveSnapshots(contracts, [alice, bob], "before")
-        const { lastUpdatedTime, interest: initialInterest } =
-          await contracts.troveManager.interestRateData(100)
-        await fastForwardTime(30 * 24 * 60 * 60)
-        await contracts.troveManager.updateSystemInterest(100)
-
-        const { interest } = await contracts.troveManager.interestRateData(100)
-
-        expect(interest).to.equal(
-          initialInterest +
-            calculateInterestOwed(
-              alice.trove.debt.before + bob.trove.debt.before,
-              100,
-              lastUpdatedTime,
-              BigInt(await getLatestBlockTimestamp()),
-            ),
-        )
-      })
-
-      it("updateSystemInterest(): should update the system interest with multiple interest rates", async () => {
-        await setupTroveWithInterestRate(100, 30)
-
-        await setInterestRate(200)
-        await openTrove(contracts, {
-          sender: bob.wallet,
-          musdAmount: "20,000",
-        })
-        const initialTime200 = BigInt(await getLatestBlockTimestamp())
-        await updateTroveSnapshots(contracts, [alice, bob], "before")
-        await contracts.troveManager.updateSystemInterest(100)
-        const { lastUpdatedTime, interest: initialInterestAt100 } =
-          await contracts.troveManager.interestRateData(100)
-
-        await fastForwardTime(30 * 24 * 60 * 60)
-        await contracts.troveManager.updateSystemInterest(100)
-        const finalTime100 = BigInt(await getLatestBlockTimestamp())
-        await contracts.troveManager.updateSystemInterest(200)
-        const finalTime200 = BigInt(await getLatestBlockTimestamp())
-
-        const { interest: finalInterestAt100 } =
-          await contracts.troveManager.interestRateData(100)
-        const { interest: finalInterestAt200 } =
-          await contracts.troveManager.interestRateData(200)
-
-        expect(finalInterestAt100).to.equal(
-          initialInterestAt100 +
-            calculateInterestOwed(
-              alice.trove.debt.before,
-              100,
-              lastUpdatedTime,
-              finalTime100,
-            ),
-        )
-        expect(finalInterestAt200).to.equal(
-          calculateInterestOwed(
-            bob.trove.debt.before,
-            200,
-            initialTime200,
-            finalTime200,
-          ),
-        )
-      })
+      )
     })
 
-    /**
-     *
-     * Individual Troves
-     *
-     */
-    context("Individual Troves", () => {})
+    it("should update the system interest with multiple troves", async () => {
+      await setupTroveWithInterestRate(100, 30)
 
-    /**
-     *
-     * Balance changes
-     *
-     */
-    context("Balance changes", () => {})
+      await openTrove(contracts, {
+        sender: bob.wallet,
+        musdAmount: "20,000",
+      })
+      await updateTroveSnapshots(contracts, [alice, bob], "before")
+      const { lastUpdatedTime, interest: initialInterest } =
+        await contracts.troveManager.interestRateData(100)
+      await fastForwardTime(30 * 24 * 60 * 60)
+      await contracts.troveManager.updateSystemInterest(100)
 
-    /**
-     *
-     * Fees
-     *
-     */
-    context("Fees", () => {})
+      const { interest } = await contracts.troveManager.interestRateData(100)
 
-    /**
-     *
-     * State change in other contracts
-     *
-     */
-    context("State change in other contracts", () => {})
+      expect(interest).to.equal(
+        initialInterest +
+          calculateInterestOwed(
+            alice.trove.debt.before + bob.trove.debt.before,
+            100,
+            lastUpdatedTime,
+            BigInt(await getLatestBlockTimestamp()),
+          ),
+      )
+    })
+
+    it("should update the system interest with multiple interest rates", async () => {
+      await setupTroveWithInterestRate(100, 30)
+
+      await setInterestRate(200)
+      await openTrove(contracts, {
+        sender: bob.wallet,
+        musdAmount: "20,000",
+      })
+      const initialTime200 = BigInt(await getLatestBlockTimestamp())
+      await updateTroveSnapshots(contracts, [alice, bob], "before")
+      await contracts.troveManager.updateSystemInterest(100)
+      const { lastUpdatedTime, interest: initialInterestAt100 } =
+        await contracts.troveManager.interestRateData(100)
+
+      await fastForwardTime(30 * 24 * 60 * 60)
+      await contracts.troveManager.updateSystemInterest(100)
+      const finalTime100 = BigInt(await getLatestBlockTimestamp())
+      await contracts.troveManager.updateSystemInterest(200)
+      const finalTime200 = BigInt(await getLatestBlockTimestamp())
+
+      const { interest: finalInterestAt100 } =
+        await contracts.troveManager.interestRateData(100)
+      const { interest: finalInterestAt200 } =
+        await contracts.troveManager.interestRateData(200)
+
+      expect(finalInterestAt100).to.equal(
+        initialInterestAt100 +
+          calculateInterestOwed(
+            alice.trove.debt.before,
+            100,
+            lastUpdatedTime,
+            finalTime100,
+          ),
+      )
+      expect(finalInterestAt200).to.equal(
+        calculateInterestOwed(
+          bob.trove.debt.before,
+          200,
+          initialTime200,
+          finalTime200,
+        ),
+      )
+    })
   })
 
   describe("Getters", () => {

--- a/solidity/test/normal/TroveManager_LiquidationRewards.test.ts
+++ b/solidity/test/normal/TroveManager_LiquidationRewards.test.ts
@@ -52,7 +52,7 @@ describe("TroveManager - Redistribution reward calculations", () => {
     return trove
   }
 
-  it("redistribution: A, B Open. B Liquidated. C, D Open. D Liquidated. Distributes correct rewards", async () => {
+  it("A, B Open. B Liquidated. C, D Open. D Liquidated. Distributes correct rewards", async () => {
     await setupTrove(alice, "1800", "400")
     await setupTrove(bob, "1800", "210")
     await updateTroveSnapshots(contracts, [alice, bob], "before")
@@ -99,7 +99,7 @@ describe("TroveManager - Redistribution reward calculations", () => {
     )
   })
 
-  it("redistribution: Sequence of alternate opening/liquidation: final surviving trove has collateral from all previously liquidated troves", async () => {
+  it("Sequence of alternate opening/liquidation: final surviving trove has collateral from all previously liquidated troves", async () => {
     // A, B open troves
     await setupTroveAndSnapshot(alice, "1800", "210")
     await setupTroveAndSnapshot(bob, "1800", "210")
@@ -140,7 +140,7 @@ describe("TroveManager - Redistribution reward calculations", () => {
     expect(gainedCollateral).to.equal(dennis.pending.collateral.after)
   })
 
-  it("redistribution: A,B,C Open. C Liquidated. B adds coll. A Liquidated. B acquires all coll and debt", async () => {
+  it("A,B,C Open. C Liquidated. B adds coll. A Liquidated. B acquires all coll and debt", async () => {
     const users = [alice, bob, carol]
     await Promise.all(
       users.map((user) => setupTroveAndSnapshot(user, "20000", "210")),
@@ -179,7 +179,7 @@ describe("TroveManager - Redistribution reward calculations", () => {
     )
   })
 
-  it("redistribution: A,B,C Open. C Liquidated. B tops up coll. D Opens. D Liquidated. Distributes correct rewards.", async () => {
+  it("A,B,C Open. C Liquidated. B tops up coll. D Opens. D Liquidated. Distributes correct rewards.", async () => {
     const users = [alice, bob, carol]
     await Promise.all(
       users.map((user) => setupTroveAndSnapshot(user, "20000", "210")),
@@ -242,7 +242,7 @@ describe("TroveManager - Redistribution reward calculations", () => {
     )
   })
 
-  it("redistribution: Trove with the majority stake tops up. A,B,C, D open. D Liquidated. C tops up. E opens, E Liquidated. Distributes correct rewards", async () => {
+  it("Trove with the majority stake tops up. A,B,C, D open. D Liquidated. C tops up. E opens, E Liquidated. Distributes correct rewards", async () => {
     const initialUsers = [alice, bob, carol, dennis]
     await setupTroveAndSnapshot(alice, "20,000", "4000")
     await setupTroveAndSnapshot(bob, "20,000", "4000")
@@ -305,7 +305,7 @@ describe("TroveManager - Redistribution reward calculations", () => {
     )
   })
 
-  it("redistribution: Trove with the majority stake tops up. A,B,C, D open. D Liquidated. A, B, C top up. E opens, E Liquidated. Distributes correct rewards", async () => {
+  it("Trove with the majority stake tops up. A,B,C, D open. D Liquidated. A, B, C top up. E opens, E Liquidated. Distributes correct rewards", async () => {
     const initialUsers = [alice, bob, carol, dennis]
     await Promise.all(
       initialUsers
@@ -375,7 +375,7 @@ describe("TroveManager - Redistribution reward calculations", () => {
     )
   })
 
-  it("redistribution: A,B,C Open. C Liquidated. B withdraws coll. A Liquidated. B acquires all coll and debt", async () => {
+  it("A,B,C Open. C Liquidated. B withdraws coll. A Liquidated. B acquires all coll and debt", async () => {
     await setupTroveAndSnapshot(alice, "20000", "210")
     await setupTroveAndSnapshot(bob, "20000", "2000")
     await setupTroveAndSnapshot(carol, "20000", "210")
@@ -413,7 +413,7 @@ describe("TroveManager - Redistribution reward calculations", () => {
     )
   })
 
-  it("redistribution: A,B,C Open. C Liquidated. B withdraws coll. D Opens. D Liquidated. Distributes correct rewards.", async () => {
+  it("A,B,C Open. C Liquidated. B withdraws coll. D Opens. D Liquidated. Distributes correct rewards.", async () => {
     // TODO Consider refactoring to remove duplication and/or use expectedRewardAmountForUsers
     const users = [alice, bob, carol]
     await setupTroveAndSnapshot(alice, "20000", "210")
@@ -475,7 +475,7 @@ describe("TroveManager - Redistribution reward calculations", () => {
     )
   })
 
-  it("redistribution: Trove with the majority stake tops up. A,B,C, D open. D Liquidated. C withdraws coll. E opens, E Liquidated. Distributes correct rewards", async () => {
+  it("Trove with the majority stake tops up. A,B,C, D open. D Liquidated. C withdraws coll. E opens, E Liquidated. Distributes correct rewards", async () => {
     const initialUsers = [alice, bob, carol, dennis]
     await setupTroveAndSnapshot(alice, "20,000", "4000")
     await setupTroveAndSnapshot(bob, "20,000", "4000")
@@ -538,7 +538,7 @@ describe("TroveManager - Redistribution reward calculations", () => {
     )
   })
 
-  it("redistribution: Trove with the majority stake withdraws. A,B,C,D open. D Liquidated. A, B, C withdraw coll. E opens, E Liquidated. Distributes correct rewards", async () => {
+  it("Trove with the majority stake withdraws. A,B,C,D open. D Liquidated. A, B, C withdraw coll. E opens, E Liquidated. Distributes correct rewards", async () => {
     const initialUsers = [alice, bob, carol, dennis]
     await setupTroveAndSnapshot(alice, "20,000", "4000")
     await setupTroveAndSnapshot(bob, "20,000", "4000")
@@ -609,7 +609,7 @@ describe("TroveManager - Redistribution reward calculations", () => {
     )
   })
 
-  it("redistribution, all operations: A,B,C open. A Liquidated. D opens. B adds, C withdraws. B Liquidated. E & F open. D adds. F Liquidated. Distributes correct rewards", async () => {
+  it("all operations: A,B,C open. A Liquidated. D opens. B adds, C withdraws. B Liquidated. E & F open. D adds. F Liquidated. Distributes correct rewards", async () => {
     const users = [alice, bob, carol]
     await setupTroveAndSnapshot(alice, "20,000", "150")
     await setupTroveAndSnapshot(bob, "20,000", "180")

--- a/solidity/test/recovery/BorrowerOperations.test.ts
+++ b/solidity/test/recovery/BorrowerOperations.test.ts
@@ -64,14 +64,71 @@ describe("BorrowerOperations in Recovery Mode", () => {
   })
 
   describe("openTrove()", () => {
-    /**
-     *
-     * Expected Reverts
-     *
-     */
+    it("Can open a trove with ICR >= CCR when system is in Recovery Mode", async () => {
+      // Carol opens at 150% ICR in Recovery Mode
+      await openTrove(contracts, {
+        musdAmount: "10,000",
+        ICR: "150",
+        sender: carol.wallet,
+      })
+
+      expect(await contracts.sortedTroves.contains(carol.address)).is.equal(
+        true,
+      )
+
+      const status = await contracts.troveManager.getTroveStatus(carol.address)
+      expect(status).is.equal(1)
+
+      const price = await contracts.priceFeed.fetchPrice()
+      const ICR = await contracts.troveManager.getCurrentICR(
+        carol.wallet,
+        price,
+      )
+      expect(ICR).is.equal(to1e18(150) / 100n)
+    })
+
+    it("Allows max fee < 0.5% in Recovery Mode", async () => {
+      await openTrove(contracts, {
+        musdAmount: "4,000",
+        ICR: "200",
+        sender: carol.wallet,
+        maxFeePercentage: "0.4999999999999999",
+      })
+      const after = await contracts.musd.balanceOf(carol.wallet)
+      expect(after).to.equal(to1e18("4,000"))
+    })
+
+    it("Records up-to-date initial snapshots of L_Collateral and L_MUSDDebt", async () => {
+      // Liquidate Alice's Trove.
+      await contracts.troveManager
+        .connect(deployer.wallet)
+        .liquidate(alice.wallet)
+
+      /* with total stakes = 10 ether/tokens, after liquidation, L_Collateral should equal 1/10 ether/token per-ether-staked/per-tokens-staked,
+      and L_MUSD should equal 18 MUSD per-ether-staked/per-tokens-staked. */
+
+      const liquidatedCollateral = await contracts.troveManager.L_Collateral()
+      const liquidatedDebt = await contracts.troveManager.L_MUSDDebt()
+
+      expect(liquidatedCollateral).is.greaterThan(0n)
+      expect(liquidatedDebt).is.greaterThan(0n)
+
+      // Carol opens trove
+      await openTrove(contracts, {
+        musdAmount: "10,000",
+        sender: carol.wallet,
+      })
+
+      // Check Carol's snapshots of L_Collateral and L_MUSD equal the respective current values
+      const snapshot = await contracts.troveManager.rewardSnapshots(
+        carol.wallet,
+      )
+      expect(snapshot[0]).is.equal(liquidatedCollateral)
+      expect(snapshot[1]).is.equal(liquidatedDebt)
+    })
 
     context("Expected Reverts", () => {
-      it("openTrove(): Reverts when system is in Recovery Mode and ICR < CCR", async () => {
+      it("Reverts when system is in Recovery Mode and ICR < CCR", async () => {
         await expect(
           openTrove(contracts, {
             musdAmount: to1e18("2,000"),
@@ -83,7 +140,7 @@ describe("BorrowerOperations in Recovery Mode", () => {
         )
       })
 
-      it("openTrove(): Reverts when trove ICR < MCR", async () => {
+      it("Reverts when trove ICR < MCR", async () => {
         await expect(
           openTrove(contracts, {
             musdAmount: to1e18("2,000"),
@@ -95,130 +152,129 @@ describe("BorrowerOperations in Recovery Mode", () => {
         )
       })
     })
-
-    /**
-     *
-     * Emitted Events
-     *
-     */
-
-    context("Emitted Events", () => {})
-
-    /**
-     *
-     * System State Changes
-     *
-     */
-
-    context("System State Changes", () => {})
-
-    /**
-     *
-     * Individual Troves
-     *
-     */
-
-    context("Individual Troves", () => {
-      it("openTrove(): Can open a trove with ICR >= CCR when system is in Recovery Mode", async () => {
-        // Carol opens at 150% ICR in Recovery Mode
-        await openTrove(contracts, {
-          musdAmount: "10,000",
-          ICR: "150",
-          sender: carol.wallet,
-        })
-
-        expect(await contracts.sortedTroves.contains(carol.address)).is.equal(
-          true,
-        )
-
-        const status = await contracts.troveManager.getTroveStatus(
-          carol.address,
-        )
-        expect(status).is.equal(1)
-
-        const price = await contracts.priceFeed.fetchPrice()
-        const ICR = await contracts.troveManager.getCurrentICR(
-          carol.wallet,
-          price,
-        )
-        expect(ICR).is.equal(to1e18(150) / 100n)
-      })
-    })
-
-    /**
-     *
-     *  Balance changes
-     *
-     */
-
-    context("Balance changes", () => {})
-
-    /**
-     *
-     * Fees
-     *
-     */
-
-    context("Fees", () => {
-      it("openTrove(): Allows max fee < 0.5% in Recovery Mode", async () => {
-        await openTrove(contracts, {
-          musdAmount: "4,000",
-          ICR: "200",
-          sender: carol.wallet,
-          maxFeePercentage: "0.4999999999999999",
-        })
-        const after = await contracts.musd.balanceOf(carol.wallet)
-        expect(after).to.equal(to1e18("4,000"))
-      })
-    })
-
-    /**
-     *
-     * State change in other contracts
-     *
-     */
-
-    context("State change in other contracts", () => {
-      it("openTrove(): Records up-to-date initial snapshots of L_Collateral and L_MUSDDebt", async () => {
-        // Liquidate Alice's Trove.
-        await contracts.troveManager
-          .connect(deployer.wallet)
-          .liquidate(alice.wallet)
-
-        /* with total stakes = 10 ether/tokens, after liquidation, L_Collateral should equal 1/10 ether/token per-ether-staked/per-tokens-staked,
-        and L_MUSD should equal 18 MUSD per-ether-staked/per-tokens-staked. */
-
-        const liquidatedCollateral = await contracts.troveManager.L_Collateral()
-        const liquidatedDebt = await contracts.troveManager.L_MUSDDebt()
-
-        expect(liquidatedCollateral).is.greaterThan(0n)
-        expect(liquidatedDebt).is.greaterThan(0n)
-
-        // Carol opens trove
-        await openTrove(contracts, {
-          musdAmount: "10,000",
-          sender: carol.wallet,
-        })
-
-        // Check Carol's snapshots of L_Collateral and L_MUSD equal the respective current values
-        const snapshot = await contracts.troveManager.rewardSnapshots(
-          carol.wallet,
-        )
-        expect(snapshot[0]).is.equal(liquidatedCollateral)
-        expect(snapshot[1]).is.equal(liquidatedDebt)
-      })
-    })
   })
 
   describe("addColl()", () => {
-    /**
-     *
-     * Expected Reverts
-     *
-     */
+    it("can add collateral in Recovery Mode", async () => {
+      await updateTroveSnapshot(contracts, alice, "before")
+
+      const collateralTopUp = to1e18(1)
+      await addColl(contracts, {
+        amount: collateralTopUp,
+        sender: alice.wallet,
+      })
+
+      await updateTroveSnapshot(contracts, alice, "after")
+
+      expect(alice.trove.collateral.after).to.equal(
+        alice.trove.collateral.before + collateralTopUp,
+      )
+    })
+
+    it("active Trove: applies pending rewards and updates user's L_Collateral, L_MUSDDebt snapshots", async () => {
+      await openTrove(contracts, {
+        musdAmount: "30,000",
+        sender: carol.wallet,
+      })
+
+      // Liquidate Alice's Trove,
+      await contracts.troveManager.liquidate(alice.address)
+      expect(await contracts.sortedTroves.contains(alice.address)).to.equal(
+        false,
+      )
+
+      state.troveManager.liquidation.collateral.before =
+        await contracts.troveManager.L_Collateral()
+      state.troveManager.liquidation.debt.before =
+        await contracts.troveManager.L_MUSDDebt()
+
+      await updateTroveSnapshot(contracts, bob, "before")
+      await updateTroveSnapshot(contracts, carol, "before")
+      await updateRewardSnapshot(contracts, bob, "before")
+      await updateRewardSnapshot(contracts, carol, "before")
+      await updatePendingSnapshot(contracts, bob, "before")
+      await updatePendingSnapshot(contracts, carol, "before")
+
+      // check Bob and Carol's reward snapshots are zero before they alter their Troves
+      expect(bob.rewardSnapshot.collateral.before).is.equal(0n)
+      expect(bob.rewardSnapshot.debt.before).is.equal(0n)
+      expect(carol.rewardSnapshot.collateral.before).is.equal(0n)
+      expect(carol.rewardSnapshot.debt.before).is.equal(0n)
+
+      // check Bob and Carol have pending reward and debt from the liquidation redistribution
+      expect(carol.pending.collateral.before).to.greaterThan(0n)
+      expect(bob.pending.collateral.before).to.greaterThan(0n)
+      expect(carol.pending.debt.before).to.greaterThan(0n)
+      expect(bob.pending.debt.before).to.greaterThan(0n)
+
+      const bobTopUp = to1e18(5)
+      await addColl(contracts, {
+        amount: bobTopUp,
+        sender: bob.wallet,
+      })
+
+      const carolTopUp = to1e18(1)
+      await addColl(contracts, {
+        amount: carolTopUp,
+        sender: carol.wallet,
+      })
+
+      await updateTroveSnapshot(contracts, bob, "after")
+      await updateTroveSnapshot(contracts, carol, "after")
+
+      expect(bob.trove.collateral.after).to.equal(
+        bob.trove.collateral.before + bobTopUp + bob.pending.collateral.before,
+      )
+      expect(bob.trove.debt.after).to.equal(
+        bob.trove.debt.before + bob.pending.debt.before,
+      )
+      expect(carol.trove.collateral.after).to.equal(
+        carol.trove.collateral.before +
+          carolTopUp +
+          carol.pending.collateral.before,
+      )
+      expect(carol.trove.debt.after).to.equal(
+        carol.trove.debt.before + carol.pending.debt.before,
+      )
+
+      /* Check that both Bob and Carol's snapshots of the rewards-per-unit-staked metrics should be updated
+      to the latest values of L_Collateral and L_MUSDDebt */
+
+      await updateRewardSnapshot(contracts, bob, "after")
+      await updateRewardSnapshot(contracts, carol, "after")
+
+      expect(bob.rewardSnapshot.collateral.after).is.equal(
+        state.troveManager.liquidation.collateral.before,
+      )
+      expect(bob.rewardSnapshot.debt.after).is.equal(
+        state.troveManager.liquidation.debt.before,
+      )
+      expect(carol.rewardSnapshot.collateral.after).is.equal(
+        state.troveManager.liquidation.collateral.before,
+      )
+      expect(carol.rewardSnapshot.debt.after).is.equal(
+        state.troveManager.liquidation.debt.before,
+      )
+    })
+
+    it("no mintlist, can add collateral", async () => {
+      await updateTroveSnapshot(contracts, alice, "before")
+      await removeMintlist(contracts, deployer.wallet)
+
+      const collateralTopUp = to1e18(1)
+      await addColl(contracts, {
+        amount: collateralTopUp,
+        sender: alice.wallet,
+      })
+
+      await updateTroveSnapshot(contracts, alice, "after")
+      expect(alice.trove.collateral.after).to.equal(
+        alice.trove.collateral.before + collateralTopUp,
+      )
+    })
 
     context("Expected Reverts", () => {
-      it("addColl(): reverts when top-up would leave trove with ICR < MCR", async () => {
+      it("reverts when top-up would leave trove with ICR < MCR", async () => {
         const price = to1e18("25,000")
         await contracts.mockAggregator.connect(deployer.wallet).setPrice(price)
 
@@ -246,7 +302,7 @@ describe("BorrowerOperations in Recovery Mode", () => {
         )
       })
 
-      it("addColl(), reverts if trove is non-existent", async () => {
+      it("reverts if trove is non-existent", async () => {
         await expect(
           addColl(contracts, {
             amount: 1n,
@@ -255,7 +311,7 @@ describe("BorrowerOperations in Recovery Mode", () => {
         ).to.be.revertedWith("BorrowerOps: Trove does not exist or is closed")
       })
 
-      it("addColl(), reverts if trove is closed", async () => {
+      it("reverts if trove is closed", async () => {
         await contracts.troveManager.liquidate(alice.address)
         await expect(
           addColl(contracts, {
@@ -265,185 +321,11 @@ describe("BorrowerOperations in Recovery Mode", () => {
         ).to.be.revertedWith("BorrowerOps: Trove does not exist or is closed")
       })
     })
-
-    /**
-     *
-     * Emitted Events
-     *
-     */
-
-    context("Emitted Events", () => {})
-
-    /**
-     *
-     * System State Changes
-     *
-     */
-
-    context("System State Changes", () => {})
-
-    /**
-     *
-     * Individual Troves
-     *
-     */
-
-    context("Individual Troves", () => {
-      it("addColl(): can add collateral in Recovery Mode", async () => {
-        await updateTroveSnapshot(contracts, alice, "before")
-
-        const collateralTopUp = to1e18(1)
-        await addColl(contracts, {
-          amount: collateralTopUp,
-          sender: alice.wallet,
-        })
-
-        await updateTroveSnapshot(contracts, alice, "after")
-
-        expect(alice.trove.collateral.after).to.equal(
-          alice.trove.collateral.before + collateralTopUp,
-        )
-      })
-
-      it("addColl(), active Trove: applies pending rewards and updates user's L_Collateral, L_MUSDDebt snapshots", async () => {
-        await openTrove(contracts, {
-          musdAmount: "30,000",
-          sender: carol.wallet,
-        })
-
-        // Liquidate Alice's Trove,
-        await contracts.troveManager.liquidate(alice.address)
-        expect(await contracts.sortedTroves.contains(alice.address)).to.equal(
-          false,
-        )
-
-        state.troveManager.liquidation.collateral.before =
-          await contracts.troveManager.L_Collateral()
-        state.troveManager.liquidation.debt.before =
-          await contracts.troveManager.L_MUSDDebt()
-
-        await updateTroveSnapshot(contracts, bob, "before")
-        await updateTroveSnapshot(contracts, carol, "before")
-        await updateRewardSnapshot(contracts, bob, "before")
-        await updateRewardSnapshot(contracts, carol, "before")
-        await updatePendingSnapshot(contracts, bob, "before")
-        await updatePendingSnapshot(contracts, carol, "before")
-
-        // check Bob and Carol's reward snapshots are zero before they alter their Troves
-        expect(bob.rewardSnapshot.collateral.before).is.equal(0n)
-        expect(bob.rewardSnapshot.debt.before).is.equal(0n)
-        expect(carol.rewardSnapshot.collateral.before).is.equal(0n)
-        expect(carol.rewardSnapshot.debt.before).is.equal(0n)
-
-        // check Bob and Carol have pending reward and debt from the liquidation redistribution
-        expect(carol.pending.collateral.before).to.greaterThan(0n)
-        expect(bob.pending.collateral.before).to.greaterThan(0n)
-        expect(carol.pending.debt.before).to.greaterThan(0n)
-        expect(bob.pending.debt.before).to.greaterThan(0n)
-
-        const bobTopUp = to1e18(5)
-        await addColl(contracts, {
-          amount: bobTopUp,
-          sender: bob.wallet,
-        })
-
-        const carolTopUp = to1e18(1)
-        await addColl(contracts, {
-          amount: carolTopUp,
-          sender: carol.wallet,
-        })
-
-        await updateTroveSnapshot(contracts, bob, "after")
-        await updateTroveSnapshot(contracts, carol, "after")
-
-        expect(bob.trove.collateral.after).to.equal(
-          bob.trove.collateral.before +
-            bobTopUp +
-            bob.pending.collateral.before,
-        )
-        expect(bob.trove.debt.after).to.equal(
-          bob.trove.debt.before + bob.pending.debt.before,
-        )
-        expect(carol.trove.collateral.after).to.equal(
-          carol.trove.collateral.before +
-            carolTopUp +
-            carol.pending.collateral.before,
-        )
-        expect(carol.trove.debt.after).to.equal(
-          carol.trove.debt.before + carol.pending.debt.before,
-        )
-
-        /* Check that both Bob and Carol's snapshots of the rewards-per-unit-staked metrics should be updated
-        to the latest values of L_Collateral and L_MUSDDebt */
-
-        await updateRewardSnapshot(contracts, bob, "after")
-        await updateRewardSnapshot(contracts, carol, "after")
-
-        expect(bob.rewardSnapshot.collateral.after).is.equal(
-          state.troveManager.liquidation.collateral.before,
-        )
-        expect(bob.rewardSnapshot.debt.after).is.equal(
-          state.troveManager.liquidation.debt.before,
-        )
-        expect(carol.rewardSnapshot.collateral.after).is.equal(
-          state.troveManager.liquidation.collateral.before,
-        )
-        expect(carol.rewardSnapshot.debt.after).is.equal(
-          state.troveManager.liquidation.debt.before,
-        )
-      })
-    })
-
-    /**
-     *
-     *  Balance changes
-     *
-     */
-
-    context("Balance changes", () => {
-      it("addColl(): no mintlist, can add collateral", async () => {
-        await updateTroveSnapshot(contracts, alice, "before")
-        await removeMintlist(contracts, deployer.wallet)
-
-        const collateralTopUp = to1e18(1)
-        await addColl(contracts, {
-          amount: collateralTopUp,
-          sender: alice.wallet,
-        })
-
-        await updateTroveSnapshot(contracts, alice, "after")
-        expect(alice.trove.collateral.after).to.equal(
-          alice.trove.collateral.before + collateralTopUp,
-        )
-      })
-    })
-
-    /**
-     *
-     * Fees
-     *
-     */
-
-    context("Fees", () => {})
-
-    /**
-     *
-     * State change in other contracts
-     *
-     */
-
-    context("State change in other contracts", () => {})
   })
 
   describe("withdrawColl()", () => {
-    /**
-     *
-     * Expected Reverts
-     *
-     */
-
     context("Expected Reverts", () => {
-      it("withdrawColl(): reverts if system is in Recovery Mode", async () => {
+      it("reverts if system is in Recovery Mode", async () => {
         await expect(
           contracts.borrowerOperations
             .connect(alice.wallet)
@@ -453,7 +335,7 @@ describe("BorrowerOperations in Recovery Mode", () => {
         )
       })
 
-      it("withdrawColl(): no mintlist, reverts if system is in Recovery Mode", async () => {
+      it("no mintlist, reverts if system is in Recovery Mode", async () => {
         await removeMintlist(contracts, deployer.wallet)
         await expect(
           contracts.borrowerOperations
@@ -464,65 +346,11 @@ describe("BorrowerOperations in Recovery Mode", () => {
         )
       })
     })
-
-    /**
-     *
-     * Emitted Events
-     *
-     */
-
-    context("Emitted Events", () => {})
-
-    /**
-     *
-     * System State Changes
-     *
-     */
-
-    context("System State Changes", () => {})
-
-    /**
-     *
-     * Individual Troves
-     *
-     */
-
-    context("Individual Troves", () => {})
-
-    /**
-     *
-     *  Balance changes
-     *
-     */
-
-    context("Balance changes", () => {})
-
-    /**
-     *
-     * Fees
-     *
-     */
-
-    context("Fees", () => {})
-
-    /**
-     *
-     * State change in other contracts
-     *
-     */
-
-    context("State change in other contracts", () => {})
   })
 
   describe("withdrawMUSD", () => {
-    /**
-     *
-     * Expected Reverts
-     *
-     */
-
     context("Expected Reverts", () => {
-      it("withdrawMUSD(): reverts when system is in Recovery Mode", async () => {
+      it("reverts when system is in Recovery Mode", async () => {
         const maxFeePercentage = to1e18(1)
         const amount = 1n
 
@@ -535,147 +363,65 @@ describe("BorrowerOperations in Recovery Mode", () => {
         )
       })
     })
-
-    /**
-     *
-     * Emitted Events
-     *
-     */
-
-    context("Emitted Events", () => {})
-
-    /**
-     *
-     * System State Changes
-     *
-     */
-
-    context("System State Changes", () => {})
-
-    /**
-     *
-     * Individual Troves
-     *
-     */
-
-    context("Individual Troves", () => {})
-
-    /**
-     *
-     *  Balance changes
-     *
-     */
-
-    context("Balance changes", () => {})
-
-    /**
-     *
-     * Fees
-     *
-     */
-
-    context("Fees", () => {})
-
-    /**
-     *
-     * State change in other contracts
-     *
-     */
-
-    context("State change in other contracts", () => {})
   })
 
   describe("repayMUSD", () => {
-    /**
-     *
-     * Expected Reverts
-     *
-     */
+    it("can repay debt in Recovery Mode", async () => {
+      const amount = to1e18("1,000")
+      await updateTroveSnapshot(contracts, bob, "before")
+      await contracts.borrowerOperations
+        .connect(bob.wallet)
+        .repayMUSD(amount, bob.wallet, bob.wallet)
+      await updateTroveSnapshot(contracts, bob, "after")
 
-    context("Expected Reverts", () => {})
-
-    /**
-     *
-     * Emitted Events
-     *
-     */
-
-    context("Emitted Events", () => {})
-
-    /**
-     *
-     * System State Changes
-     *
-     */
-
-    context("System State Changes", () => {})
-
-    /**
-     *
-     * Individual Troves
-     *
-     */
-
-    context("Individual Troves", () => {
-      it("repayMUSD(): can repay debt in Recovery Mode", async () => {
-        const amount = to1e18("1,000")
-        await updateTroveSnapshot(contracts, bob, "before")
-        await contracts.borrowerOperations
-          .connect(bob.wallet)
-          .repayMUSD(amount, bob.wallet, bob.wallet)
-        await updateTroveSnapshot(contracts, bob, "after")
-
-        expect(bob.trove.debt.after).to.equal(bob.trove.debt.before - amount)
-      })
-
-      it("repayMUSD(): no mintlist, can repay debt in Recovery Mode", async () => {
-        await removeMintlist(contracts, deployer.wallet)
-
-        const amount = to1e18("1,000")
-        await updateTroveSnapshot(contracts, bob, "before")
-        await contracts.borrowerOperations
-          .connect(bob.wallet)
-          .repayMUSD(amount, bob.wallet, bob.wallet)
-        await updateTroveSnapshot(contracts, bob, "after")
-
-        expect(bob.trove.debt.after).to.equal(bob.trove.debt.before - amount)
-      })
+      expect(bob.trove.debt.after).to.equal(bob.trove.debt.before - amount)
     })
 
-    /**
-     *
-     *  Balance changes
-     *
-     */
+    it("no mintlist, can repay debt in Recovery Mode", async () => {
+      await removeMintlist(contracts, deployer.wallet)
 
-    context("Balance changes", () => {})
+      const amount = to1e18("1,000")
+      await updateTroveSnapshot(contracts, bob, "before")
+      await contracts.borrowerOperations
+        .connect(bob.wallet)
+        .repayMUSD(amount, bob.wallet, bob.wallet)
+      await updateTroveSnapshot(contracts, bob, "after")
 
-    /**
-     *
-     * Fees
-     *
-     */
-
-    context("Fees", () => {})
-
-    /**
-     *
-     * State change in other contracts
-     *
-     */
-
-    context("State change in other contracts", () => {})
+      expect(bob.trove.debt.after).to.equal(bob.trove.debt.before - amount)
+    })
   })
 
   describe("closeTrove", () => {
-    /**
-     *
-     * Expected Reverts
-     *
-     */
+    it("no mintlist, succeeds when in Recovery Mode", async () => {
+      await removeMintlist(contracts, deployer.wallet)
+      await contracts.musd
+        .connect(alice.wallet)
+        .transfer(bob.address, to1e18("2,000"))
+      await contracts.borrowerOperations.connect(bob.wallet).closeTrove()
+
+      await updateTroveSnapshot(contracts, bob, "after")
+      expect(bob.trove.status.after).to.equal(2)
+      expect(await contracts.sortedTroves.contains(bob.wallet)).to.equal(false)
+    })
+
+    it("no mintlist, succeeds when trove is the only one in the system", async () => {
+      await removeMintlist(contracts, deployer.wallet)
+
+      await contracts.musd.unprotectedMint(alice.wallet, to1e18("2,000"))
+      await contracts.musd.unprotectedMint(bob.wallet, to1e18("2,000"))
+
+      await contracts.borrowerOperations.connect(alice.wallet).closeTrove()
+      await contracts.borrowerOperations.connect(bob.wallet).closeTrove()
+
+      await updateTroveSnapshot(contracts, bob, "after")
+      expect(bob.trove.status.after).to.equal(2)
+      expect(await contracts.sortedTroves.contains(bob.wallet)).to.equal(false)
+
+      expect(await contracts.sortedTroves.isEmpty()).to.equal(true)
+    })
 
     context("Expected Reverts", () => {
-      it("closeTrove(): reverts when system is in Recovery Mode", async () => {
+      it("reverts when system is in Recovery Mode", async () => {
         await contracts.musd
           .connect(alice.wallet)
           .transfer(bob.address, to1e18("2,000"))
@@ -686,97 +432,127 @@ describe("BorrowerOperations in Recovery Mode", () => {
         )
       })
     })
-
-    /**
-     *
-     * Emitted Events
-     *
-     */
-
-    context("Emitted Events", () => {})
-
-    /**
-     *
-     * System State Changes
-     *
-     */
-
-    context("System State Changes", () => {})
-
-    /**
-     *
-     * Individual Troves
-     *
-     */
-
-    context("Individual Troves", () => {
-      it("closeTrove(): no mintlist, succeeds when in Recovery Mode", async () => {
-        await removeMintlist(contracts, deployer.wallet)
-        await contracts.musd
-          .connect(alice.wallet)
-          .transfer(bob.address, to1e18("2,000"))
-        await contracts.borrowerOperations.connect(bob.wallet).closeTrove()
-
-        await updateTroveSnapshot(contracts, bob, "after")
-        expect(bob.trove.status.after).to.equal(2)
-        expect(await contracts.sortedTroves.contains(bob.wallet)).to.equal(
-          false,
-        )
-      })
-
-      it("closeTrove(): no mintlist, succeeds when trove is the only one in the system", async () => {
-        await removeMintlist(contracts, deployer.wallet)
-
-        await contracts.musd.unprotectedMint(alice.wallet, to1e18("2,000"))
-        await contracts.musd.unprotectedMint(bob.wallet, to1e18("2,000"))
-
-        await contracts.borrowerOperations.connect(alice.wallet).closeTrove()
-        await contracts.borrowerOperations.connect(bob.wallet).closeTrove()
-
-        await updateTroveSnapshot(contracts, bob, "after")
-        expect(bob.trove.status.after).to.equal(2)
-        expect(await contracts.sortedTroves.contains(bob.wallet)).to.equal(
-          false,
-        )
-
-        expect(await contracts.sortedTroves.isEmpty()).to.equal(true)
-      })
-    })
-
-    /**
-     *
-     *  Balance changes
-     *
-     */
-
-    context("Balance changes", () => {})
-
-    /**
-     *
-     * Fees
-     *
-     */
-
-    context("Fees", () => {})
-
-    /**
-     *
-     * State change in other contracts
-     *
-     */
-
-    context("State change in other contracts", () => {})
   })
 
   describe("adjustTrove", () => {
-    /**
-     *
-     * Expected Reverts
-     *
-     */
+    it("A trove with ICR < CCR in Recovery Mode can adjust their trove to ICR > CCR", async () => {
+      const maxFeePercentage = to1e18(1)
+      const collChange = to1e18("20")
+
+      await updateTroveSnapshot(contracts, alice, "before")
+      // collateral deposit that would increase ICR > CCR
+      await contracts.borrowerOperations
+        .connect(alice.wallet)
+        .adjustTrove(
+          maxFeePercentage,
+          0,
+          0,
+          false,
+          collChange,
+          alice.wallet,
+          alice.wallet,
+          {
+            value: collChange,
+          },
+        )
+      await updateTroveSnapshot(contracts, alice, "after")
+      const ccr = await contracts.troveManager.CCR()
+      expect(alice.trove.icr.before).to.be.lessThan(ccr)
+      expect(alice.trove.icr.after).to.be.greaterThan(ccr)
+    })
+
+    it("A trove with ICR > CCR in Recovery Mode can improve their ICR", async () => {
+      const maxFeePercentage = to1e18(1)
+      const collChange = to1e18("20")
+
+      await setupCarolsTrove()
+      await updateTroveSnapshot(contracts, carol, "before")
+      // collateral deposit that would increase ICR > CCR
+      await contracts.borrowerOperations
+        .connect(carol.wallet)
+        .adjustTrove(
+          maxFeePercentage,
+          0,
+          0,
+          false,
+          collChange,
+          carol.wallet,
+          carol.wallet,
+          {
+            value: collChange,
+          },
+        )
+      await updateTroveSnapshot(contracts, carol, "after")
+      const ccr = await contracts.troveManager.CCR()
+      expect(carol.trove.icr.before).to.be.greaterThan(ccr)
+      expect(carol.trove.icr.after).to.be.greaterThan(carol.trove.icr.before)
+    })
+
+    it("allows max fee < 0.5% in Recovery mode", async () => {
+      const maxFeePercentage = 4999999999999999n
+      const collChange = to1e18("20")
+      const debtChange = to1e18("2,000")
+
+      await setupCarolsTrove()
+      await contracts.borrowerOperations
+        .connect(carol.wallet)
+        .adjustTrove(
+          maxFeePercentage,
+          0,
+          debtChange,
+          true,
+          collChange,
+          carol.wallet,
+          carol.wallet,
+          {
+            value: collChange,
+          },
+        )
+    })
+
+    it("debt increase in Recovery Mode charges no fee", async () => {
+      const maxFeePercentage = to1e18(1)
+      const collChange = to1e18("20")
+      const debtChange = to1e18("2,000")
+      const abi = [
+        // Add your contract ABI here
+        "event MUSDBorrowingFeePaid(address indexed _borrower, uint256 _MUSDFee)",
+      ]
+
+      await setupCarolsTrove()
+
+      state.pcv.musd.before = await contracts.musd.balanceOf(addresses.pcv)
+
+      const tx = await contracts.borrowerOperations
+        .connect(carol.wallet)
+        .adjustTrove(
+          maxFeePercentage,
+          0,
+          debtChange,
+          true,
+          collChange,
+          carol.wallet,
+          carol.wallet,
+          {
+            value: collChange,
+          },
+        )
+
+      const emittedFee = await getEventArgByName(
+        tx,
+        abi,
+        "MUSDBorrowingFeePaid",
+        1,
+      )
+      expect(emittedFee).to.be.equal(0)
+
+      // Check no fee was sent to PCV contract
+      state.pcv.musd.after = await contracts.musd.balanceOf(addresses.pcv)
+      expect(state.pcv.musd.after).to.be.equal(state.pcv.musd.before)
+    })
 
     context("Expected Reverts", () => {
-      it("adjustTrove(): reverts in Recovery Mode when the adjustment would reduce the TCR", async () => {
+      it("reverts in Recovery Mode when the adjustment would reduce the TCR", async () => {
         const maxFeePercentage = to1e18(1)
         const debtChange = to1e18(5000)
         const collChange = to1e18(0.0001)
@@ -834,7 +610,7 @@ describe("BorrowerOperations in Recovery Mode", () => {
         )
       })
 
-      it("adjustTrove(): collateral withdrawal reverts in Recovery Mode", async () => {
+      it("collateral withdrawal reverts in Recovery Mode", async () => {
         const maxFeePercentage = to1e18(1)
         const collChange = to1e18(0.0001)
         await setupCarolsTrove()
@@ -857,7 +633,7 @@ describe("BorrowerOperations in Recovery Mode", () => {
         )
       })
 
-      it("adjustTrove(): no mintlist, collateral withdrawal reverts in Recovery Mode", async () => {
+      it("no mintlist, collateral withdrawal reverts in Recovery Mode", async () => {
         const maxFeePercentage = to1e18(1)
         const collChange = to1e18(0.0001)
         await setupCarolsTrove()
@@ -881,7 +657,7 @@ describe("BorrowerOperations in Recovery Mode", () => {
         )
       })
 
-      it("adjustTrove(): debt increase that would leave ICR < CCR (150%) reverts in Recovery Mode", async () => {
+      it("debt increase that would leave ICR < CCR (150%) reverts in Recovery Mode", async () => {
         const maxFeePercentage = to1e18(1)
         const collChange = to1e18(1)
         const debtChange = to1e18("2,000")
@@ -909,7 +685,7 @@ describe("BorrowerOperations in Recovery Mode", () => {
         )
       })
 
-      it("adjustTrove(): debt increase that would reduce the ICR reverts in Recovery Mode", async () => {
+      it("debt increase that would reduce the ICR reverts in Recovery Mode", async () => {
         const maxFeePercentage = to1e18(1)
         const debtChange = to1e18("2,000")
 
@@ -961,168 +737,5 @@ describe("BorrowerOperations in Recovery Mode", () => {
         )
       })
     })
-
-    /**
-     *
-     * Emitted Events
-     *
-     */
-
-    context("Emitted Events", () => {})
-
-    /**
-     *
-     * System State Changes
-     *
-     */
-
-    context("System State Changes", () => {
-      it("adjustTrove(): A trove with ICR < CCR in Recovery Mode can adjust their trove to ICR > CCR", async () => {
-        const maxFeePercentage = to1e18(1)
-        const collChange = to1e18("20")
-
-        await updateTroveSnapshot(contracts, alice, "before")
-        // collateral deposit that would increase ICR > CCR
-        await contracts.borrowerOperations
-          .connect(alice.wallet)
-          .adjustTrove(
-            maxFeePercentage,
-            0,
-            0,
-            false,
-            collChange,
-            alice.wallet,
-            alice.wallet,
-            {
-              value: collChange,
-            },
-          )
-        await updateTroveSnapshot(contracts, alice, "after")
-        const ccr = await contracts.troveManager.CCR()
-        expect(alice.trove.icr.before).to.be.lessThan(ccr)
-        expect(alice.trove.icr.after).to.be.greaterThan(ccr)
-      })
-      it("adjustTrove(): A trove with ICR > CCR in Recovery Mode can improve their ICR", async () => {
-        const maxFeePercentage = to1e18(1)
-        const collChange = to1e18("20")
-
-        await setupCarolsTrove()
-        await updateTroveSnapshot(contracts, carol, "before")
-        // collateral deposit that would increase ICR > CCR
-        await contracts.borrowerOperations
-          .connect(carol.wallet)
-          .adjustTrove(
-            maxFeePercentage,
-            0,
-            0,
-            false,
-            collChange,
-            carol.wallet,
-            carol.wallet,
-            {
-              value: collChange,
-            },
-          )
-        await updateTroveSnapshot(contracts, carol, "after")
-        const ccr = await contracts.troveManager.CCR()
-        expect(carol.trove.icr.before).to.be.greaterThan(ccr)
-        expect(carol.trove.icr.after).to.be.greaterThan(carol.trove.icr.before)
-      })
-    })
-
-    /**
-     *
-     * Individual Troves
-     *
-     */
-
-    context("Individual Troves", () => {})
-
-    /**
-     *
-     *  Balance changes
-     *
-     */
-
-    context("Balance changes", () => {})
-
-    /**
-     *
-     * Fees
-     *
-     */
-
-    context("Fees", () => {
-      it("adjustTrove(): allows max fee < 0.5% in Recovery mode", async () => {
-        const maxFeePercentage = 4999999999999999n
-        const collChange = to1e18("20")
-        const debtChange = to1e18("2,000")
-
-        await setupCarolsTrove()
-        await contracts.borrowerOperations
-          .connect(carol.wallet)
-          .adjustTrove(
-            maxFeePercentage,
-            0,
-            debtChange,
-            true,
-            collChange,
-            carol.wallet,
-            carol.wallet,
-            {
-              value: collChange,
-            },
-          )
-      })
-
-      it("adjustTrove(): debt increase in Recovery Mode charges no fee", async () => {
-        const maxFeePercentage = to1e18(1)
-        const collChange = to1e18("20")
-        const debtChange = to1e18("2,000")
-        const abi = [
-          // Add your contract ABI here
-          "event MUSDBorrowingFeePaid(address indexed _borrower, uint256 _MUSDFee)",
-        ]
-
-        await setupCarolsTrove()
-
-        state.pcv.musd.before = await contracts.musd.balanceOf(addresses.pcv)
-
-        const tx = await contracts.borrowerOperations
-          .connect(carol.wallet)
-          .adjustTrove(
-            maxFeePercentage,
-            0,
-            debtChange,
-            true,
-            collChange,
-            carol.wallet,
-            carol.wallet,
-            {
-              value: collChange,
-            },
-          )
-
-        const emittedFee = await getEventArgByName(
-          tx,
-          abi,
-          "MUSDBorrowingFeePaid",
-          1,
-        )
-        expect(emittedFee).to.be.equal(0)
-
-        // Check no fee was sent to PCV contract
-        state.pcv.musd.after = await contracts.musd.balanceOf(addresses.pcv)
-        expect(state.pcv.musd.after).to.be.equal(state.pcv.musd.before)
-      })
-    })
-
-    /**
-     *
-     * State change in other contracts
-     *
-     */
-
-    context("State change in other contracts", () => {})
   })
 })

--- a/solidity/test/recovery/TroveManager.test.ts
+++ b/solidity/test/recovery/TroveManager.test.ts
@@ -117,13 +117,383 @@ describe("TroveManager in Recovery Mode", () => {
   }
 
   describe("liquidateTroves()", () => {
-    /**
-     *
-     * Expected Reverts
-     *
-     */
+    it("a liquidation sequence containing Pool offsets increases the TCR", async () => {
+      await setupTrove(alice, "5000", "150")
+      await setupTrove(bob, "50,000", "400")
+      await setupTrove(carol, "5000", "150")
+
+      await provideToSP(contracts, bob, to1e18("10,000"))
+
+      await dropPrice(contracts, alice)
+      await updateTroveManagerSnapshot(contracts, state, "before")
+      await contracts.troveManager.liquidateTroves(2)
+      await updateTroveManagerSnapshot(contracts, state, "after")
+      expect(state.troveManager.TCR.after).to.be.greaterThan(
+        state.troveManager.TCR.before,
+      )
+    })
+
+    it("A liquidation sequence of pure redistributions decreases the TCR, due to gas compensation, but up to 0.5%", async () => {
+      await setupTrove(alice, "5000", "400")
+      await setupTrove(bob, "50,000", "5000")
+      await setupTrove(carol, "2000", "400")
+      await setupTrove(dennis, "2000", "400")
+
+      // Drop the price to make everyone but Bob eligible for liquidation and snapshot the TCR
+      await dropPrice(contracts, alice)
+      await updateTroveManagerSnapshot(contracts, state, "before")
+
+      // Perform liquidation and check that TCR has decreased
+      await contracts.troveManager.liquidateTroves(4)
+      await updateTroveManagerSnapshot(contracts, state, "after")
+      expect(state.troveManager.TCR.before).to.be.greaterThan(
+        state.troveManager.TCR.after,
+      )
+
+      // Check that the TCR has decreased by no more than the liquidation fee
+      expect(state.troveManager.TCR.after).to.be.greaterThanOrEqual(
+        applyLiquidationFee(state.troveManager.TCR.before),
+      )
+    })
+
+    it("With all ICRs > 110%, Liquidates Troves until system leaves recovery mode", async () => {
+      // Open 5 troves
+      await setupTroveAndSnapshot(bob, "5000", "240")
+      await setupTroveAndSnapshot(carol, "5000", "240")
+      await setupTroveAndSnapshot(dennis, "5000", "232")
+      await setupTroveAndSnapshot(eric, "5000", "230")
+      await setupTroveAndSnapshot(frank, "5000", "228")
+
+      // Open a trove for Alice that contains the debt of 3 other troves plus min debt
+      const amount =
+        dennis.trove.debt.before +
+        eric.trove.debt.before +
+        frank.trove.debt.before
+
+      await openTrove(contracts, {
+        musdAmount: amount + to1e18("1800"),
+        sender: alice.wallet,
+        ICR: "400",
+      })
+
+      // Alice provides the total debt to the SP
+      await provideToSP(contracts, alice, amount)
+
+      // Drop the price to put the system into recovery mode (TCR < 150%)
+      // Since frank has the lowest ICR, everyone else should have ICR > 111%
+      await dropPrice(contracts, frank, to1e18("111"))
+      expect(await checkRecoveryMode()).to.equal(true)
+
+      // Liquidate Troves until the system leaves recovery mode
+      await contracts.troveManager.liquidateTroves(5n)
+
+      // Check that we are no longer in recovery mode
+      expect(await checkRecoveryMode()).to.equal(false)
+
+      // Only frank should be liquidated, everyone else is still active
+      expect(await checkTroveActive(contracts, alice)).to.equal(true)
+      expect(await checkTroveActive(contracts, bob)).to.equal(true)
+      expect(await checkTroveActive(contracts, carol)).to.equal(true)
+      expect(await checkTroveActive(contracts, dennis)).to.equal(true)
+      expect(await checkTroveActive(contracts, eric)).to.equal(true)
+      expect(await checkTroveClosedByLiquidation(contracts, frank)).to.equal(
+        true,
+      )
+    })
+
+    it("Liquidates Troves until 1) system has left recovery mode AND 2) it reaches a Trove with ICR >= 110%", async () => {
+      // Open 5 troves
+      await setupTroveAndSnapshot(bob, "5000", "240")
+      await setupTroveAndSnapshot(carol, "5000", "240")
+      await setupTroveAndSnapshot(dennis, "5000", "230")
+      await setupTroveAndSnapshot(eric, "5000", "240")
+      await setupTroveAndSnapshot(frank, "5000", "240")
+
+      // Open another trove for Eric that contains the total debt of the other troves plus min debt
+      const liquidationAmount =
+        bob.trove.debt.before +
+        carol.trove.debt.before +
+        dennis.trove.debt.before +
+        eric.trove.debt.before +
+        frank.trove.debt.before
+
+      await openTrove(contracts, {
+        musdAmount: liquidationAmount + to1e18("1800"),
+        sender: alice.wallet,
+        ICR: "400",
+      })
+
+      // Alice provides the total debt to the SP
+      await provideToSP(contracts, alice, liquidationAmount)
+
+      // Drop the price to put the system into recovery mode (TCR < 150%)
+      await dropPrice(contracts, dennis, to1e18("105"))
+      expect(await checkRecoveryMode()).to.equal(true)
+      await updateTroveSnapshots(
+        contracts,
+        [alice, bob, carol, dennis, eric, frank],
+        "after",
+      )
+
+      // Liquidate Troves until the system leaves recovery mode
+      await contracts.troveManager.liquidateTroves(6n)
+
+      // Check that we are no longer in recovery mode
+      expect(await checkRecoveryMode()).to.equal(false)
+
+      // Alice should still be active, everyone else is closed by liquidation
+      expect(await checkTroveActive(contracts, alice)).to.equal(true)
+      expect(await checkTroveClosedByLiquidation(contracts, bob)).to.equal(true)
+      expect(await checkTroveClosedByLiquidation(contracts, carol)).to.equal(
+        true,
+      )
+      expect(await checkTroveClosedByLiquidation(contracts, dennis)).to.equal(
+        true,
+      )
+      expect(await checkTroveClosedByLiquidation(contracts, eric)).to.equal(
+        true,
+      )
+      expect(await checkTroveClosedByLiquidation(contracts, frank)).to.equal(
+        true,
+      )
+    })
+
+    it("liquidates only up to the requested number of undercollateralized troves", async () => {
+      await setupTrove(alice, "5000", "150")
+      await setupTrove(bob, "5000", "150")
+
+      await dropPrice(contracts, alice, to1e18("100"))
+
+      await contracts.troveManager.liquidateTroves(1n)
+
+      expect(await checkTroveClosedByLiquidation(contracts, alice)).to.equal(
+        true,
+      )
+      expect(await checkTroveActive(contracts, bob)).to.equal(true)
+    })
+
+    it("closes every Trove with ICR < MCR, when n > number of undercollateralized troves", async () => {
+      const underCollateralizedUsers = [alice, carol, dennis, eric]
+      await Promise.all(
+        underCollateralizedUsers.map((user) => setupTrove(user, "5000", "150")),
+      )
+      await setupTrove(bob, "50,000", "200")
+
+      await provideToSP(contracts, bob, to1e18("25,000"))
+      await dropPrice(contracts, alice)
+
+      await contracts.troveManager.liquidateTroves(5n)
+      const closedByLiquidation = await Promise.all(
+        underCollateralizedUsers.map((user) =>
+          checkTroveClosedByLiquidation(contracts, user),
+        ),
+      )
+      expect(closedByLiquidation.every(Boolean)).to.equal(true)
+
+      expect(await checkTroveActive(contracts, bob)).to.equal(true)
+    })
+
+    it("liquidates based on entire/collateral debt (including pending rewards), not raw collateral/debt", async () => {
+      await setupTrove(alice, "2000", "400")
+      await setupTrove(bob, "2000", "200.01")
+      await setupTrove(carol, "2000", "200")
+      await setupTrove(dennis, "2000", "200")
+
+      // Drop the price so that Carol and Dennis are at risk for liquidation, but do not liquidate anyone yet
+      const newPrice = await dropPrice(contracts, dennis)
+
+      // Check that Bob's ICR is above the MCR after the price drop and before liquidation
+      await updateTroveSnapshot(contracts, bob, "before")
+      const mcr = await contracts.troveManager.MCR()
+      expect(bob.trove.icr.before).to.be.greaterThan(mcr)
+
+      // Liquidate Dennis, creating rewards for everyone
+      await contracts.troveManager.liquidate(dennis.wallet)
+
+      // Check that Bob's ICR is below the MCR following liquidation
+      await updateTroveSnapshot(contracts, bob, "after")
+      expect(bob.trove.icr.after).to.be.lessThan(mcr)
+
+      // Check that Bob's raw ICR (debt and coll less pending rewards) is above the MCR
+      const rawICR =
+        (bob.trove.collateral.after * newPrice) / bob.trove.debt.after
+      expect(rawICR).to.be.greaterThan(mcr)
+
+      // Attempt to liquidate all troves
+      await contracts.troveManager.liquidateTroves(3)
+
+      // Check that Alice stays active and Carol and Bob get liquidated
+      expect(await checkTroveActive(contracts, alice)).to.equal(true)
+      expect(await checkTroveClosedByLiquidation(contracts, bob)).to.equal(true)
+      expect(await checkTroveClosedByLiquidation(contracts, carol)).to.equal(
+        true,
+      )
+    })
+
+    it("with a non fulfilled liquidation: still can liquidate further troves after the non-liquidated, emptied pool", async () => {
+      await setupTroveAndSnapshot(alice, "5000", "150")
+      await setupTroveAndSnapshot(bob, "5000", "150")
+      await setupTroveAndSnapshot(carol, "20,000", "180")
+      await setupTroveAndSnapshot(dennis, "2000", "160")
+
+      // Carol deposits enough to cover Alice and Dennis' debt
+      const spDeposit = alice.trove.debt.before + dennis.trove.debt.before
+      await provideToSP(contracts, carol, spDeposit)
+
+      await dropPrice(contracts, alice, to1e18("115"))
+
+      // Troves in ICR order: Alice, Bob, Dennis, Carol
+      await contracts.troveManager.liquidateTroves(4)
+
+      expect(await checkTroveClosedByLiquidation(contracts, alice)).to.equal(
+        true,
+      )
+      // SP can cover Dennis' debt, so he gets liquidated even though he has a higher ICR than Bob
+      expect(await checkTroveClosedByLiquidation(contracts, dennis)).to.equal(
+        true,
+      )
+      expect(await checkTroveActive(contracts, bob)).to.equal(true)
+      expect(await checkTroveActive(contracts, carol)).to.equal(true)
+    })
+
+    it("with a non fulfilled liquidation: non liquidated trove remains active", async () => {
+      await setupTroveAndSnapshot(alice, "5000", "150")
+      await setupTroveAndSnapshot(bob, "5000", "150")
+      await setupTroveAndSnapshot(carol, "20,000", "160")
+
+      // Carol deposits enough to cover Alice's debt and half of Bob's
+      const spDeposit = alice.trove.debt.before + bob.trove.debt.before / 2n
+      await provideToSP(contracts, carol, spDeposit)
+
+      await dropPrice(contracts, alice, to1e18("115"))
+      await contracts.troveManager.liquidateTroves(2)
+
+      expect(await checkTroveClosedByLiquidation(contracts, alice)).to.equal(
+        true,
+      )
+      // Bob should remain active because his trove was only partially liquidated
+      expect(await checkTroveActive(contracts, bob)).to.equal(true)
+      expect(await checkTroveActive(contracts, carol)).to.equal(true)
+    })
+
+    it("does not affect the liquidated user's token balances", async () => {
+      await setupTrove(alice, "5000", "150")
+      await setupTrove(bob, "5000", "150")
+      await updateWalletSnapshot(contracts, alice, "before")
+      await updateWalletSnapshot(contracts, bob, "before")
+
+      await dropPrice(contracts, alice)
+      await contracts.troveManager.liquidateTroves(2)
+      await updateWalletSnapshot(contracts, alice, "after")
+      await updateWalletSnapshot(contracts, bob, "after")
+
+      // Balances should remain unchanged
+      expect(alice.musd.after).to.equal(alice.musd.before + to1e18("200"))
+      expect(bob.musd.after).to.equal(bob.musd.before)
+    })
+
+    it("Liquidating troves at 100 < ICR < 110 with SP deposits correctly impacts their SP deposit and collateral gains", async () => {
+      // Open three troves: Alice, Bob, Carol
+      await setupTroveAndSnapshot(alice, "2000", "200")
+      await setupTroveAndSnapshot(bob, "2000", "200")
+      await setupTroveAndSnapshot(carol, "20,000", "210")
+
+      // All deposit into the stability pool
+      const aliceDeposit = to1e18("500")
+      const bobDeposit = to1e18("1000")
+      const carolDeposit = to1e18("3000")
+      await provideToSP(contracts, alice, aliceDeposit)
+      await provideToSP(contracts, bob, bobDeposit)
+      await provideToSP(contracts, carol, carolDeposit)
+
+      await updateStabilityPoolUserSnapshots(
+        contracts,
+        [alice, bob, carol],
+        "before",
+      )
+
+      await dropPrice(contracts, alice, to1e18("105"))
+      await contracts.troveManager.liquidateTroves(2)
+
+      // Check that each user's deposit has decreased by their share of the total liquidated debt
+      const totalDeposits = aliceDeposit + bobDeposit + carolDeposit
+      const liquidatedDebt = alice.trove.debt.before + bob.trove.debt.before
+      await updateStabilityPoolUserSnapshots(
+        contracts,
+        [alice, bob, carol],
+        "after",
+      )
+
+      expect(
+        aliceDeposit - (liquidatedDebt * aliceDeposit) / totalDeposits,
+      ).to.be.closeTo(alice.stabilityPool.compoundedDeposit.after, 1000)
+      expect(
+        bobDeposit - (liquidatedDebt * bobDeposit) / totalDeposits,
+      ).to.be.closeTo(bob.stabilityPool.compoundedDeposit.after, 1000)
+      expect(
+        carolDeposit - (liquidatedDebt * carolDeposit) / totalDeposits,
+      ).to.be.closeTo(carol.stabilityPool.compoundedDeposit.after, 10000)
+
+      // Check that each user's collateral gain has increased by their share of the total liquidated collateral
+      const liquidatedColl = applyLiquidationFee(
+        alice.trove.collateral.before + bob.trove.collateral.before,
+      )
+      expect((liquidatedColl * aliceDeposit) / totalDeposits).to.be.closeTo(
+        alice.stabilityPool.collateralGain.after,
+        1000,
+      )
+      expect((liquidatedColl * bobDeposit) / totalDeposits).to.be.closeTo(
+        bob.stabilityPool.collateralGain.after,
+        1000,
+      )
+      expect((liquidatedColl * carolDeposit) / totalDeposits).to.be.closeTo(
+        carol.stabilityPool.collateralGain.after,
+        10000,
+      )
+    })
+
+    it("Liquidating troves at ICR <=100% with SP deposits does not alter their deposit or collateral gain", async () => {
+      // Open three troves: Alice, Bob, Carol
+      await setupTroveAndSnapshot(alice, "2000", "200")
+      await setupTroveAndSnapshot(bob, "2000", "200")
+      await setupTroveAndSnapshot(carol, "20,000", "200")
+
+      // All deposit into the stability pool
+      const aliceDeposit = to1e18("500")
+      const bobDeposit = to1e18("1000")
+      const carolDeposit = to1e18("3000")
+      await provideToSP(contracts, alice, aliceDeposit)
+      await provideToSP(contracts, bob, bobDeposit)
+      await provideToSP(contracts, carol, carolDeposit)
+
+      await updateStabilityPoolUserSnapshots(
+        contracts,
+        [alice, bob, carol],
+        "before",
+      )
+
+      await dropPrice(contracts, alice, to1e18("100"))
+      await contracts.troveManager.liquidateTroves(3)
+
+      // Check that each user's deposit has not changed
+      await updateStabilityPoolUserSnapshots(
+        contracts,
+        [alice, bob, carol],
+        "after",
+      )
+
+      expect(aliceDeposit).to.equal(alice.stabilityPool.compoundedDeposit.after)
+      expect(bobDeposit).to.equal(bob.stabilityPool.compoundedDeposit.after)
+      expect(carolDeposit).to.equal(carol.stabilityPool.compoundedDeposit.after)
+
+      // Check that each user's collateral gain has not changed
+      expect(0n).to.equal(alice.stabilityPool.collateralGain.after)
+      expect(0n).to.equal(bob.stabilityPool.collateralGain.after)
+      expect(0n).to.equal(carol.stabilityPool.collateralGain.after)
+    })
+
     context("Expected Reverts", () => {
-      it("liquidateTroves(): reverts if n = 0", async () => {
+      it("reverts if n = 0", async () => {
         await setupTrove(alice, "5000", "150")
         await setupTrove(bob, "5000", "150")
 
@@ -134,7 +504,7 @@ describe("TroveManager in Recovery Mode", () => {
         ).to.be.revertedWith("TroveManager: nothing to liquidate")
       })
 
-      it("liquidateTroves(): does nothing if all troves have ICR > 110% and Stability Pool is empty", async () => {
+      it("does nothing if all troves have ICR > 110% and Stability Pool is empty", async () => {
         await setupTrove(alice, "5000", "200")
         await setupTrove(bob, "5000", "200")
         await expect(
@@ -143,13 +513,8 @@ describe("TroveManager in Recovery Mode", () => {
       })
     })
 
-    /**
-     *
-     * Emitted Events
-     *
-     */
     context("Emitted Events", () => {
-      it("liquidateTroves(): emits liquidation event with correct values when all troves have ICR > 110% and Stability Pool covers a subset of troves", async () => {
+      it("emits liquidation event with correct values when all troves have ICR > 110% and Stability Pool covers a subset of troves", async () => {
         // Users to be absorbed by the SP
         await setupTroveAndSnapshot(alice, "2000", "200")
         await setupTroveAndSnapshot(bob, "2000", "200")
@@ -177,430 +542,10 @@ describe("TroveManager in Recovery Mode", () => {
         )
       })
     })
-
-    /**
-     *
-     * System State Changes
-     *
-     */
-    context("System State Changes", () => {
-      it("liquidateTroves(): a liquidation sequence containing Pool offsets increases the TCR", async () => {
-        await setupTrove(alice, "5000", "150")
-        await setupTrove(bob, "50,000", "400")
-        await setupTrove(carol, "5000", "150")
-
-        await provideToSP(contracts, bob, to1e18("10,000"))
-
-        await dropPrice(contracts, alice)
-        await updateTroveManagerSnapshot(contracts, state, "before")
-        await contracts.troveManager.liquidateTroves(2)
-        await updateTroveManagerSnapshot(contracts, state, "after")
-        expect(state.troveManager.TCR.after).to.be.greaterThan(
-          state.troveManager.TCR.before,
-        )
-      })
-
-      it("liquidateTroves(): A liquidation sequence of pure redistributions decreases the TCR, due to gas compensation, but up to 0.5%", async () => {
-        await setupTrove(alice, "5000", "400")
-        await setupTrove(bob, "50,000", "5000")
-        await setupTrove(carol, "2000", "400")
-        await setupTrove(dennis, "2000", "400")
-
-        // Drop the price to make everyone but Bob eligible for liquidation and snapshot the TCR
-        await dropPrice(contracts, alice)
-        await updateTroveManagerSnapshot(contracts, state, "before")
-
-        // Perform liquidation and check that TCR has decreased
-        await contracts.troveManager.liquidateTroves(4)
-        await updateTroveManagerSnapshot(contracts, state, "after")
-        expect(state.troveManager.TCR.before).to.be.greaterThan(
-          state.troveManager.TCR.after,
-        )
-
-        // Check that the TCR has decreased by no more than the liquidation fee
-        expect(state.troveManager.TCR.after).to.be.greaterThanOrEqual(
-          applyLiquidationFee(state.troveManager.TCR.before),
-        )
-      })
-    })
-
-    /**
-     *
-     * Individual Troves
-     *
-     */
-    context("Individual Troves", () => {
-      it("liquidateTroves(): With all ICRs > 110%, Liquidates Troves until system leaves recovery mode", async () => {
-        // Open 5 troves
-        await setupTroveAndSnapshot(bob, "5000", "240")
-        await setupTroveAndSnapshot(carol, "5000", "240")
-        await setupTroveAndSnapshot(dennis, "5000", "232")
-        await setupTroveAndSnapshot(eric, "5000", "230")
-        await setupTroveAndSnapshot(frank, "5000", "228")
-
-        // Open a trove for Alice that contains the debt of 3 other troves plus min debt
-        const amount =
-          dennis.trove.debt.before +
-          eric.trove.debt.before +
-          frank.trove.debt.before
-
-        await openTrove(contracts, {
-          musdAmount: amount + to1e18("1800"),
-          sender: alice.wallet,
-          ICR: "400",
-        })
-
-        // Alice provides the total debt to the SP
-        await provideToSP(contracts, alice, amount)
-
-        // Drop the price to put the system into recovery mode (TCR < 150%)
-        // Since frank has the lowest ICR, everyone else should have ICR > 111%
-        await dropPrice(contracts, frank, to1e18("111"))
-        expect(await checkRecoveryMode()).to.equal(true)
-
-        // Liquidate Troves until the system leaves recovery mode
-        await contracts.troveManager.liquidateTroves(5n)
-
-        // Check that we are no longer in recovery mode
-        expect(await checkRecoveryMode()).to.equal(false)
-
-        // Only frank should be liquidated, everyone else is still active
-        expect(await checkTroveActive(contracts, alice)).to.equal(true)
-        expect(await checkTroveActive(contracts, bob)).to.equal(true)
-        expect(await checkTroveActive(contracts, carol)).to.equal(true)
-        expect(await checkTroveActive(contracts, dennis)).to.equal(true)
-        expect(await checkTroveActive(contracts, eric)).to.equal(true)
-        expect(await checkTroveClosedByLiquidation(contracts, frank)).to.equal(
-          true,
-        )
-      })
-
-      it("liquidateTroves(): Liquidates Troves until 1) system has left recovery mode AND 2) it reaches a Trove with ICR >= 110%", async () => {
-        // Open 5 troves
-        await setupTroveAndSnapshot(bob, "5000", "240")
-        await setupTroveAndSnapshot(carol, "5000", "240")
-        await setupTroveAndSnapshot(dennis, "5000", "230")
-        await setupTroveAndSnapshot(eric, "5000", "240")
-        await setupTroveAndSnapshot(frank, "5000", "240")
-
-        // Open another trove for Eric that contains the total debt of the other troves plus min debt
-        const liquidationAmount =
-          bob.trove.debt.before +
-          carol.trove.debt.before +
-          dennis.trove.debt.before +
-          eric.trove.debt.before +
-          frank.trove.debt.before
-
-        await openTrove(contracts, {
-          musdAmount: liquidationAmount + to1e18("1800"),
-          sender: alice.wallet,
-          ICR: "400",
-        })
-
-        // Alice provides the total debt to the SP
-        await provideToSP(contracts, alice, liquidationAmount)
-
-        // Drop the price to put the system into recovery mode (TCR < 150%)
-        await dropPrice(contracts, dennis, to1e18("105"))
-        expect(await checkRecoveryMode()).to.equal(true)
-        await updateTroveSnapshots(
-          contracts,
-          [alice, bob, carol, dennis, eric, frank],
-          "after",
-        )
-
-        // Liquidate Troves until the system leaves recovery mode
-        await contracts.troveManager.liquidateTroves(6n)
-
-        // Check that we are no longer in recovery mode
-        expect(await checkRecoveryMode()).to.equal(false)
-
-        // Alice should still be active, everyone else is closed by liquidation
-        expect(await checkTroveActive(contracts, alice)).to.equal(true)
-        expect(await checkTroveClosedByLiquidation(contracts, bob)).to.equal(
-          true,
-        )
-        expect(await checkTroveClosedByLiquidation(contracts, carol)).to.equal(
-          true,
-        )
-        expect(await checkTroveClosedByLiquidation(contracts, dennis)).to.equal(
-          true,
-        )
-        expect(await checkTroveClosedByLiquidation(contracts, eric)).to.equal(
-          true,
-        )
-        expect(await checkTroveClosedByLiquidation(contracts, frank)).to.equal(
-          true,
-        )
-      })
-
-      it("liquidateTroves(): liquidates only up to the requested number of undercollateralized troves", async () => {
-        await setupTrove(alice, "5000", "150")
-        await setupTrove(bob, "5000", "150")
-
-        await dropPrice(contracts, alice, to1e18("100"))
-
-        await contracts.troveManager.liquidateTroves(1n)
-
-        expect(await checkTroveClosedByLiquidation(contracts, alice)).to.equal(
-          true,
-        )
-        expect(await checkTroveActive(contracts, bob)).to.equal(true)
-      })
-
-      it("liquidateTroves(): closes every Trove with ICR < MCR, when n > number of undercollateralized troves", async () => {
-        const underCollateralizedUsers = [alice, carol, dennis, eric]
-        await Promise.all(
-          underCollateralizedUsers.map((user) =>
-            setupTrove(user, "5000", "150"),
-          ),
-        )
-        await setupTrove(bob, "50,000", "200")
-
-        await provideToSP(contracts, bob, to1e18("25,000"))
-        await dropPrice(contracts, alice)
-
-        await contracts.troveManager.liquidateTroves(5n)
-        const closedByLiquidation = await Promise.all(
-          underCollateralizedUsers.map((user) =>
-            checkTroveClosedByLiquidation(contracts, user),
-          ),
-        )
-        expect(closedByLiquidation.every(Boolean)).to.equal(true)
-
-        expect(await checkTroveActive(contracts, bob)).to.equal(true)
-      })
-
-      it("liquidateTroves(): liquidates based on entire/collateral debt (including pending rewards), not raw collateral/debt", async () => {
-        await setupTrove(alice, "2000", "400")
-        await setupTrove(bob, "2000", "200.01")
-        await setupTrove(carol, "2000", "200")
-        await setupTrove(dennis, "2000", "200")
-
-        // Drop the price so that Carol and Dennis are at risk for liquidation, but do not liquidate anyone yet
-        const newPrice = await dropPrice(contracts, dennis)
-
-        // Check that Bob's ICR is above the MCR after the price drop and before liquidation
-        await updateTroveSnapshot(contracts, bob, "before")
-        const mcr = await contracts.troveManager.MCR()
-        expect(bob.trove.icr.before).to.be.greaterThan(mcr)
-
-        // Liquidate Dennis, creating rewards for everyone
-        await contracts.troveManager.liquidate(dennis.wallet)
-
-        // Check that Bob's ICR is below the MCR following liquidation
-        await updateTroveSnapshot(contracts, bob, "after")
-        expect(bob.trove.icr.after).to.be.lessThan(mcr)
-
-        // Check that Bob's raw ICR (debt and coll less pending rewards) is above the MCR
-        const rawICR =
-          (bob.trove.collateral.after * newPrice) / bob.trove.debt.after
-        expect(rawICR).to.be.greaterThan(mcr)
-
-        // Attempt to liquidate all troves
-        await contracts.troveManager.liquidateTroves(3)
-
-        // Check that Alice stays active and Carol and Bob get liquidated
-        expect(await checkTroveActive(contracts, alice)).to.equal(true)
-        expect(await checkTroveClosedByLiquidation(contracts, bob)).to.equal(
-          true,
-        )
-        expect(await checkTroveClosedByLiquidation(contracts, carol)).to.equal(
-          true,
-        )
-      })
-
-      it("liquidateTroves() with a non fulfilled liquidation: still can liquidate further troves after the non-liquidated, emptied pool", async () => {
-        await setupTroveAndSnapshot(alice, "5000", "150")
-        await setupTroveAndSnapshot(bob, "5000", "150")
-        await setupTroveAndSnapshot(carol, "20,000", "180")
-        await setupTroveAndSnapshot(dennis, "2000", "160")
-
-        // Carol deposits enough to cover Alice and Dennis' debt
-        const spDeposit = alice.trove.debt.before + dennis.trove.debt.before
-        await provideToSP(contracts, carol, spDeposit)
-
-        await dropPrice(contracts, alice, to1e18("115"))
-
-        // Troves in ICR order: Alice, Bob, Dennis, Carol
-        await contracts.troveManager.liquidateTroves(4)
-
-        expect(await checkTroveClosedByLiquidation(contracts, alice)).to.equal(
-          true,
-        )
-        // SP can cover Dennis' debt, so he gets liquidated even though he has a higher ICR than Bob
-        expect(await checkTroveClosedByLiquidation(contracts, dennis)).to.equal(
-          true,
-        )
-        expect(await checkTroveActive(contracts, bob)).to.equal(true)
-        expect(await checkTroveActive(contracts, carol)).to.equal(true)
-      })
-
-      it("liquidateTroves() with a non fulfilled liquidation: non liquidated trove remains active", async () => {
-        await setupTroveAndSnapshot(alice, "5000", "150")
-        await setupTroveAndSnapshot(bob, "5000", "150")
-        await setupTroveAndSnapshot(carol, "20,000", "160")
-
-        // Carol deposits enough to cover Alice's debt and half of Bob's
-        const spDeposit = alice.trove.debt.before + bob.trove.debt.before / 2n
-        await provideToSP(contracts, carol, spDeposit)
-
-        await dropPrice(contracts, alice, to1e18("115"))
-        await contracts.troveManager.liquidateTroves(2)
-
-        expect(await checkTroveClosedByLiquidation(contracts, alice)).to.equal(
-          true,
-        )
-        // Bob should remain active because his trove was only partially liquidated
-        expect(await checkTroveActive(contracts, bob)).to.equal(true)
-        expect(await checkTroveActive(contracts, carol)).to.equal(true)
-      })
-    })
-
-    /**
-     *
-     * Balance changes
-     *
-     */
-    context("Balance changes", () => {
-      it("liquidateTroves(): does not affect the liquidated user's token balances", async () => {
-        await setupTrove(alice, "5000", "150")
-        await setupTrove(bob, "5000", "150")
-        await updateWalletSnapshot(contracts, alice, "before")
-        await updateWalletSnapshot(contracts, bob, "before")
-
-        await dropPrice(contracts, alice)
-        await contracts.troveManager.liquidateTroves(2)
-        await updateWalletSnapshot(contracts, alice, "after")
-        await updateWalletSnapshot(contracts, bob, "after")
-
-        // Balances should remain unchanged
-        expect(alice.musd.after).to.equal(alice.musd.before + to1e18("200"))
-        expect(bob.musd.after).to.equal(bob.musd.before)
-      })
-
-      it("liquidateTroves(): Liquidating troves at 100 < ICR < 110 with SP deposits correctly impacts their SP deposit and collateral gains", async () => {
-        // Open three troves: Alice, Bob, Carol
-        await setupTroveAndSnapshot(alice, "2000", "200")
-        await setupTroveAndSnapshot(bob, "2000", "200")
-        await setupTroveAndSnapshot(carol, "20,000", "210")
-
-        // All deposit into the stability pool
-        const aliceDeposit = to1e18("500")
-        const bobDeposit = to1e18("1000")
-        const carolDeposit = to1e18("3000")
-        await provideToSP(contracts, alice, aliceDeposit)
-        await provideToSP(contracts, bob, bobDeposit)
-        await provideToSP(contracts, carol, carolDeposit)
-
-        await updateStabilityPoolUserSnapshots(
-          contracts,
-          [alice, bob, carol],
-          "before",
-        )
-
-        await dropPrice(contracts, alice, to1e18("105"))
-        await contracts.troveManager.liquidateTroves(2)
-
-        // Check that each user's deposit has decreased by their share of the total liquidated debt
-        const totalDeposits = aliceDeposit + bobDeposit + carolDeposit
-        const liquidatedDebt = alice.trove.debt.before + bob.trove.debt.before
-        await updateStabilityPoolUserSnapshots(
-          contracts,
-          [alice, bob, carol],
-          "after",
-        )
-
-        expect(
-          aliceDeposit - (liquidatedDebt * aliceDeposit) / totalDeposits,
-        ).to.be.closeTo(alice.stabilityPool.compoundedDeposit.after, 1000)
-        expect(
-          bobDeposit - (liquidatedDebt * bobDeposit) / totalDeposits,
-        ).to.be.closeTo(bob.stabilityPool.compoundedDeposit.after, 1000)
-        expect(
-          carolDeposit - (liquidatedDebt * carolDeposit) / totalDeposits,
-        ).to.be.closeTo(carol.stabilityPool.compoundedDeposit.after, 10000)
-
-        // Check that each user's collateral gain has increased by their share of the total liquidated collateral
-        const liquidatedColl = applyLiquidationFee(
-          alice.trove.collateral.before + bob.trove.collateral.before,
-        )
-        expect((liquidatedColl * aliceDeposit) / totalDeposits).to.be.closeTo(
-          alice.stabilityPool.collateralGain.after,
-          1000,
-        )
-        expect((liquidatedColl * bobDeposit) / totalDeposits).to.be.closeTo(
-          bob.stabilityPool.collateralGain.after,
-          1000,
-        )
-        expect((liquidatedColl * carolDeposit) / totalDeposits).to.be.closeTo(
-          carol.stabilityPool.collateralGain.after,
-          10000,
-        )
-      })
-
-      it("liquidateTroves(): Liquidating troves at ICR <=100% with SP deposits does not alter their deposit or collateral gain", async () => {
-        // Open three troves: Alice, Bob, Carol
-        await setupTroveAndSnapshot(alice, "2000", "200")
-        await setupTroveAndSnapshot(bob, "2000", "200")
-        await setupTroveAndSnapshot(carol, "20,000", "200")
-
-        // All deposit into the stability pool
-        const aliceDeposit = to1e18("500")
-        const bobDeposit = to1e18("1000")
-        const carolDeposit = to1e18("3000")
-        await provideToSP(contracts, alice, aliceDeposit)
-        await provideToSP(contracts, bob, bobDeposit)
-        await provideToSP(contracts, carol, carolDeposit)
-
-        await updateStabilityPoolUserSnapshots(
-          contracts,
-          [alice, bob, carol],
-          "before",
-        )
-
-        await dropPrice(contracts, alice, to1e18("100"))
-        await contracts.troveManager.liquidateTroves(3)
-
-        // Check that each user's deposit has not changed
-        await updateStabilityPoolUserSnapshots(
-          contracts,
-          [alice, bob, carol],
-          "after",
-        )
-
-        expect(aliceDeposit).to.equal(
-          alice.stabilityPool.compoundedDeposit.after,
-        )
-        expect(bobDeposit).to.equal(bob.stabilityPool.compoundedDeposit.after)
-        expect(carolDeposit).to.equal(
-          carol.stabilityPool.compoundedDeposit.after,
-        )
-
-        // Check that each user's collateral gain has not changed
-        expect(0n).to.equal(alice.stabilityPool.collateralGain.after)
-        expect(0n).to.equal(bob.stabilityPool.collateralGain.after)
-        expect(0n).to.equal(carol.stabilityPool.collateralGain.after)
-      })
-    })
-
-    /**
-     *
-     * Fees
-     *
-     */
-    context("Fees", () => {})
-
-    /**
-     *
-     * State change in other contracts
-     *
-     */
-    context("State change in other contracts", () => {})
   })
 
   describe("checkRecoveryMode()", () => {
-    it("checkRecoveryMode(): Returns true if TCR falls below CCR", async () => {
+    it("Returns true if TCR falls below CCR", async () => {
       await openTrove(contracts, {
         musdAmount: "5000",
         ICR: "400",
@@ -613,7 +558,7 @@ describe("TroveManager in Recovery Mode", () => {
       expect(recoveryMode).to.equal(true)
     })
 
-    it("checkRecoveryMode(): returns false if TCR stays above CCR", async () => {
+    it("returns false if TCR stays above CCR", async () => {
       await openTrove(contracts, {
         musdAmount: "5000",
         ICR: "400",
@@ -626,7 +571,7 @@ describe("TroveManager in Recovery Mode", () => {
       expect(recoveryMode).to.equal(false)
     })
 
-    it("checkRecoveryMode(): returns false if TCR rises above CCR", async () => {
+    it("returns false if TCR rises above CCR", async () => {
       await openTrove(contracts, {
         musdAmount: "5000",
         ICR: "400",
@@ -655,8 +600,343 @@ describe("TroveManager in Recovery Mode", () => {
       return price
     }
 
+    it("with ICR < 100%: removes stake and updates totalStakes", async () => {
+      await setupTroveAndLiquidateBob()
+
+      await updateTroveSnapshot(contracts, alice, "after")
+      await updateTroveSnapshot(contracts, bob, "after")
+      await updateTroveManagerSnapshot(contracts, state, "after")
+
+      expect(bob.trove.stake.after).to.equal(0n)
+      expect(state.troveManager.stakes.after).to.equal(
+        alice.trove.collateral.after,
+      )
+    })
+
+    it("with 100% < ICR < 110%: removes stake and updates totalStakes", async () => {
+      await setupTroveAndLiquidateBob(to1e18("105"))
+
+      await updateTroveSnapshot(contracts, alice, "after")
+      await updateTroveSnapshot(contracts, bob, "after")
+      await updateTroveManagerSnapshot(contracts, state, "after")
+
+      expect(bob.trove.stake.after).to.equal(0n)
+      expect(state.troveManager.stakes.after).to.equal(
+        alice.trove.collateral.after,
+      )
+    })
+
+    it("with ICR < 100%: updates system snapshots correctly", async () => {
+      await setupTroveAndLiquidateBob()
+
+      await updateTroveManagerSnapshot(contracts, state, "after")
+
+      expect(state.troveManager.collateralSnapshot.after).to.equal(
+        await getTroveEntireColl(contracts, alice.wallet),
+      )
+      expect(state.troveManager.stakesSnapshot.after).to.equal(
+        alice.trove.stake.before,
+      )
+    })
+
+    it("with 100% < ICR < 110%: updates system snapshots correctly", async () => {
+      await setupTroveAndLiquidateBob(to1e18("105"))
+
+      await updateTroveManagerSnapshot(contracts, state, "after")
+
+      expect(state.troveManager.collateralSnapshot.after).to.equal(
+        await getTroveEntireColl(contracts, alice.wallet),
+      )
+      expect(state.troveManager.stakesSnapshot.after).to.equal(
+        alice.trove.stake.before,
+      )
+    })
+
+    it("with ICR < 100%: closes the Trove and removes it from the Trove array", async () => {
+      await setupTroveAndLiquidateBob()
+
+      expect(await checkTroveClosedByLiquidation(contracts, bob)).to.equal(true)
+    })
+
+    it("with 100% < ICR < 110%: closes the Trove and removes it from the Trove array", async () => {
+      await setupTroveAndLiquidateBob(to1e18("105"))
+
+      expect(await checkTroveClosedByLiquidation(contracts, bob)).to.equal(true)
+    })
+
+    it("liquidates based on entire collateral/debt (including pending rewards), not raw collateral/debt", async () => {
+      await setupTroveAndSnapshot(alice, "2000", "400")
+      await setupTroveAndSnapshot(bob, "2000", "221")
+      await setupTroveAndSnapshot(carol, "2000", "200")
+      await setupTroveAndSnapshot(dennis, "2000", "200")
+
+      // Drop the price and liquidate Dennis to create pending rewards for everyone
+      const price = await dropPrice(contracts, dennis, to1e18("100"))
+      await contracts.troveManager.liquidate(dennis.address)
+
+      await updateTroveSnapshot(contracts, bob, "after")
+
+      expect(await contracts.troveManager.checkRecoveryMode(price)).to.equal(
+        true,
+      )
+
+      // Check that Bob's "raw" ICR (not including pending rewards) is above MCR
+      const mcr = await contracts.troveManager.MCR()
+      expect(
+        (bob.trove.collateral.after * price) / bob.trove.debt.after,
+      ).to.be.greaterThan(mcr)
+
+      // Bob's ICR (with pending rewards) should be below MCR
+      expect(bob.trove.icr.after).to.be.lessThan(mcr)
+
+      await expect(
+        contracts.troveManager.liquidate(alice.address),
+      ).to.be.revertedWith("TroveManager: nothing to liquidate")
+      await contracts.troveManager.liquidate(bob.address)
+      await contracts.troveManager.liquidate(carol.address)
+
+      expect(await checkTroveActive(contracts, alice))
+      expect(await checkTroveClosedByLiquidation(contracts, bob))
+      expect(await checkTroveClosedByLiquidation(contracts, carol))
+    })
+
+    it("does not alter the liquidated user's token balance", async () => {
+      await setupTroveAndSnapshot(alice, "5000", "400")
+      await setupTroveAndSnapshot(bob, "5000", "400")
+      await dropPriceAndLiquidate(contracts, alice)
+      expect(await contracts.musd.balanceOf(alice.wallet)).to.equal(
+        to1e18("5200"),
+      )
+    })
+
+    it("with ICR < 100%: only redistributes to active Troves - no offset to Stability Pool", async () => {
+      await setupTroveAndSnapshot(alice, "5000", "400")
+      await setupTroveAndSnapshot(bob, "5000", "150")
+
+      await updateStabilityPoolSnapshot(contracts, state, "before")
+
+      await dropPriceAndLiquidate(contracts, bob)
+      await updateStabilityPoolSnapshot(contracts, state, "after")
+
+      expect(state.stabilityPool.musd.after).to.equal(
+        state.stabilityPool.musd.before,
+      )
+    })
+
+    it("with 100% < ICR < 110%: offsets as much debt as possible with the Stability Pool, then redistributes the remainder coll and debt", async () => {
+      await setupTroveAndSnapshot(alice, "5000", "150")
+      await setupTroveAndSnapshot(bob, "5000", "150")
+      const spDeposit = to1e18("1000")
+      await provideToSP(contracts, alice, spDeposit)
+
+      await updateStabilityPoolSnapshot(contracts, state, "before")
+      await updatePendingSnapshot(contracts, alice, "after")
+
+      await dropPrice(contracts, bob, to1e18("105"))
+      await contracts.troveManager.liquidate(bob.address)
+      await updateStabilityPoolSnapshot(contracts, state, "after")
+      await updatePendingSnapshot(contracts, alice, "after")
+
+      expect(state.stabilityPool.musd.after).to.equal(0n)
+      expect(alice.pending.debt.after).to.be.closeTo(
+        bob.trove.debt.before - spDeposit,
+        100n,
+      )
+      expect(alice.pending.collateral.after).to.be.closeTo(
+        applyLiquidationFee(bob.trove.collateral.before) -
+          state.stabilityPool.collateral.after,
+        100n,
+      )
+    })
+
+    it("with 110% < ICR < TCR, and StabilityPool MUSD > debt to liquidate: offsets the trove entirely with the pool", async () => {
+      const { spDeposit, totalDebt } = await setupTrovesForStabilityPoolTests()
+
+      await updateStabilityPoolSnapshot(contracts, state, "before")
+      await dropPrice(contracts, bob, to1e18("112"))
+      await contracts.troveManager.liquidate(bob.address)
+      await updateStabilityPoolSnapshot(contracts, state, "after")
+
+      expect(state.stabilityPool.musd.after).to.equal(spDeposit - totalDebt)
+    })
+
+    it("with ICR% = 110 < TCR, and StabilityPool MUSD > debt to liquidate: offsets the trove entirely with the pool, there’s no collateral surplus", async () => {
+      await setupTrovesForStabilityPoolTests()
+
+      await dropPrice(contracts, bob, to1e18("110"))
+      await contracts.troveManager.liquidate(bob.address)
+
+      expect(
+        await contracts.collSurplusPool.getCollateral(bob.address),
+      ).to.equal(0n)
+    })
+
+    it("with 110% < ICR < TCR, and StabilityPool MUSD > debt to liquidate: removes stake and updates totalStakes", async () => {
+      await setupTrovesForStabilityPoolTests()
+
+      await updateStabilityPoolSnapshot(contracts, state, "before")
+      await dropPrice(contracts, bob, to1e18("112"))
+      await contracts.troveManager.liquidate(bob.address)
+      await updateStabilityPoolSnapshot(contracts, state, "after")
+
+      await updateTroveSnapshot(contracts, bob, "after")
+      await updateTroveManagerSnapshot(contracts, state, "after")
+      expect(bob.trove.stake.after).to.equal(0n)
+      expect(state.troveManager.stakes.after).to.equal(
+        alice.trove.collateral.before + dennis.trove.collateral.before,
+      )
+    })
+
+    it("with 110% < ICR < TCR, and StabilityPool MUSD > debt to liquidate: updates system snapshots", async () => {
+      await setupTrovesForStabilityPoolTests()
+      await updateTroveManagerSnapshot(contracts, state, "before")
+      await dropPrice(contracts, bob, to1e18("112"))
+      await contracts.troveManager.liquidate(bob.address)
+      await updateTroveManagerSnapshot(contracts, state, "after")
+      expect(state.troveManager.stakesSnapshot.after).to.equal(
+        alice.trove.collateral.before + dennis.trove.collateral.before,
+      )
+      expect(state.troveManager.collateralSnapshot.after).to.equal(
+        alice.trove.collateral.before + dennis.trove.collateral.before,
+      )
+    })
+
+    it("with 110% < ICR < TCR, and StabilityPool MUSD > debt to liquidate: closes the Trove", async () => {
+      await setupTrovesForStabilityPoolTests()
+      await dropPrice(contracts, bob, to1e18("112"))
+      await contracts.troveManager.liquidate(bob.address)
+      expect(await checkTroveClosedByLiquidation(contracts, bob)).to.equal(true)
+    })
+
+    it("with 110% < ICR < TCR, and StabilityPool THUSD > debt to liquidate: can liquidate troves out of order", async () => {
+      await setupTroveAndSnapshot(alice, "5000", "200")
+      await setupTroveAndSnapshot(bob, "5000", "202")
+      await setupTroveAndSnapshot(carol, "5000", "204")
+      await setupTroveAndSnapshot(dennis, "5000", "206")
+      const totalDebtToBeLiquidated =
+        alice.trove.debt.before +
+        bob.trove.debt.before +
+        carol.trove.debt.before +
+        dennis.trove.debt.before
+      await openTrove(contracts, {
+        musdAmount: totalDebtToBeLiquidated + to1e18("5000"),
+        ICR: "210",
+        sender: eric.wallet,
+      })
+
+      await provideToSP(contracts, eric, totalDebtToBeLiquidated + to1e18("1"))
+
+      await dropPrice(contracts, alice, to1e18("111"))
+
+      // Troves should be ordered by ICR, low to high: A, B, C, D, E
+      await updateTroveSnapshot(contracts, carol, "after")
+
+      // Liquidate out of ICR order
+      await contracts.troveManager.liquidate(carol.address)
+      await contracts.troveManager.liquidate(dennis.address)
+      await contracts.troveManager.liquidate(bob.address)
+      await contracts.troveManager.liquidate(alice.address)
+
+      expect(await checkTroveClosedByLiquidation(contracts, carol)).to.equal(
+        true,
+      )
+      expect(await checkTroveClosedByLiquidation(contracts, dennis)).to.equal(
+        true,
+      )
+      expect(await checkTroveClosedByLiquidation(contracts, bob)).to.equal(true)
+      expect(await checkTroveClosedByLiquidation(contracts, alice)).to.equal(
+        true,
+      )
+    })
+
+    it("with 110% < ICR < TCR, can claim collateral, re-open, be redeemed and claim again", async () => {
+      await setupTrovesForStabilityPoolTests()
+
+      const price = await contracts.priceFeed.fetchPrice()
+      await dropPrice(contracts, bob, to1e18("111"))
+      expect(await checkRecoveryMode()).to.equal(true)
+
+      await contracts.troveManager.liquidate(bob.address)
+
+      await contracts.borrowerOperations
+        .connect(bob.wallet)
+        .claimCollateral(NO_GAS)
+
+      await contracts.mockAggregator.setPrice(price)
+      const { netDebt } = await setupTrove(bob, "1800", "120")
+      await contracts.troveManager
+        .connect(dennis.wallet)
+        .redeemCollateral(
+          netDebt,
+          bob.address,
+          bob.address,
+          bob.address,
+          0,
+          0,
+          to1e18("1"),
+          NO_GAS,
+        )
+      await updateWalletSnapshot(contracts, bob, "before")
+      const surplus = await contracts.collSurplusPool.getCollateral(bob.address)
+      await contracts.borrowerOperations
+        .connect(bob.wallet)
+        .claimCollateral(NO_GAS)
+      await updateWalletSnapshot(contracts, bob, "after")
+      expect(bob.btc.after).to.equal(bob.btc.before + surplus)
+    })
+
+    it("with 110% < ICR < TCR, can claim collateral, after another claim from a redemption", async () => {
+      // Open two troves:
+      const { netDebt } = await setupTrove(bob, "2000", "222")
+      await setupTrove(alice, "5000", "266")
+
+      // A redeems some collateral, creating a surplus for B
+      await contracts.troveManager
+        .connect(alice.wallet)
+        .redeemCollateral(
+          netDebt,
+          bob.address,
+          bob.address,
+          bob.address,
+          0,
+          0,
+          to1e18("1"),
+          NO_GAS,
+        )
+
+      // B claims collateral
+      await contracts.borrowerOperations
+        .connect(bob.wallet)
+        .claimCollateral(NO_GAS)
+
+      // B reopens trove
+      const { totalDebt } = await setupTroveAndSnapshot(bob, "2000", "240")
+
+      // C opens a trove and deposits to SP
+      await setupTrove(carol, "5000", "266")
+      const spDeposit = totalDebt
+      await provideToSP(contracts, carol, spDeposit)
+
+      // Price drops, reducing TCR below 150%
+      await dropPrice(contracts, alice, to1e18("149"))
+
+      // B is liquidated
+      await contracts.troveManager.liquidate(bob.address)
+
+      // B claims collateral
+      await updateWalletSnapshot(contracts, bob, "before")
+      const surplus = await contracts.collSurplusPool.getCollateral(bob.address)
+      await contracts.borrowerOperations
+        .connect(bob.wallet)
+        .claimCollateral(NO_GAS)
+
+      // Check balance and coll surplus are equal
+      await updateWalletSnapshot(contracts, bob, "after")
+      expect(bob.btc.after).to.equal(bob.btc.before + surplus)
+    })
+
     context("Expected Reverts", () => {
-      it("liquidate(): reverts with ICR > 110%, and StabilityPool MUSD < liquidated debt", async () => {
+      it("reverts with ICR > 110%, and StabilityPool MUSD < liquidated debt", async () => {
         await setupTrovesStabilityPoolLessThanDebt()
 
         await dropPrice(contracts, bob, to1e18("112"))
@@ -665,7 +945,7 @@ describe("TroveManager in Recovery Mode", () => {
         ).to.be.revertedWith("TroveManager: nothing to liquidate")
       })
 
-      it("liquidate(): Doesn't liquidate undercollateralized trove if it is the only trove in the system", async () => {
+      it("Doesn't liquidate undercollateralized trove if it is the only trove in the system", async () => {
         await setupTrove(alice, "5000", "150")
         await dropPrice(contracts, alice, to1e18("99"))
         await expect(
@@ -673,7 +953,7 @@ describe("TroveManager in Recovery Mode", () => {
         ).to.be.revertedWith("TroveManager: nothing to liquidate")
       })
 
-      it("liquidate(), with ICR > 110%, trove has lowest ICR, and StabilityPool is empty: does nothing", async () => {
+      it("with ICR > 110%, trove has lowest ICR, and StabilityPool is empty: does nothing", async () => {
         await setupTroveAndSnapshot(alice, "50,000", "240")
         await setupTroveAndSnapshot(bob, "5000", "270")
 
@@ -683,7 +963,7 @@ describe("TroveManager in Recovery Mode", () => {
         ).to.be.revertedWith("TroveManager: nothing to liquidate")
       })
 
-      it("liquidate(): does nothing if trove ICR >= TCR, and SP covers trove's debt", async () => {
+      it("does nothing if trove ICR >= TCR, and SP covers trove's debt", async () => {
         await setupTroveAndSnapshot(alice, "5000", "200")
         await setupTroveAndSnapshot(bob, "15,000", "180")
 
@@ -697,7 +977,7 @@ describe("TroveManager in Recovery Mode", () => {
         ).to.be.revertedWith("TroveManager: nothing to liquidate")
       })
 
-      it("liquidate(): reverts if trove is non-existent", async () => {
+      it("reverts if trove is non-existent", async () => {
         await setupTrove(alice, "5000", "150")
         await dropPrice(contracts, alice, to1e18("100"))
         await expect(
@@ -705,7 +985,7 @@ describe("TroveManager in Recovery Mode", () => {
         ).to.be.revertedWith("TroveManager: Trove does not exist or is closed")
       })
 
-      it("liquidate(): reverts if trove has been closed", async () => {
+      it("reverts if trove has been closed", async () => {
         await setupTrove(alice, "5000", "150")
         await setupTrove(bob, "5000", "150")
         await dropPriceAndLiquidate(contracts, alice)
@@ -714,450 +994,39 @@ describe("TroveManager in Recovery Mode", () => {
         ).to.be.revertedWith("TroveManager: Trove does not exist or is closed")
       })
     })
-
-    context("Emitted Events", () => {})
-
-    context("System State Changes", () => {
-      it("liquidate(), with ICR < 100%: removes stake and updates totalStakes", async () => {
-        await setupTroveAndLiquidateBob()
-
-        await updateTroveSnapshot(contracts, alice, "after")
-        await updateTroveSnapshot(contracts, bob, "after")
-        await updateTroveManagerSnapshot(contracts, state, "after")
-
-        expect(bob.trove.stake.after).to.equal(0n)
-        expect(state.troveManager.stakes.after).to.equal(
-          alice.trove.collateral.after,
-        )
-      })
-
-      it("liquidate(), with 100% < ICR < 110%: removes stake and updates totalStakes", async () => {
-        await setupTroveAndLiquidateBob(to1e18("105"))
-
-        await updateTroveSnapshot(contracts, alice, "after")
-        await updateTroveSnapshot(contracts, bob, "after")
-        await updateTroveManagerSnapshot(contracts, state, "after")
-
-        expect(bob.trove.stake.after).to.equal(0n)
-        expect(state.troveManager.stakes.after).to.equal(
-          alice.trove.collateral.after,
-        )
-      })
-
-      it("liquidate(), with ICR < 100%: updates system snapshots correctly", async () => {
-        await setupTroveAndLiquidateBob()
-
-        await updateTroveManagerSnapshot(contracts, state, "after")
-
-        expect(state.troveManager.collateralSnapshot.after).to.equal(
-          await getTroveEntireColl(contracts, alice.wallet),
-        )
-        expect(state.troveManager.stakesSnapshot.after).to.equal(
-          alice.trove.stake.before,
-        )
-      })
-
-      it("liquidate(), with 100% < ICR < 110%: updates system snapshots correctly", async () => {
-        await setupTroveAndLiquidateBob(to1e18("105"))
-
-        await updateTroveManagerSnapshot(contracts, state, "after")
-
-        expect(state.troveManager.collateralSnapshot.after).to.equal(
-          await getTroveEntireColl(contracts, alice.wallet),
-        )
-        expect(state.troveManager.stakesSnapshot.after).to.equal(
-          alice.trove.stake.before,
-        )
-      })
-    })
-
-    context("Individual Troves", () => {
-      it("liquidate(), with ICR < 100%: closes the Trove and removes it from the Trove array", async () => {
-        await setupTroveAndLiquidateBob()
-
-        expect(await checkTroveClosedByLiquidation(contracts, bob)).to.equal(
-          true,
-        )
-      })
-
-      it("liquidate(), with 100% < ICR < 110%: closes the Trove and removes it from the Trove array", async () => {
-        await setupTroveAndLiquidateBob(to1e18("105"))
-
-        expect(await checkTroveClosedByLiquidation(contracts, bob)).to.equal(
-          true,
-        )
-      })
-
-      it("liquidate(): liquidates based on entire collateral/debt (including pending rewards), not raw collateral/debt", async () => {
-        await setupTroveAndSnapshot(alice, "2000", "400")
-        await setupTroveAndSnapshot(bob, "2000", "221")
-        await setupTroveAndSnapshot(carol, "2000", "200")
-        await setupTroveAndSnapshot(dennis, "2000", "200")
-
-        // Drop the price and liquidate Dennis to create pending rewards for everyone
-        const price = await dropPrice(contracts, dennis, to1e18("100"))
-        await contracts.troveManager.liquidate(dennis.address)
-
-        await updateTroveSnapshot(contracts, bob, "after")
-
-        expect(await contracts.troveManager.checkRecoveryMode(price)).to.equal(
-          true,
-        )
-
-        // Check that Bob's "raw" ICR (not including pending rewards) is above MCR
-        const mcr = await contracts.troveManager.MCR()
-        expect(
-          (bob.trove.collateral.after * price) / bob.trove.debt.after,
-        ).to.be.greaterThan(mcr)
-
-        // Bob's ICR (with pending rewards) should be below MCR
-        expect(bob.trove.icr.after).to.be.lessThan(mcr)
-
-        await expect(
-          contracts.troveManager.liquidate(alice.address),
-        ).to.be.revertedWith("TroveManager: nothing to liquidate")
-        await contracts.troveManager.liquidate(bob.address)
-        await contracts.troveManager.liquidate(carol.address)
-
-        expect(await checkTroveActive(contracts, alice))
-        expect(await checkTroveClosedByLiquidation(contracts, bob))
-        expect(await checkTroveClosedByLiquidation(contracts, carol))
-      })
-    })
-
-    context("Balance changes", () => {
-      it("liquidate(): does not alter the liquidated user's token balance", async () => {
-        await setupTroveAndSnapshot(alice, "5000", "400")
-        await setupTroveAndSnapshot(bob, "5000", "400")
-        await dropPriceAndLiquidate(contracts, alice)
-        expect(await contracts.musd.balanceOf(alice.wallet)).to.equal(
-          to1e18("5200"),
-        )
-      })
-    })
-
-    context("State changes in other contracts", () => {
-      it("liquidate(), with ICR < 100%: only redistributes to active Troves - no offset to Stability Pool", async () => {
-        await setupTroveAndSnapshot(alice, "5000", "400")
-        await setupTroveAndSnapshot(bob, "5000", "150")
-
-        await updateStabilityPoolSnapshot(contracts, state, "before")
-
-        await dropPriceAndLiquidate(contracts, bob)
-        await updateStabilityPoolSnapshot(contracts, state, "after")
-
-        expect(state.stabilityPool.musd.after).to.equal(
-          state.stabilityPool.musd.before,
-        )
-      })
-
-      it("liquidate(), with 100% < ICR < 110%: offsets as much debt as possible with the Stability Pool, then redistributes the remainder coll and debt", async () => {
-        await setupTroveAndSnapshot(alice, "5000", "150")
-        await setupTroveAndSnapshot(bob, "5000", "150")
-        const spDeposit = to1e18("1000")
-        await provideToSP(contracts, alice, spDeposit)
-
-        await updateStabilityPoolSnapshot(contracts, state, "before")
-        await updatePendingSnapshot(contracts, alice, "after")
-
-        await dropPrice(contracts, bob, to1e18("105"))
-        await contracts.troveManager.liquidate(bob.address)
-        await updateStabilityPoolSnapshot(contracts, state, "after")
-        await updatePendingSnapshot(contracts, alice, "after")
-
-        expect(state.stabilityPool.musd.after).to.equal(0n)
-        expect(alice.pending.debt.after).to.be.closeTo(
-          bob.trove.debt.before - spDeposit,
-          100n,
-        )
-        expect(alice.pending.collateral.after).to.be.closeTo(
-          applyLiquidationFee(bob.trove.collateral.before) -
-            state.stabilityPool.collateral.after,
-          100n,
-        )
-      })
-
-      it("liquidate(), with 110% < ICR < TCR, and StabilityPool MUSD > debt to liquidate: offsets the trove entirely with the pool", async () => {
-        const { spDeposit, totalDebt } =
-          await setupTrovesForStabilityPoolTests()
-
-        await updateStabilityPoolSnapshot(contracts, state, "before")
-        await dropPrice(contracts, bob, to1e18("112"))
-        await contracts.troveManager.liquidate(bob.address)
-        await updateStabilityPoolSnapshot(contracts, state, "after")
-
-        expect(state.stabilityPool.musd.after).to.equal(spDeposit - totalDebt)
-      })
-
-      it("liquidate(), with ICR% = 110 < TCR, and StabilityPool MUSD > debt to liquidate: offsets the trove entirely with the pool, there’s no collateral surplus", async () => {
-        await setupTrovesForStabilityPoolTests()
-
-        await dropPrice(contracts, bob, to1e18("110"))
-        await contracts.troveManager.liquidate(bob.address)
-
-        expect(
-          await contracts.collSurplusPool.getCollateral(bob.address),
-        ).to.equal(0n)
-      })
-
-      it("liquidate(), with  110% < ICR < TCR, and StabilityPool MUSD > debt to liquidate: removes stake and updates totalStakes", async () => {
-        await setupTrovesForStabilityPoolTests()
-
-        await updateStabilityPoolSnapshot(contracts, state, "before")
-        await dropPrice(contracts, bob, to1e18("112"))
-        await contracts.troveManager.liquidate(bob.address)
-        await updateStabilityPoolSnapshot(contracts, state, "after")
-
-        await updateTroveSnapshot(contracts, bob, "after")
-        await updateTroveManagerSnapshot(contracts, state, "after")
-        expect(bob.trove.stake.after).to.equal(0n)
-        expect(state.troveManager.stakes.after).to.equal(
-          alice.trove.collateral.before + dennis.trove.collateral.before,
-        )
-      })
-
-      it("liquidate(), with  110% < ICR < TCR, and StabilityPool MUSD > debt to liquidate: updates system snapshots", async () => {
-        await setupTrovesForStabilityPoolTests()
-        await updateTroveManagerSnapshot(contracts, state, "before")
-        await dropPrice(contracts, bob, to1e18("112"))
-        await contracts.troveManager.liquidate(bob.address)
-        await updateTroveManagerSnapshot(contracts, state, "after")
-        expect(state.troveManager.stakesSnapshot.after).to.equal(
-          alice.trove.collateral.before + dennis.trove.collateral.before,
-        )
-        expect(state.troveManager.collateralSnapshot.after).to.equal(
-          alice.trove.collateral.before + dennis.trove.collateral.before,
-        )
-      })
-
-      it("liquidate(), with 110% < ICR < TCR, and StabilityPool MUSD > debt to liquidate: closes the Trove", async () => {
-        await setupTrovesForStabilityPoolTests()
-        await dropPrice(contracts, bob, to1e18("112"))
-        await contracts.troveManager.liquidate(bob.address)
-        expect(await checkTroveClosedByLiquidation(contracts, bob)).to.equal(
-          true,
-        )
-      })
-
-      it("liquidate(), with 110% < ICR < TCR, and StabilityPool THUSD > debt to liquidate: can liquidate troves out of order", async () => {
-        await setupTroveAndSnapshot(alice, "5000", "200")
-        await setupTroveAndSnapshot(bob, "5000", "202")
-        await setupTroveAndSnapshot(carol, "5000", "204")
-        await setupTroveAndSnapshot(dennis, "5000", "206")
-        const totalDebtToBeLiquidated =
-          alice.trove.debt.before +
-          bob.trove.debt.before +
-          carol.trove.debt.before +
-          dennis.trove.debt.before
-        await openTrove(contracts, {
-          musdAmount: totalDebtToBeLiquidated + to1e18("5000"),
-          ICR: "210",
-          sender: eric.wallet,
-        })
-
-        await provideToSP(
-          contracts,
-          eric,
-          totalDebtToBeLiquidated + to1e18("1"),
-        )
-
-        await dropPrice(contracts, alice, to1e18("111"))
-
-        // Troves should be ordered by ICR, low to high: A, B, C, D, E
-        await updateTroveSnapshot(contracts, carol, "after")
-
-        // Liquidate out of ICR order
-        await contracts.troveManager.liquidate(carol.address)
-        await contracts.troveManager.liquidate(dennis.address)
-        await contracts.troveManager.liquidate(bob.address)
-        await contracts.troveManager.liquidate(alice.address)
-
-        expect(await checkTroveClosedByLiquidation(contracts, carol)).to.equal(
-          true,
-        )
-        expect(await checkTroveClosedByLiquidation(contracts, dennis)).to.equal(
-          true,
-        )
-        expect(await checkTroveClosedByLiquidation(contracts, bob)).to.equal(
-          true,
-        )
-        expect(await checkTroveClosedByLiquidation(contracts, alice)).to.equal(
-          true,
-        )
-      })
-
-      it("liquidate(): with 110% < ICR < TCR, can claim collateral, re-open, be redeemed and claim again", async () => {
-        await setupTrovesForStabilityPoolTests()
-
-        const price = await contracts.priceFeed.fetchPrice()
-        await dropPrice(contracts, bob, to1e18("111"))
-        expect(await checkRecoveryMode()).to.equal(true)
-
-        await contracts.troveManager.liquidate(bob.address)
-
-        await contracts.borrowerOperations
-          .connect(bob.wallet)
-          .claimCollateral(NO_GAS)
-
-        await contracts.mockAggregator.setPrice(price)
-        const { netDebt } = await setupTrove(bob, "1800", "120")
-        await contracts.troveManager
-          .connect(dennis.wallet)
-          .redeemCollateral(
-            netDebt,
-            bob.address,
-            bob.address,
-            bob.address,
-            0,
-            0,
-            to1e18("1"),
-            NO_GAS,
-          )
-        await updateWalletSnapshot(contracts, bob, "before")
-        const surplus = await contracts.collSurplusPool.getCollateral(
-          bob.address,
-        )
-        await contracts.borrowerOperations
-          .connect(bob.wallet)
-          .claimCollateral(NO_GAS)
-        await updateWalletSnapshot(contracts, bob, "after")
-        expect(bob.btc.after).to.equal(bob.btc.before + surplus)
-      })
-
-      it("liquidate(): with 110% < ICR < TCR, can claim collateral, after another claim from a redemption", async () => {
-        // Open two troves:
-        const { netDebt } = await setupTrove(bob, "2000", "222")
-        await setupTrove(alice, "5000", "266")
-
-        // A redeems some collateral, creating a surplus for B
-        await contracts.troveManager
-          .connect(alice.wallet)
-          .redeemCollateral(
-            netDebt,
-            bob.address,
-            bob.address,
-            bob.address,
-            0,
-            0,
-            to1e18("1"),
-            NO_GAS,
-          )
-
-        // B claims collateral
-        await contracts.borrowerOperations
-          .connect(bob.wallet)
-          .claimCollateral(NO_GAS)
-
-        // B reopens trove
-        const { totalDebt } = await setupTroveAndSnapshot(bob, "2000", "240")
-
-        // C opens a trove and deposits to SP
-        await setupTrove(carol, "5000", "266")
-        const spDeposit = totalDebt
-        await provideToSP(contracts, carol, spDeposit)
-
-        // Price drops, reducing TCR below 150%
-        await dropPrice(contracts, alice, to1e18("149"))
-
-        // B is liquidated
-        await contracts.troveManager.liquidate(bob.address)
-
-        // B claims collateral
-        await updateWalletSnapshot(contracts, bob, "before")
-        const surplus = await contracts.collSurplusPool.getCollateral(
-          bob.address,
-        )
-        await contracts.borrowerOperations
-          .connect(bob.wallet)
-          .claimCollateral(NO_GAS)
-
-        // Check balance and coll surplus are equal
-        await updateWalletSnapshot(contracts, bob, "after")
-        expect(bob.btc.after).to.equal(bob.btc.before + surplus)
-      })
-    })
   })
 
   describe("batchLiquidateTroves()", () => {
-    /**
-     *
-     * Expected Reverts
-     *
-     */
+    it("liquidating a single trove does not return to normal mode if TCR < MCR", async () => {
+      await setupBatchLiquidation()
+      await contracts.troveManager.batchLiquidateTroves([alice.address])
+      expect(await checkRecoveryMode()).to.equal(true)
+    })
+
+    it("troves with ICR > MCR can be liquidated", async () => {
+      await setupBatchLiquidation()
+      await contracts.troveManager.batchLiquidateTroves([
+        alice.address,
+        bob.address,
+        carol.address,
+      ])
+
+      expect(await checkTroveClosedByLiquidation(contracts, alice)).to.equal(
+        true,
+      )
+      expect(await checkTroveClosedByLiquidation(contracts, bob)).to.equal(true)
+      expect(await checkTroveClosedByLiquidation(contracts, carol)).to.equal(
+        true,
+      )
+    })
+
     context("Expected Reverts", () => {
-      it("batchLiquidateTroves(): does not liquidate troves with ICR > TCR", async () => {
+      it("does not liquidate troves with ICR > TCR", async () => {
         await setupBatchLiquidation()
         await expect(
           contracts.troveManager.batchLiquidateTroves([dennis.address]),
         ).to.be.revertedWith("TroveManager: nothing to liquidate")
       })
     })
-
-    /**
-     *
-     * Emitted Events
-     *
-     */
-    context("Emitted Events", () => {})
-
-    /**
-     *
-     * System State Changes
-     *
-     */
-    context("System State Changes", () => {
-      it("batchLiquidateTroves(): liquidating a single trove does not return to normal mode if TCR < MCR", async () => {
-        await setupBatchLiquidation()
-        await contracts.troveManager.batchLiquidateTroves([alice.address])
-        expect(await checkRecoveryMode()).to.equal(true)
-      })
-    })
-
-    /**
-     *
-     * Individual Troves
-     *
-     */
-    context("Individual Troves", () => {
-      it("batchLiquidateTroves(): troves with ICR > MCR can be liquidated", async () => {
-        await setupBatchLiquidation()
-        await contracts.troveManager.batchLiquidateTroves([
-          alice.address,
-          bob.address,
-          carol.address,
-        ])
-
-        expect(await checkTroveClosedByLiquidation(contracts, alice)).to.equal(
-          true,
-        )
-        expect(await checkTroveClosedByLiquidation(contracts, bob)).to.equal(
-          true,
-        )
-        expect(await checkTroveClosedByLiquidation(contracts, carol)).to.equal(
-          true,
-        )
-      })
-    })
-
-    /**
-     *
-     * Balance changes
-     *
-     */
-    context("Balance changes", () => {})
-
-    /**
-     *
-     * Fees
-     *
-     */
-    context("Fees", () => {})
-
-    /**
-     *
-     * State change in other contracts
-     *
-     */
-    context("State change in other contracts", () => {})
   })
 })


### PR DESCRIPTION
closes ENG-284

Currently the tests are structured like this

![image](https://github.com/user-attachments/assets/da0bef63-39be-4dd1-9dfb-bdbc9fca8a81)

- each contract has a normal mode and recovery mode
- within each mode, there's a context for each external function
- within each function, there's 7 categories: "Expected Reverts", "Emitted Events", "System State Changes", "Individual Troves", "Balance changes", "Fees", and "State change in other contracts"
- within each categories, we have tests that duplicate the function name, like `calculateInterestOwed(): should calculate the interest owed for a trove after 15 days`

on a practical level

- it's hard/inaccurate/annoying to choose a category when creating/porting a test
- the categories don't help me locate a test
- there are often empty categories, and each category uses a lot of white space

for an example of the last one, we have stuff like

```
    /**
     *
     * System State Changes
     *
     */
    context("System State Changes", () => {})
```

The tests have been restructured and standardized to:

- Remove all of the categories except expected reverts and expected events, which are objectively measurable
- Make each describe be the name of the function being tested
- Remove redundant test name information, so the "describe" has the function name, but not the "it".

result:

<img width="1360" alt="image" src="https://github.com/user-attachments/assets/02e065cc-1c26-432b-be3f-903549629248">


Tagging @rwatts07 for review