### PR TITLE
Rename MUSD to mUSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# MUSD
+# mUSD
 
-Smart contracts and the dApp powering MUSD on Mezo.
+Smart contracts and the dApp powering mUSD on Mezo.
 
 ## Development
 

--- a/dapp/README.md
+++ b/dapp/README.md
@@ -1,6 +1,6 @@
-# MUSD Dapp
+# mUSD Dapp
 
-The dApp powering MUSD
+The dApp powering mUSD
 
 ## Development
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,33 +1,33 @@
 # Mezo USD
 
-MUSD is a stablecoin that is minted by creating a loan against the borrowers crytpo assets, this is known as a Collateralised Debt Position (CDP).
+mUSD is a stablecoin that is minted by creating a loan against the borrowers crytpo assets, this is known as a Collateralised Debt Position (CDP).
 
-MUSD v0 is based on [Threshold USD](https://github.com/Threshold-USD/dev) which is a fork of [Liquity](https://github.com/liquity/dev) for the [Mezo Network](https://mezo.org).
+mUSD is based on [Threshold USD](https://github.com/Threshold-USD/dev) which is a fork of [Liquity](https://github.com/liquity/dev) for the [Mezo Network](https://mezo.org).
 
 ## Core Ideas
 
 To give borrowers certainty the deployed contracts are immutable. However at some point in the future if the price feeds no longer work the price feed logic will fail.
 
 - Sets of immutable contracts are deployed together for different versions or collaterals.
-- The mintlist in the MUSD Token contract is used to sunset contracts if a new version is deployed by preventing any new debt positions from being opened. However the contracts will continue to function.
+- The mintlist in the mUSD Token contract is used to sunset contracts if a new version is deployed by preventing any new debt positions from being opened. However the contracts will continue to function.
 - There is a governance delay to make changes to the mint list.
 - There is a governance delay to deploy new sets of contracts.
 
 The tradeoffs between immutability and upgradability are explored [here](https://medium.com/@ben_longstaff/threshold-usd-token-design-trade-offs-2926087d31c4).
 
-The three main contracts - `BorrowerOperations.sol`, `TroveManager.sol` and `StabilityPool.sol` - hold the user-facing public functions, and contain most of the internal system logic. Together they control Trove state updates and movements of collateral and MUSD tokens around the system.
+The three main contracts - `BorrowerOperations.sol`, `TroveManager.sol` and `StabilityPool.sol` - hold the user-facing public functions, and contain most of the internal system logic. Together they control Trove state updates and movements of collateral and mUSD tokens around the system.
 
 ### Core Smart Contracts
 
-`MUSD.sol` - the stablecoin token contract, which implements the ERC20 fungible token standard in conjunction with EIP-2612 and a mechanism that blocks (accidental) transfers to addresses like the StabilityPool and address(0) that are not supposed to receive funds through direct transfers. The contract mints, burns and transfers MUSD tokens.
+`MUSD.sol` - the stablecoin token contract, which implements the ERC20 fungible token standard in conjunction with EIP-2612 and a mechanism that blocks (accidental) transfers to addresses like the StabilityPool and address(0) that are not supposed to receive funds through direct transfers. The contract mints, burns and transfers mUSD tokens.
 
 `BorrowerOperations.sol` - contains the basic operations by which borrowers interact with their Trove: Trove creation, collateral top-up / withdrawal, stablecoin issuance and repayment. BorrowerOperations functions call in to TroveManager, telling it to update Trove state, where necessary. BorrowerOperations functions also call in to the various Pools, telling them to move collateral/Tokens between Pools or between Pool <> user, where necessary.
 
 `TroveManager.sol` - contains functionality for liquidations and redemptions. Also contains the state of each Trove - i.e. a record of the Trove’s collateral and debt. TroveManager does not hold value (i.e. collateral / other tokens). TroveManager functions call in to the various Pools to tell them to move collateral/tokens between Pools, where necessary.
 
-`StabilityPool.sol` - contains functionality for Stability Pool operations: making deposits, and withdrawing compounded deposits and accumulated collateral gains. Holds the MUSD Stability Pool deposits, and the collateral gains for depositors, from liquidations.
+`StabilityPool.sol` - contains functionality for Stability Pool operations: making deposits, and withdrawing compounded deposits and accumulated collateral gains. Holds the mUSD Stability Pool deposits, and the collateral gains for depositors, from liquidations.
 
-### MUSD Token - `MUSD.sol`
+### mUSD Token - `MUSD.sol`
 
 `startRevokeMintList(address _account)`: This function initiates the process of revoking a borrower operations contract's capability to mint new tokens. It first validates that the address provided in `_account` parameter is included in the `mintList`. Once verified, the function initializes the revocation process by updating `revokeMintListInitiated` with the current block timestamp and `pendingRevokedMintAddress` with the address passed in `_account` parameter.
 
@@ -41,13 +41,13 @@ The three main contracts - `BorrowerOperations.sol`, `TroveManager.sol` and `Sta
 
 `finalizeAddMintList()`: This function adds the minting capability to the borrower operations contract, previously designated in the `pendingAddedMintAddress`. It executes only after the governance delay has elapsed following the `addMintListInitiated` timestamp. By finalizing the revoke mint process it resets the `pendingAddedMintAddress` and `addMintListInitiated`.
 
-`startAddContracts(address _troveManagerAddress, address _stabilityPoolAddress, address _borrowerOperationsAddress)`: This function initiates the process of integrating borrower operations, trove manager, and stability pool contracts, enabling them to mint and burn MUSD tokens. It begins by verifying that the contract addresses provided as parameters are indeed contracts. Once confirmed, it assigns the addresses to `pendingTroveManager`, `pendingStabilityPool`, and `pendingBorrowerOperations` using `_troveManagerAddress`, `_stabilityPoolAddress`, and `_borrowerOperationsAddress`, respectively. Additionally, it records the initiation of adding these contracts by setting `addContractsInitiated` to the current block timestamp when the transaction is executed.
+`startAddContracts(address _troveManagerAddress, address _stabilityPoolAddress, address _borrowerOperationsAddress)`: This function initiates the process of integrating borrower operations, trove manager, and stability pool contracts, enabling them to mint and burn mUSD tokens. It begins by verifying that the contract addresses provided as parameters are indeed contracts. Once confirmed, it assigns the addresses to `pendingTroveManager`, `pendingStabilityPool`, and `pendingBorrowerOperations` using `_troveManagerAddress`, `_stabilityPoolAddress`, and `_borrowerOperationsAddress`, respectively. Additionally, it records the initiation of adding these contracts by setting `addContractsInitiated` to the current block timestamp when the transaction is executed.
 
 `cancelAddContracts()`: This function terminates the current process of adding contracts. Initially, it checks that `addContractsInitiated` is not zero, which indicates an active process of adding contracts is underway. Upon confirmation, it resets `addContractsInitiated`, `pendingTroveManager`, `pendingStabilityPool`, and `pendingRevokedMintAddress` to 0, `address(0)`, `address(0)`, and `address(0)` respectively. This action effectively concludes the process of adding contracts.
 
 `finalizeAddContracts()`: This function adds the minting and burning capabilities to the borrower operations, trove manager, and stability pool contracts previously designated in the `pendingBorrowerOperations`, `pendingStabilityPool` and `pendingTroveManager`. It executes only after the governance delay has elapsed following the `addContractsInitiated` timestamp. By finalizing the process of adding new contracts, it resets the `pendingBorrowerOperations`, `pendingStabilityPool`,`pendingTroveManager` and `addContractsInitiated`.
 
-`startRevokeBurnList(address _account)`: This function initiates the process of revoking a borrower operations contract's capability to burn MUSD tokens. It first validates that the address provided in `_account` parameter is included in the `burnList`. Once verified, the function initializes the revocation process by updating `revokeBurnListInitiated` with the current block timestamp and `pendingRevokedBurnAddress` with the address passed in `_account` parameter.
+`startRevokeBurnList(address _account)`: This function initiates the process of revoking a borrower operations contract's capability to burn mUSD tokens. It first validates that the address provided in `_account` parameter is included in the `burnList`. Once verified, the function initializes the revocation process by updating `revokeBurnListInitiated` with the current block timestamp and `pendingRevokedBurnAddress` with the address passed in `_account` parameter.
 
 `cancelRevokeBurnList()`: It cancels the existing revoking mint process. The function first validates whether the `pendingRevokedBurnAddress` is non-zero to confirm the presence of an ongoing pending revoking process. Once verified, it resets both `revokeBurnListInitiated` and `pendingRevokedBurnAddress` to zero and `address(0)` respectively. Effectively finalizing the existing revoking process.
 
@@ -61,9 +61,9 @@ The three main contracts - `BorrowerOperations.sol`, `TroveManager.sol` and `Sta
 
 `batchLiquidateTroves(address[] calldata _troveArray)`: callable by anyone, accepts a custom list of Troves addresses as an argument. Steps through the provided list and attempts to liquidate every Trove, until it reaches the end or it runs out of gas. A Trove is liquidated only if it meets the conditions for liquidation. For a batch of 10 Troves, the gas costs per liquidated Trove are roughly between 75K-83K, for a batch of 50 Troves between 54K-69K.
 
-`redeemCollateral(uint _MUSDAmount, address _firstRedemptionHint, address _upperPartialRedemptionHint, address _lowerPartialRedemptionHint, uint _partialRedemptionHintNICR, uint _maxIterations, uint _maxFeePercentage)`: redeems `_MUSDamount` of stablecoins for ether from the system. Decreases the caller’s MUSD balance, and sends them the corresponding amount of collateral. Executes successfully if the caller has sufficient MUSD to redeem. The number of Troves redeemed from is capped by `_maxIterations`. The borrower has to provide a `_maxFeePercentage` that he/she is willing to accept in case of a fee slippage, i.e. when another redemption transaction is processed first, driving up the redemption fee.
+`redeemCollateral(uint _MUSDAmount, address _firstRedemptionHint, address _upperPartialRedemptionHint, address _lowerPartialRedemptionHint, uint _partialRedemptionHintNICR, uint _maxIterations, uint _maxFeePercentage)`: redeems `_MUSDamount` of stablecoins for ether from the system. Decreases the caller’s mUSD balance, and sends them the corresponding amount of collateral. Executes successfully if the caller has sufficient mUSD to redeem. The number of Troves redeemed from is capped by `_maxIterations`. The borrower has to provide a `_maxFeePercentage` that he/she is willing to accept in case of a fee slippage, i.e. when another redemption transaction is processed first, driving up the redemption fee.
 
-`getCurrentICR(address _user, uint _price)`: computes the user’s individual collateralization ratio (ICR) based on their total collateral and total MUSD debt. Returns 2^256 -1 if they have 0 debt.
+`getCurrentICR(address _user, uint _price)`: computes the user’s individual collateralization ratio (ICR) based on their total collateral and total mUSD debt. Returns 2^256 -1 if they have 0 debt.
 
 `getTroveOwnersCount()`: get the number of active Troves in the system.
 
@@ -91,4 +91,4 @@ _**Total collateralization ratio (TCR):**_ the ratio of the dollar value of the 
 
 _**Critical collateralization ratio (CCR):**_ 150%. When the TCR is below the CCR, the system enters Recovery Mode.
 
-_**Gas compensation:**_ A refund, in MUSD and collateral, automatically paid to the caller of a liquidation function, intended to at least cover the gas cost of the transaction. Designed to ensure that liquidators are not dissuaded by potentially high gas costs.
+_**Gas compensation:**_ A refund, in mUSD and collateral, automatically paid to the caller of a liquidation function, intended to at least cover the gas cost of the transaction. Designed to ensure that liquidators are not dissuaded by potentially high gas costs.

--- a/docs/simpleInterest.md
+++ b/docs/simpleInterest.md
@@ -1,36 +1,43 @@
-# MUSD V2: Simple Interest Approach
+# mUSD V2: Simple Interest Approach
 
 ## Overview
 
-This document outlines a block-based simple interest approach to manage debt and calculate interest in MUSD V2. The system uses linear interest calculations to minimize complexity while maintaining accurate debt tracking.
+This document outlines a block-based simple interest approach to manage debt and calculate interest in mUSD V2. The system uses linear interest calculations to minimize complexity while maintaining accurate debt tracking.
 
 ## Key Concepts
 
 ### 1. Time-Based Interest Computation
+
 - Interest is computed based on elapsed time (in seconds)
 - Linear calculation eliminates the need for compound interest complexity
 - Uses timestamps for precise time tracking
 
 ### 2. Total Debt Tracking
+
 For the system, we maintain for each interest rate:
+
 - Total debt amount
 - Total interest owed
 - Timestamp of the last update
 
 ### 3. Individual Trove Data
+
 Each trove stores:
+
 - Original debt amount
 - Interest owed
-- Interest rate 
+- Interest rate
 - Maximum borrowing capacity at current rate (fixed at opening based on 110% CR capacity)
 - Last update timestamp
 
 ### 4. Real-Time Interest
+
 - Interest is calculated precisely based on actual time elapsed
 - No rounding or daily boundaries to consider
 - Interest accumulates linearly over time
 
 ### 5. Interest Accumulation and Distribution
+
 - Interest is stored separately from the principal
 - New interest is calculated and added to owed interest during each user interaction with a trove
 - Total obligations are the sum of principal and accumulated interest
@@ -41,7 +48,7 @@ Each trove stores:
 
 ### Updating Total System Interest
 
-System interest is stored per interest rate.  When a trove is modified, the interest for that rate is updated:
+System interest is stored per interest rate. When a trove is modified, the interest for that rate is updated:
 
 1. Calculate new interest:
    ```
@@ -51,6 +58,7 @@ System interest is stored per interest rate.  When a trove is modified, the inte
 3. Update the last update timestamp
 
 ### Opening a New Trove
+
 1. Record the initial debt amount
 2. Calculate maximum borrowing capacity at 110% CR
 3. Set fixed interest rate based on maximum capacity (not initial borrow)
@@ -59,6 +67,7 @@ System interest is stored per interest rate.  When a trove is modified, the inte
 6. Add principal to total system principal
 
 ### Calculating Interest for a Trove
+
 1. Calculate new interest accrued:
    ```
    new_interest = principal * (current_timestamp - last_update_timestamp) * interest_rate_per_second
@@ -66,12 +75,14 @@ System interest is stored per interest rate.  When a trove is modified, the inte
 2. Total obligations = principal + stored interest + new interest
 
 ### Trove Interactions (Borrowing/Repaying/Adjusting)
+
 1. Calculate new interest owed up to current timestamp
 2. Add new interest to stored interest for the trove and for the system at the trove's interest rate
 3. Process the requested operation (note that repayments will first be applied to owed interest before paying off principal)
 4. Optionally mint and distribute accumulated interest to PCV and gauge pool
 
 ### Closing a Trove
+
 1. Calculate final interest owed up to current timestamp
 2. Add final interest to stored interest
 3. Process repayment of total obligations (debt + total interest)

--- a/solidity/README.md
+++ b/solidity/README.md
@@ -1,6 +1,6 @@
 # musd Contracts
 
-Smart contracts powering MUSD
+Smart contracts powering mUSD
 
 ## Development
 

--- a/solidity/contracts/ActivePool.sol
+++ b/solidity/contracts/ActivePool.sol
@@ -13,9 +13,9 @@ import "./interfaces/IDefaultPool.sol";
 import "./interfaces/IStabilityPool.sol";
 
 /*
- * The Active Pool holds the collateral and MUSD debt (but not MUSD tokens) for all active troves.
+ * The Active Pool holds the collateral and mUSD debt (but not mUSD tokens) for all active troves.
  *
- * When a trove is liquidated, it's collateral and MUSD debt are transferred from the Active Pool, to either the
+ * When a trove is liquidated, it's collateral and mUSD debt are transferred from the Active Pool, to either the
  * Stability Pool, the Default Pool, or both, depending on the liquidation conditions.
  *
  */

--- a/solidity/contracts/BorrowerOperations.sol
+++ b/solidity/contracts/BorrowerOperations.sol
@@ -138,7 +138,7 @@ contract BorrowerOperations is
 
         _requireAtLeastMinNetDebt(vars.netDebt);
 
-        // ICR is based on the composite debt, i.e. the requested MUSD amount + MUSD borrowing fee + MUSD gas comp.
+        // ICR is based on the composite debt, i.e. the requested mUSD amount + mUSD borrowing fee + mUSD gas comp.
         vars.compositeDebt = _getCompositeDebt(vars.netDebt);
         assert(vars.compositeDebt > 0);
 
@@ -234,7 +234,7 @@ contract BorrowerOperations is
             _debtAmount,
             vars.netDebt
         );
-        // Move the MUSD gas compensation to the Gas Pool
+        // Move the mUSD gas compensation to the Gas Pool
         _withdrawMUSD(
             contractsCache.activePool,
             contractsCache.musd,
@@ -311,7 +311,7 @@ contract BorrowerOperations is
         );
     }
 
-    // Withdraw MUSD tokens from a trove: mint new MUSD tokens to the owner, and increase the trove's debt accordingly
+    // Withdraw mUSD tokens from a trove: mint new mUSD tokens to the owner, and increase the trove's debt accordingly
     function withdrawMUSD(
         uint256 _maxFeePercentage,
         uint256 _amount,
@@ -330,7 +330,7 @@ contract BorrowerOperations is
         );
     }
 
-    // Repay MUSD tokens to a Trove: Burn the repaid MUSD tokens, and reduce the trove's debt accordingly
+    // Repay mUSD tokens to a Trove: Burn the repaid mUSD tokens, and reduce the trove's debt accordingly
     function repayMUSD(
         uint256 _amount,
         address _upperHint,
@@ -393,7 +393,7 @@ contract BorrowerOperations is
             uint8(BorrowerOperation.closeTrove)
         );
 
-        // Burn the repaid MUSD from the user's balance and the gas compensation from the Gas Pool
+        // Burn the repaid mUSD from the user's balance and the gas compensation from the Gas Pool
         _repayMUSD(
             activePoolCached,
             musdTokenCached,
@@ -452,7 +452,7 @@ contract BorrowerOperations is
         address _sortedTrovesAddress,
         address _troveManagerAddress
     ) external override onlyOwner {
-        // This makes impossible to open a trove with zero withdrawn MUSD
+        // This makes impossible to open a trove with zero withdrawn mUSD
         assert(MIN_NET_DEBT > 0);
 
         checkContract(_activePoolAddress);
@@ -611,7 +611,7 @@ contract BorrowerOperations is
             vars
         );
 
-        // When the adjustment is a debt repayment, check it's a valid amount and that the caller has enough MUSD
+        // When the adjustment is a debt repayment, check it's a valid amount and that the caller has enough mUSD
         if (!_isDebtIncrease && _MUSDChange > 0) {
             _requireAtLeastMinNetDebt(
                 _getNetDebt(vars.debt) - vars.netDebtChange
@@ -671,7 +671,7 @@ contract BorrowerOperations is
         );
     }
 
-    // Issue the specified amount of MUSD to _account and increases the total active debt (_netDebtIncrease potentially includes a MUSDFee)
+    // Issue the specified amount of mUSD to _account and increases the total active debt (_netDebtIncrease potentially includes a MUSDFee)
     function _withdrawMUSD(
         IActivePool _activePool,
         IMUSD _musd,
@@ -891,7 +891,7 @@ contract BorrowerOperations is
     ) internal view {
         require(
             _musd.balanceOf(_borrower) >= _debtRepayment,
-            "BorrowerOps: Caller doesnt have enough MUSD to make repayment"
+            "BorrowerOps: Caller doesnt have enough mUSD to make repayment"
         );
     }
 

--- a/solidity/contracts/DefaultPool.sol
+++ b/solidity/contracts/DefaultPool.sol
@@ -10,10 +10,10 @@ import "./interfaces/IDefaultPool.sol";
 import "./interfaces/IActivePool.sol";
 
 /*
- * The Default Pool holds the collateral and MUSD debt (but not MUSD tokens) from liquidations that have been redistributed
+ * The Default Pool holds the collateral and mUSD debt (but not mUSD tokens) from liquidations that have been redistributed
  * to active troves but not yet "applied", i.e. not yet recorded on a recipient active trove's struct.
  *
- * When a trove makes an operation that applies its pending collateral and MUSD debt, its pending collateral and MUSD debt is moved
+ * When a trove makes an operation that applies its pending collateral and mUSD debt, its pending collateral and mUSD debt is moved
  * from the Default Pool to the Active Pool.
  */
 contract DefaultPool is Ownable, CheckContract, SendCollateral, IDefaultPool {

--- a/solidity/contracts/GasPool.sol
+++ b/solidity/contracts/GasPool.sol
@@ -47,7 +47,7 @@ contract GasPool is Ownable, CheckContract, IGasPool {
         );
         require(
             musdToken.transfer(_account, _amount),
-            "GasPool: sending MUSD failed"
+            "GasPool: sending mUSD failed"
         );
     }
 }

--- a/solidity/contracts/PCV.sol
+++ b/solidity/contracts/PCV.sol
@@ -11,7 +11,7 @@ import "./interfaces/IPCV.sol";
 import "./BorrowerOperations.sol";
 
 contract PCV is IPCV, Ownable, CheckContract, SendCollateral {
-    uint256 public constant BOOTSTRAP_LOAN = 1e26; // 100M MUSD
+    uint256 public constant BOOTSTRAP_LOAN = 1e26; // 100M mUSD
 
     uint256 public immutable governanceTimeDelay;
 
@@ -135,7 +135,7 @@ contract PCV is IPCV, Ownable, CheckContract, SendCollateral {
         );
         require(
             musd.transfer(_recipient, _musdAmount),
-            "PCV: sending MUSD failed"
+            "PCV: sending mUSD failed"
         );
         // slither-disable-next-line reentrancy-events
         emit MUSDWithdraw(_recipient, _musdAmount);

--- a/solidity/contracts/StabilityPool.sol
+++ b/solidity/contracts/StabilityPool.sol
@@ -44,14 +44,14 @@ contract StabilityPool is
     IMUSD public musd;
     // Needed to check if there are pending liquidations
     ISortedTroves public sortedTroves;
-    // Tracker for MUSD held in the pool. Changes when users deposit/withdraw, and when Trove debt is offset.
+    // Tracker for mUSD held in the pool. Changes when users deposit/withdraw, and when Trove debt is offset.
     uint256 internal totalMUSDDeposits;
     uint256 internal collateral; // deposited collateral tracker
     mapping(address => uint256) public deposits; // depositor address -> initial value
     mapping(address => Snapshots) public depositSnapshots; // depositor address -> snapshots struct
 
     /*  Product 'P': Running product by which to multiply an initial deposit, in order to find the current compounded deposit,
-     * after a series of liquidations have occurred, each of which cancel some MUSD debt with the deposit.
+     * after a series of liquidations have occurred, each of which cancel some mUSD debt with the deposit.
      *
      * During its lifetime, a deposit's value evolves from d_t to d_t * P / P_t , where P_t
      * is the snapshot of P taken at the instant the deposit was made. 18-digit decimal.
@@ -161,7 +161,7 @@ contract StabilityPool is
             msg.sender,
             depositorCollateralGain,
             MUSDLoss
-        ); // MUSD Loss required for event log
+        ); // mUSD Loss required for event log
 
         _sendMUSDtoStabilityPool(msg.sender, _amount);
 
@@ -203,7 +203,7 @@ contract StabilityPool is
             msg.sender,
             depositorCollateralGain,
             MUSDLoss
-        ); // MUSD Loss required for event log
+        ); // mUSD Loss required for event log
 
         _sendCollateralGainToDepositor(depositorCollateralGain);
     }
@@ -259,7 +259,7 @@ contract StabilityPool is
     }
 
     /*
-     * Cancels out the specified debt against the MUSD contained in the Stability Pool (as far as possible)
+     * Cancels out the specified debt against the mUSD contained in the Stability Pool (as far as possible)
      * and transfers the Trove's collateral from ActivePool to StabilityPool.
      * Only called by liquidation functions in the TroveManager.
      */
@@ -359,8 +359,8 @@ contract StabilityPool is
         _decreaseMUSD(MUSDWithdrawal);
     }
 
-    // Transfer the MUSD tokens from the user to the Stability Pool's address,
-    // and update its recorded MUSD
+    // Transfer the mUSD tokens from the user to the Stability Pool's address,
+    // and update its recorded mUSD
     function _sendMUSDtoStabilityPool(
         address _address,
         uint256 _amount
@@ -431,7 +431,7 @@ contract StabilityPool is
         )
     {
         /*
-         * Compute the MUSD and collateral rewards. Uses a "feedback" error correction, to keep
+         * Compute the mUSD and collateral rewards. Uses a "feedback" error correction, to keep
          * the cumulative error in the P and S state variables low:
          *
          * 1) Form numerators which compensate for the floor division errors that occurred the last time this
@@ -454,7 +454,7 @@ contract StabilityPool is
                 DECIMAL_PRECISION -
                 lastMUSDLossError_Offset;
             /*
-             * Add 1 to make error in quotient positive. We want "slightly too much" MUSD loss,
+             * Add 1 to make error in quotient positive. We want "slightly too much" mUSD loss,
              * which ensures the error in any given compoundedMUSDDeposit favors the Stability Pool.
              */
             MUSDLossPerUnitStaked = MUSDLossNumerator / _totalMUSDDeposits + 1;
@@ -479,7 +479,7 @@ contract StabilityPool is
     ) internal {
         IActivePool activePoolCached = activePool;
 
-        // Cancel the liquidated MUSD debt with the MUSD in the stability pool
+        // Cancel the liquidated mUSD debt with the mUSD in the stability pool
         activePoolCached.decreaseMUSDDebt(_debtToOffset);
         _decreaseMUSD(_debtToOffset);
 
@@ -507,7 +507,7 @@ contract StabilityPool is
 
         assert(_MUSDLossPerUnitStaked <= DECIMAL_PRECISION);
         /*
-         * The newProductFactor is the factor by which to change all deposits, due to the depletion of Stability Pool MUSD in the liquidation.
+         * The newProductFactor is the factor by which to change all deposits, due to the depletion of Stability Pool mUSD in the liquidation.
          * We make the product factor 0 if there was a pool-emptying. Otherwise, it is (1 - MUSDLossPerUnitStaked)
          */
         uint256 newProductFactor = DECIMAL_PRECISION - _MUSDLossPerUnitStaked;

--- a/solidity/contracts/TroveManager.sol
+++ b/solidity/contracts/TroveManager.sol
@@ -38,7 +38,7 @@ contract TroveManager is LiquityBase, Ownable, CheckContract, ITroveManager {
         uint128 arrayIndex;
     }
 
-    // Object containing the collateral and MUSD snapshots for a given active trove
+    // Object containing the collateral and mUSD snapshots for a given active trove
     struct RewardSnapshot {
         uint256 collateral;
         uint256 MUSDDebt;
@@ -162,7 +162,7 @@ contract TroveManager is LiquityBase, Ownable, CheckContract, ITroveManager {
 
     uint256 public baseRate;
 
-    // The timestamp of the latest fee operation (redemption or new MUSD issuance)
+    // The timestamp of the latest fee operation (redemption or new mUSD issuance)
     uint256 public lastFeeOperationTime;
 
     mapping(address => Trove) public Troves;
@@ -331,7 +331,7 @@ contract TroveManager is LiquityBase, Ownable, CheckContract, ITroveManager {
             "TroveManager: nothing to liquidate"
         );
 
-        // Move liquidated collateral and MUSD to the appropriate pools
+        // Move liquidated collateral and mUSD to the appropriate pools
         stabilityPoolCached.offset(
             totals.totalDebtToOffset,
             totals.totalCollToSendToSP
@@ -376,7 +376,7 @@ contract TroveManager is LiquityBase, Ownable, CheckContract, ITroveManager {
         );
     }
 
-    /* Send _MUSDamount MUSD to the system and redeem the corresponding amount of collateral from as many Troves as are needed to fill the redemption
+    /* Send _MUSDamount mUSD to the system and redeem the corresponding amount of collateral from as many Troves as are needed to fill the redemption
      * request.  Applies pending rewards to a Trove before reducing its debt and coll.
      *
      * Note that if _amount is very large, this function can run out of gas, specially if traversed troves are small. This can be easily avoided by
@@ -394,7 +394,7 @@ contract TroveManager is LiquityBase, Ownable, CheckContract, ITroveManager {
      *
      * If another transaction modifies the list between calling getRedemptionHints() and passing the hints to redeemCollateral(), it
      * is very likely that the last (partially) redeemed Trove would end up with a different ICR than what the hint is for. In this case the
-     * redemption will stop after the last completely redeemed Trove and the sender will keep the remaining MUSD amount, which they can attempt
+     * redemption will stop after the last completely redeemed Trove and the sender will keep the remaining mUSD amount, which they can attempt
      * to redeem later.
      */
     function redeemCollateral(
@@ -454,7 +454,7 @@ contract TroveManager is LiquityBase, Ownable, CheckContract, ITroveManager {
             }
         }
 
-        // Loop through the Troves starting from the one with lowest collateral ratio until _amount of MUSD is exchanged for collateral
+        // Loop through the Troves starting from the one with lowest collateral ratio until _amount of mUSD is exchanged for collateral
         if (_maxIterations == 0) {
             _maxIterations = type(uint256).max;
         }
@@ -501,7 +501,7 @@ contract TroveManager is LiquityBase, Ownable, CheckContract, ITroveManager {
         );
 
         // Decay the baseRate due to time passed, and then increase it according to the size of this redemption.
-        // Use the saved total MUSD supply value, from before it was reduced by the redemption.
+        // Use the saved total mUSD supply value, from before it was reduced by the redemption.
         _updateBaseRateFromRedemption(
             totals.totalCollateralDrawn,
             totals.price,
@@ -534,9 +534,9 @@ contract TroveManager is LiquityBase, Ownable, CheckContract, ITroveManager {
             totals.collateralFee
         );
 
-        // Burn the total MUSD that is cancelled with debt, and send the redeemed collateral to msg.sender
+        // Burn the total mUSD that is cancelled with debt, and send the redeemed collateral to msg.sender
         contractsCache.musdToken.burn(msg.sender, totals.totalMUSDToRedeem);
-        // Update Active Pool MUSD, and send collateral to account
+        // Update Active Pool mUSD, and send collateral to account
         contractsCache.activePool.decreaseMUSDDebt(totals.totalMUSDToRedeem);
         contractsCache.activePool.sendCollateral(
             msg.sender,
@@ -580,7 +580,7 @@ contract TroveManager is LiquityBase, Ownable, CheckContract, ITroveManager {
         return _removeStake(_borrower);
     }
 
-    // Updates the baseRate state variable based on time elapsed since the last redemption or MUSD borrowing operation.
+    // Updates the baseRate state variable based on time elapsed since the last redemption or mUSD borrowing operation.
     function decayBaseRateFromBorrowing() external override {
         _requireCallerIsBorrowerOperations();
 
@@ -877,7 +877,7 @@ contract TroveManager is LiquityBase, Ownable, CheckContract, ITroveManager {
             "TroveManager: nothing to liquidate"
         );
 
-        // Move liquidated collateral and MUSD to the appropriate pools
+        // Move liquidated collateral and mUSD to the appropriate pools
         stabilityPoolCached.offset(
             totals.totalDebtToOffset,
             totals.totalCollToSendToSP
@@ -1204,7 +1204,7 @@ contract TroveManager is LiquityBase, Ownable, CheckContract, ITroveManager {
 
     /*
      * This function has two impacts on the baseRate state variable:
-     * 1) decays the baseRate based on time passed since last redemption or MUSD borrowing operation.
+     * 1) decays the baseRate based on time passed since last redemption or mUSD borrowing operation.
      * then,
      * 2) increases the baseRate based on the amount redeemed, as a proportion of total debt
      */
@@ -1215,7 +1215,7 @@ contract TroveManager is LiquityBase, Ownable, CheckContract, ITroveManager {
     ) internal returns (uint) {
         uint256 decayedBaseRate = _calcDecayedBaseRate();
 
-        /* Convert the drawn collateral back to MUSD at face value rate (1 MUSD:1 USD), in order to get
+        /* Convert the drawn collateral back to mUSD at face value rate (1 mUSD:1 USD), in order to get
          * the fraction of total supply that was redeemed at face value. */
         uint256 redeemedMUSDFraction = (_collateralDrawn * _price) /
             _totalMUSDDebt;
@@ -1658,7 +1658,7 @@ contract TroveManager is LiquityBase, Ownable, CheckContract, ITroveManager {
             );
             /*
              * If 110% <= ICR < current TCR (accounting for the preceding liquidations in the current sequence)
-             * and there is MUSD in the Stability Pool, only offset, with no redistribution,
+             * and there is mUSD in the Stability Pool, only offset, with no redistribution,
              * but at a capped rate of 1.1 and only if the whole debt can be liquidated.
              * The remainder due to the capped rate will be claimable as collateral surplus.
              */
@@ -1715,8 +1715,8 @@ contract TroveManager is LiquityBase, Ownable, CheckContract, ITroveManager {
 
     /*
      * Called when a full redemption occurs, and closes the trove.
-     * The redeemer swaps (debt - liquidation reserve) MUSD for (debt - liquidation reserve) worth of collateral, so the MUSD liquidation reserve left corresponds to the remaining debt.
-     * In order to close the trove, the MUSD liquidation reserve is burned, and the corresponding debt is removed from the active pool.
+     * The redeemer swaps (debt - liquidation reserve) mUSD for (debt - liquidation reserve) worth of collateral, so the mUSD liquidation reserve left corresponds to the remaining debt.
+     * In order to close the trove, the mUSD liquidation reserve is burned, and the corresponding debt is removed from the active pool.
      * The debt recorded on the trove's struct is zero'd elswhere, in _closeTrove.
      * Any surplus collateral left in the trove, is sent to the Coll surplus pool, and can be later claimed by the borrower.
      */
@@ -1728,7 +1728,7 @@ contract TroveManager is LiquityBase, Ownable, CheckContract, ITroveManager {
     ) internal {
         // slither-disable-next-line calls-loop
         _contractsCache.musdToken.burn(gasPoolAddress, _MUSD);
-        // Update Active Pool MUSD, and send collateral to account
+        // Update Active Pool mUSD, and send collateral to account
         // slither-disable-next-line calls-loop
         _contractsCache.activePool.decreaseMUSDDebt(_MUSD);
 
@@ -1742,7 +1742,7 @@ contract TroveManager is LiquityBase, Ownable, CheckContract, ITroveManager {
         );
     }
 
-    // Redeem as much collateral as possible from _borrower's Trove in exchange for MUSD up to _maxMUSDamount
+    // Redeem as much collateral as possible from _borrower's Trove in exchange for mUSD up to _maxMUSDamount
     function _redeemCollateralFromTrove(
         ContractsCache memory _contractsCache,
         address _borrower,
@@ -1763,7 +1763,7 @@ contract TroveManager is LiquityBase, Ownable, CheckContract, ITroveManager {
             (singleRedemption.MUSDLot * DECIMAL_PRECISION) /
             _price;
 
-        // Decrease the debt and collateral of the current Trove according to the MUSD lot and corresponding collateral to send
+        // Decrease the debt and collateral of the current Trove according to the mUSD lot and corresponding collateral to send
         uint256 newDebt = Troves[_borrower].debt - singleRedemption.MUSDLot;
         uint256 newColl = Troves[_borrower].coll -
             singleRedemption.collateralLot;
@@ -1850,8 +1850,8 @@ contract TroveManager is LiquityBase, Ownable, CheckContract, ITroveManager {
     function _addTroveOwnerToArray(
         address _borrower
     ) internal returns (uint128 index) {
-        /* Max array size is 2**128 - 1, i.e. ~3e30 troves. No risk of overflow, since troves have minimum MUSD
-        debt of liquidation reserve plus MIN_NET_DEBT. 3e30 MUSD dwarfs the value of all wealth in the world ( which is < 1e15 USD). */
+        /* Max array size is 2**128 - 1, i.e. ~3e30 troves. No risk of overflow, since troves have minimum mUSD
+        debt of liquidation reserve plus MIN_NET_DEBT. 3e30 mUSD dwarfs the value of all wealth in the world ( which is < 1e15 USD). */
 
         // Push the Troveowner to the array
         TroveOwners.push(_borrower);
@@ -1975,7 +1975,7 @@ contract TroveManager is LiquityBase, Ownable, CheckContract, ITroveManager {
     ) internal view {
         require(
             _musd.balanceOf(_redeemer) >= _amount,
-            "TroveManager: Requested redemption amount must be <= user's MUSD token balance"
+            "TroveManager: Requested redemption amount must be <= user's mUSD token balance"
         );
     }
 
@@ -2078,9 +2078,9 @@ contract TroveManager is LiquityBase, Ownable, CheckContract, ITroveManager {
              * Offset as much debt & collateral as possible against the Stability Pool, and redistribute the remainder
              * between all active troves.
              *
-             *  If the trove's debt is larger than the deposited MUSD in the Stability Pool:
+             *  If the trove's debt is larger than the deposited mUSD in the Stability Pool:
              *
-             *  - Offset an amount of the trove's debt equal to the MUSD in the Stability Pool
+             *  - Offset an amount of the trove's debt equal to the mUSD in the Stability Pool
              *  - Send a fraction of the trove's collateral to the Stability Pool, equal to the fraction of its offset debt
              *
              */

--- a/solidity/contracts/dependencies/LiquityBase.sol
+++ b/solidity/contracts/dependencies/LiquityBase.sol
@@ -22,10 +22,10 @@ abstract contract LiquityBase is BaseMath, ILiquityBase {
     // Critical system collateral ratio. If the system's total collateral ratio (TCR) falls below the CCR, Recovery Mode is triggered.
     uint256 public constant CCR = 1.5e18; // 150%
 
-    // Amount of MUSD to be locked in gas pool on opening troves
+    // Amount of mUSD to be locked in gas pool on opening troves
     uint256 public constant MUSD_GAS_COMPENSATION = 200e18;
 
-    // Minimum amount of net MUSD debt a trove must have
+    // Minimum amount of net mUSD debt a trove must have
     uint256 public constant MIN_NET_DEBT = 1800e18;
     // uint256 constant public MIN_NET_DEBT = 0;
 

--- a/solidity/contracts/interfaces/IStabilityPool.sol
+++ b/solidity/contracts/interfaces/IStabilityPool.sol
@@ -3,17 +3,17 @@
 pragma solidity ^0.8.24;
 
 /*
- * The Stability Pool holds MUSD tokens deposited by Stability Pool depositors.
+ * The Stability Pool holds mUSD tokens deposited by Stability Pool depositors.
  *
- * When a trove is liquidated, then depending on system conditions, some of its MUSD debt gets offset with
- * MUSD in the Stability Pool:  that is, the offset debt evaporates, and an equal amount of MUSD tokens in the Stability Pool is burned.
+ * When a trove is liquidated, then depending on system conditions, some of its mUSD debt gets offset with
+ * mUSD in the Stability Pool:  that is, the offset debt evaporates, and an equal amount of mUSD tokens in the Stability Pool is burned.
  *
- * Thus, a liquidation causes each depositor to receive a MUSD loss, in proportion to their deposit as a share of total deposits.
+ * Thus, a liquidation causes each depositor to receive a mUSD loss, in proportion to their deposit as a share of total deposits.
  * They also receive an collateral gain, as the collateral of the liquidated trove is distributed among Stability depositors,
  * in the same proportion.
  *
  * When a liquidation occurs, it depletes every deposit by the same fraction: for example, a liquidation that depletes 40%
- * of the total MUSD in the Stability Pool, depletes 40% of each deposit.
+ * of the total mUSD in the Stability Pool, depletes 40% of each deposit.
  *
  * A deposit that has experienced a series of liquidations is termed a "compounded deposit": each liquidation depletes the deposit,
  * multiplying it by some factor in range ]0,1[
@@ -113,7 +113,7 @@ interface IStabilityPool {
      * Initial checks:
      * - Caller is TroveManager
      * ---
-     * Cancels out the specified debt against the MUSD contained in the Stability Pool (as far as possible)
+     * Cancels out the specified debt against the mUSD contained in the Stability Pool (as far as possible)
      * and transfers the Trove's collateral from ActivePool to StabilityPool.
      * Only called by liquidation functions in the TroveManager.
      */
@@ -126,7 +126,7 @@ interface IStabilityPool {
     function getCollateralBalance() external view returns (uint);
 
     /*
-     * Returns MUSD held in the pool. Changes when users deposit/withdraw, and when Trove debt is offset.
+     * Returns mUSD held in the pool. Changes when users deposit/withdraw, and when Trove debt is offset.
      */
     function getTotalMUSDDeposits() external view returns (uint);
 

--- a/solidity/test/helpers/debugging.ts
+++ b/solidity/test/helpers/debugging.ts
@@ -67,7 +67,7 @@ async function printAddressBalances(
     } else {
       console.log(address)
     }
-    console.log("\tMUSD : \t\t", formatBigIntWithCommas(balances.musd))
+    console.log("\tmUSD : \t\t", formatBigIntWithCommas(balances.musd))
     console.log("\tBTC : \t\t", formatBigIntWithCommas(balances.btc))
     console.log("")
   }

--- a/solidity/test/helpers/functions.ts
+++ b/solidity/test/helpers/functions.ts
@@ -39,7 +39,7 @@ export async function removeMintlist(
 }
 
 /*
- * given the requested MUSD amount in openTrove, returns the total debt
+ * given the requested mUSD amount in openTrove, returns the total debt
  * So, it adds the gas compensation and the borrowing fee
  */
 export async function getOpenTroveTotalDebt(
@@ -486,7 +486,7 @@ export async function withdrawColl(
     .withdrawColl(amount, params.lowerHint, params.upperHint)
 }
 
-// Withdraw MUSD from a trove to make ICR equal to the target ICR
+// Withdraw mUSD from a trove to make ICR equal to the target ICR
 export async function adjustTroveToICR(
   contracts: Contracts,
   from: HardhatEthersSigner,

--- a/solidity/test/normal/ActivePool.test.ts
+++ b/solidity/test/normal/ActivePool.test.ts
@@ -38,13 +38,13 @@ describe("ActivePool", () => {
   })
 
   describe("getMUSDDebt()", () => {
-    it("gets the recorded MUSD balance", async () => {
+    it("gets the recorded mUSD balance", async () => {
       expect(await contracts.activePool.getMUSDDebt()).to.equal(0)
     })
   })
 
   describe("increaseMUSDDebt()", () => {
-    it("increases the recorded MUSD balance by the correct amount", async () => {
+    it("increases the recorded mUSD balance by the correct amount", async () => {
       await updateContractsSnapshot(
         contracts,
         state,
@@ -73,7 +73,7 @@ describe("ActivePool", () => {
   })
 
   describe("decreaseMUSDDebt()", () => {
-    it("decreases the recorded MUSD balance by the correct amount", async () => {
+    it("decreases the recorded mUSD balance by the correct amount", async () => {
       const initialAmount = to1e18("100")
 
       await contracts.activePool

--- a/solidity/test/normal/BorrowerOperations.test.ts
+++ b/solidity/test/normal/BorrowerOperations.test.ts
@@ -377,7 +377,7 @@ describe("BorrowerOperations in Normal Mode", () => {
         sender: carol.wallet,
       })
 
-      // Get the expected debt based on the MUSD request (adding fee and liq. reserve on top)
+      // Get the expected debt based on the mUSD request (adding fee and liq. reserve on top)
       const expectedDebt =
         MIN_NET_DEBT +
         (await contracts.troveManager.getBorrowingFee(MIN_NET_DEBT)) +
@@ -394,7 +394,7 @@ describe("BorrowerOperations in Normal Mode", () => {
     })
 
     it("Allows a user to open a Trove, then close it, then re-open it", async () => {
-      // Send MUSD to Alice so she has sufficent funds to close the trove
+      // Send mUSD to Alice so she has sufficent funds to close the trove
       await contracts.musd
         .connect(bob.wallet)
         .transfer(alice.address, to1e18("10,000"))
@@ -454,7 +454,7 @@ describe("BorrowerOperations in Normal Mode", () => {
       expect(lastInterestUpdatedTime).is.equal(currentTime)
     })
 
-    it("Increases user MUSD balance by correct amount", async () => {
+    it("Increases user mUSD balance by correct amount", async () => {
       expect(await contracts.musd.balanceOf(carol.wallet)).to.equal(0)
 
       const musdAmount = to1e18("100,000")
@@ -466,7 +466,7 @@ describe("BorrowerOperations in Normal Mode", () => {
       expect(await contracts.musd.balanceOf(carol.wallet)).to.equal(musdAmount)
     })
 
-    it("Increases the Trove's MUSD debt by the correct amount", async () => {
+    it("Increases the Trove's mUSD debt by the correct amount", async () => {
       const abi = [
         // Add your contract ABI here
         "event MUSDBorrowingFeePaid(address indexed _borrower, uint256 _MUSDFee)",
@@ -492,7 +492,7 @@ describe("BorrowerOperations in Normal Mode", () => {
       )
     })
 
-    it("Increases MUSD debt in ActivePool by the debt of the trove", async () => {
+    it("Increases mUSD debt in ActivePool by the debt of the trove", async () => {
       const debtBefore = await contracts.activePool.getMUSDDebt()
 
       await openTrove(contracts, {
@@ -583,7 +583,7 @@ describe("BorrowerOperations in Normal Mode", () => {
       )
     })
 
-    it("Borrowing at non-zero base rate sends MUSD fee to PCV contract", async () => {
+    it("Borrowing at non-zero base rate sends mUSD fee to PCV contract", async () => {
       state.pcv.musd.before = await contracts.musd.balanceOf(addresses.pcv)
 
       const newRate = to1e18(5) / 100n
@@ -620,7 +620,7 @@ describe("BorrowerOperations in Normal Mode", () => {
       expect(dennis.musd.after).to.equal(musdAmount)
     })
 
-    it("Borrowing at zero base rate changes the PCV contract MUSD fees collected", async () => {
+    it("Borrowing at zero base rate changes the PCV contract mUSD fees collected", async () => {
       state.troveManager.baseRate.before =
         await contracts.troveManager.baseRate()
       expect(state.troveManager.baseRate.before).to.be.equal(0)
@@ -980,7 +980,7 @@ describe("BorrowerOperations in Normal Mode", () => {
       )
     })
 
-    it("subtracts the debt of the closed Trove from the Borrower's MUSDToken balance", async () => {
+    it("subtracts the debt of the closed Trove from the Borrower's mUSD balance", async () => {
       await updateTroveSnapshot(contracts, alice, "before")
 
       const amount = to1e18("10,000")
@@ -1143,11 +1143,11 @@ describe("BorrowerOperations in Normal Mode", () => {
         ).to.be.revertedWith("TroveManager: Only one trove in the system")
       })
 
-      it("reverts if borrower has insufficient MUSD balance to repay his entire debt", async () => {
+      it("reverts if borrower has insufficient mUSD to repay his entire debt", async () => {
         await expect(
           contracts.borrowerOperations.connect(bob.wallet).closeTrove(),
         ).to.be.revertedWith(
-          "BorrowerOps: Caller doesnt have enough MUSD to make repayment",
+          "BorrowerOps: Caller doesnt have enough mUSD to make repayment",
         )
       })
     })
@@ -1587,7 +1587,7 @@ describe("BorrowerOperations in Normal Mode", () => {
       )
     })
 
-    it("borrowing at zero base rate changes MUSD fees", async () => {
+    it("borrowing at zero base rate changes mUSD fees", async () => {
       const maxFeePercentage = to1e18(1)
       const amount = to1e18(1)
       await setupCarolsTrove()
@@ -1601,7 +1601,7 @@ describe("BorrowerOperations in Normal Mode", () => {
       expect(state.pcv.musd.after).is.greaterThan(state.pcv.musd.before)
     })
 
-    it("increases the Trove's MUSD debt by the correct amount", async () => {
+    it("increases the Trove's mUSD debt by the correct amount", async () => {
       const maxFeePercentage = to1e18(1)
       const amount = to1e18(1)
       const borrowingRate = await contracts.troveManager.getBorrowingRate()
@@ -1685,7 +1685,7 @@ describe("BorrowerOperations in Normal Mode", () => {
       expect(await contracts.troveManager.baseRate()).is.lessThan(newRate)
     })
 
-    it("borrowing at non-zero base rate sends MUSD fee to PCV contract", async () => {
+    it("borrowing at non-zero base rate sends mUSD fee to PCV contract", async () => {
       const maxFeePercentage = to1e18(1)
       const amount = to1e18(1)
       await setupCarolsTroveAndAdjustRate()
@@ -1727,7 +1727,7 @@ describe("BorrowerOperations in Normal Mode", () => {
       )
     })
 
-    it("increases MUSD debt in ActivePool by correct amount", async () => {
+    it("increases mUSD debt in ActivePool by correct amount", async () => {
       const maxFeePercentage = to1e18(1)
       const amount = to1e18(1)
 
@@ -1849,7 +1849,7 @@ describe("BorrowerOperations in Normal Mode", () => {
         ).to.be.revertedWith("BorrowerOps: Trove does not exist or is closed")
       })
 
-      it("reverts when requested withdrawal amount is zero MUSD", async () => {
+      it("reverts when requested withdrawal amount is zero mUSD", async () => {
         const maxFeePercentage = to1e18(1)
         const amount = 0
 
@@ -1868,7 +1868,7 @@ describe("BorrowerOperations in Normal Mode", () => {
 
         expect(tcr).to.equal(to1e18(1.5))
 
-        // Bob attempts to withdraw 1 MUSD.
+        // Bob attempts to withdraw 1 mUSD.
         const maxFeePercentage = to1e18(1)
         const amount = to1e18(1)
 
@@ -1894,7 +1894,7 @@ describe("BorrowerOperations in Normal Mode", () => {
       expect(bob.trove.debt.after).is.greaterThan(MIN_NET_DEBT)
     })
 
-    it("reduces the Trove's MUSD debt by the correct amount", async () => {
+    it("reduces the Trove's mUSD debt by the correct amount", async () => {
       const amount = to1e18("1,000")
       await updateTroveSnapshot(contracts, bob, "before")
       await contracts.borrowerOperations
@@ -1905,7 +1905,7 @@ describe("BorrowerOperations in Normal Mode", () => {
       expect(bob.trove.debt.after).to.equal(bob.trove.debt.before - amount)
     })
 
-    it("decreases user MUSDToken balance by correct amount", async () => {
+    it("decreases user mUSD balance by correct amount", async () => {
       bob.musd.before = await contracts.musd.balanceOf(bob.address)
       const amount = to1e18("1,000")
       await contracts.borrowerOperations
@@ -1916,7 +1916,7 @@ describe("BorrowerOperations in Normal Mode", () => {
       expect(bob.musd.after).to.equal(bob.musd.before - amount)
     })
 
-    it("decreases MUSD debt in ActivePool by correct amount", async () => {
+    it("decreases mUSD debt in ActivePool by correct amount", async () => {
       await updateContractsSnapshot(
         contracts,
         state,
@@ -2010,7 +2010,7 @@ describe("BorrowerOperations in Normal Mode", () => {
         ).to.be.revertedWithPanic()
       })
 
-      it("Reverts if borrower has insufficient MUSD balance to cover his debt repayment", async () => {
+      it("Reverts if borrower has insufficient mUSD to cover his debt repayment", async () => {
         // bob has $20,000 of MUSD. Transfer $15,000 to Alice before trying to repay $15,000
         const amount = to1e18("15,000")
         await contracts.musd.connect(bob.wallet).transfer(alice.wallet, amount)
@@ -2020,7 +2020,7 @@ describe("BorrowerOperations in Normal Mode", () => {
             .connect(bob.wallet)
             .repayMUSD(amount, bob.wallet, bob.wallet),
         ).to.be.revertedWith(
-          "BorrowerOps: Caller doesnt have enough MUSD to make repayment",
+          "BorrowerOps: Caller doesnt have enough mUSD to make repayment",
         )
       })
     })
@@ -2245,7 +2245,7 @@ describe("BorrowerOperations in Normal Mode", () => {
       expect(carol.musd.after).to.equal(carol.musd.before + amount)
     })
 
-    it("Borrowing at zero base rate sends total requested MUSD to the user", async () => {
+    it("Borrowing at zero base rate sends total requested mUSD to the user", async () => {
       const maxFeePercentage = to1e18(1)
       const amount = to1e18(37)
 
@@ -2269,7 +2269,7 @@ describe("BorrowerOperations in Normal Mode", () => {
       expect(carol.musd.after).to.equal(carol.musd.before + amount)
     })
 
-    it("Borrowing at zero base rate changes MUSD balance of PCV contract", async () => {
+    it("Borrowing at zero base rate changes mUSD balance of PCV contract", async () => {
       const maxFeePercentage = to1e18(1)
       const amount = to1e18(37)
 
@@ -2295,7 +2295,7 @@ describe("BorrowerOperations in Normal Mode", () => {
       expect(state.pcv.musd.after).to.be.greaterThan(state.pcv.musd.before)
     })
 
-    it("borrowing at non-zero base rate sends MUSD fee to PCV contract", async () => {
+    it("borrowing at non-zero base rate sends mUSD fee to PCV contract", async () => {
       const maxFeePercentage = to1e18(1)
       const amount = to1e18(37)
 
@@ -2616,7 +2616,7 @@ describe("BorrowerOperations in Normal Mode", () => {
       )
     })
 
-    it("changes MUSDToken balance by the requested decrease", async () => {
+    it("changes mUSD balance by the requested decrease", async () => {
       const maxFeePercentage = to1e18(1)
       const debtChange = to1e18(50)
       const collChange = to1e18(1)
@@ -2639,7 +2639,7 @@ describe("BorrowerOperations in Normal Mode", () => {
       expect(carol.musd.after).to.be.equal(carol.musd.before - debtChange)
     })
 
-    it("changes MUSDToken balance by the requested increase", async () => {
+    it("changes mUSD balance by the requested increase", async () => {
       const maxFeePercentage = to1e18(1)
       const debtChange = to1e18(50)
       const collChange = to1e18(1)
@@ -2748,7 +2748,7 @@ describe("BorrowerOperations in Normal Mode", () => {
       )
     })
 
-    it("Changes the MUSD debt in ActivePool by requested decrease", async () => {
+    it("Changes the mUSD debt in ActivePool by requested decrease", async () => {
       const maxFeePercentage = to1e18(1)
       const debtChange = to1e18(50)
       const collChange = to1e18(1)
@@ -2788,7 +2788,7 @@ describe("BorrowerOperations in Normal Mode", () => {
       )
     })
 
-    it("Changes the MUSD debt in ActivePool by requested increase", async () => {
+    it("Changes the mUSD debt in ActivePool by requested increase", async () => {
       const abi = [
         // Add your contract ABI here
         "event MUSDBorrowingFeePaid(address indexed _borrower, uint256 _MUSDFee)",
@@ -2993,7 +2993,7 @@ describe("BorrowerOperations in Normal Mode", () => {
         )
       })
 
-      it("reverts when MUSD repaid is > debt of the trove", async () => {
+      it("reverts when mUSD repaid is > debt of the trove", async () => {
         // Alice transfers MUSD to bob to compensate borrowing fees
         await contracts.musd
           .connect(alice.wallet)
@@ -3126,7 +3126,7 @@ describe("BorrowerOperations in Normal Mode", () => {
         )
       })
 
-      it("Reverts if borrower has insufficient MUSD balance to cover his debt repayment", async () => {
+      it("Reverts if borrower has insufficient mUSD to cover his debt repayment", async () => {
         await updateTroveSnapshot(contracts, alice, "before")
         await expect(
           contracts.borrowerOperations

--- a/solidity/test/normal/CollSurplusPool.test.ts
+++ b/solidity/test/normal/CollSurplusPool.test.ts
@@ -53,7 +53,7 @@ describe("CollSurplusPool in Normal Mode", () => {
         sender: alice.wallet,
       })
 
-      // Whale sends Bob enough MUSD to liquidate Alice
+      // Whale sends Bob enough mUSD to liquidate Alice
       await contracts.musd.connect(whale.wallet).transfer(bob.wallet, netDebt)
 
       await updateTroveSnapshot(contracts, alice, "before")
@@ -109,7 +109,7 @@ describe("CollSurplusPool in Normal Mode", () => {
         sender: alice.wallet,
       })
 
-      // Whale sends Bob enough MUSD to liquidate Alice
+      // Whale sends Bob enough mUSD to liquidate Alice
       await contracts.musd.connect(whale.wallet).transfer(bob.wallet, netDebt)
 
       await updateTroveSnapshot(contracts, alice, "before")
@@ -146,7 +146,7 @@ describe("CollSurplusPool in Normal Mode", () => {
         sender: alice.wallet,
       })
 
-      // Whale sends Bob enough MUSD to liquidate Alice
+      // Whale sends Bob enough mUSD to liquidate Alice
       await contracts.musd.connect(whale.wallet).transfer(bob.wallet, netDebt)
 
       await updateTroveSnapshot(contracts, alice, "before")

--- a/solidity/test/normal/DefaultPool.test.ts
+++ b/solidity/test/normal/DefaultPool.test.ts
@@ -55,13 +55,13 @@ describe("DefaultPool", () => {
   })
 
   describe("getMUSDDebt()", () => {
-    it("gets the recorded MUSD balance", async () => {
+    it("gets the recorded mUSD balance", async () => {
       expect(await contracts.defaultPool.getMUSDDebt()).to.equal(0)
     })
   })
 
   context("increaseMUSDDebt()", () => {
-    it("increases the recorded MUSD balance by the correct amount", async () => {
+    it("increases the recorded mUSD balance by the correct amount", async () => {
       await updateContractsSnapshot(
         contracts,
         state,
@@ -90,7 +90,7 @@ describe("DefaultPool", () => {
   })
 
   describe("decreaseMUSDDebt()", () => {
-    it("decreases the recorded MUSD balance by the correct amount", async () => {
+    it("decreases the recorded mUSD balance by the correct amount", async () => {
       const originalAmount = to1e18("200")
       await contracts.defaultPool
         .connect(troveManagerSigner)

--- a/solidity/test/normal/PCV.test.ts
+++ b/solidity/test/normal/PCV.test.ts
@@ -163,7 +163,7 @@ describe("PCV", () => {
   })
 
   describe("depositToStabilityPool()", () => {
-    it("deposits additional MUSD to StabilityPool", async () => {
+    it("deposits additional mUSD to StabilityPool", async () => {
       const depositAmount = to1e18("20")
       await contracts.musd.unprotectedMint(addresses.pcv, depositAmount)
       await PCVDeployer.depositToStabilityPool(depositAmount)
@@ -174,7 +174,7 @@ describe("PCV", () => {
     })
 
     context("Expected Reverts", () => {
-      it("reverts when not enough MUSD", async () => {
+      it("reverts when not enough mUSD", async () => {
         await expect(
           PCVDeployer.depositToStabilityPool(bootstrapLoan + 1n),
         ).to.be.revertedWith("PCV: not enough tokens")
@@ -183,7 +183,7 @@ describe("PCV", () => {
   })
 
   describe("withdrawMUSD()", () => {
-    it("withdraws MUSD to recipient", async () => {
+    it("withdraws mUSD to recipient", async () => {
       await debtPaid()
       const value = to1e18("20")
       await contracts.musd.unprotectedMint(addresses.pcv, value)
@@ -213,7 +213,7 @@ describe("PCV", () => {
         ).to.be.revertedWith("PCV: recipient must be in whitelist")
       })
 
-      it("reverts if not enough MUSD", async () => {
+      it("reverts if not enough mUSD", async () => {
         await debtPaid()
         await contracts.musd.unprotectedMint(addresses.pcv, bootstrapLoan)
         await expect(

--- a/solidity/test/normal/SortedTroves.test.ts
+++ b/solidity/test/normal/SortedTroves.test.ts
@@ -41,7 +41,7 @@ describe("SortedTroves", () => {
       // Need to open two troves so that we can close Alice's. We can't close the last trove.
       await openTroves(contracts, [alice, bob], "2,000", "200")
 
-      // Give Alice extra MUSD to pay back fees.
+      // Give Alice extra mUSD to pay back fees.
       await contracts.musd.unprotectedMint(alice.wallet, to1e18("1,000"))
 
       await contracts.borrowerOperations.connect(alice.wallet).closeTrove()
@@ -55,7 +55,7 @@ describe("SortedTroves", () => {
       // Need to open two troves so that we can close Alice's. We can't close the last trove.
       await openTroves(contracts, [alice, bob], "2,000", "200")
 
-      // Give Alice extra MUSD to pay back fees.
+      // Give Alice extra mUSD to pay back fees.
       await contracts.musd.unprotectedMint(alice.wallet, to1e18("1,000"))
 
       await contracts.borrowerOperations.connect(alice.wallet).closeTrove()

--- a/solidity/test/normal/StabilityPool.test.ts
+++ b/solidity/test/normal/StabilityPool.test.ts
@@ -83,7 +83,7 @@ describe("StabilityPool in Normal Mode", () => {
       await createLiquidationEvent(contracts)
     }
 
-    it("increases the Stability Pool MUSD balance", async () => {
+    it("increases the Stability Pool mUSD balance", async () => {
       const amount = to1e18(30)
 
       await updateStabilityPoolSnapshot(contracts, state, "before")
@@ -161,7 +161,7 @@ describe("StabilityPool in Normal Mode", () => {
       expect(alice.stabilityPool.P.after).to.equal(state.stabilityPool.P.after)
       expect(alice.stabilityPool.S.after).to.equal(state.stabilityPool.S.after)
 
-      // Bob withdraws MUSD and deposits to StabilityPool
+      // Bob withdraws mUSD and deposits to StabilityPool
 
       await openTrove(contracts, {
         musdAmount: "3,000",
@@ -297,7 +297,7 @@ describe("StabilityPool in Normal Mode", () => {
       ).to.equal("3")
     })
 
-    it("reduces the user's MUSD balance", async () => {
+    it("reduces the user's mUSD balance", async () => {
       await updateWalletSnapshot(contracts, alice, "before")
 
       const amount = to1e18(200)
@@ -346,14 +346,14 @@ describe("StabilityPool in Normal Mode", () => {
     })
 
     context("Expected Reverts", () => {
-      it("reverts if user tries to provide more than their MUSD balance", async () => {
+      it("reverts if user tries to provide more than their mUSD balance", async () => {
         await updateWalletSnapshot(contracts, alice, "before")
 
         await expect(provideToSP(contracts, alice, alice.musd.before + 1n)).to
           .be.reverted
       })
 
-      it("reverts if user tries to provide 2^256-1 MUSD, which exceeds their balance", async () => {
+      it("reverts if user tries to provide 2^256-1 mUSD, which exceeds their balance", async () => {
         // Alice attempts to deposit 2^256-1 MUSD
         const maxBytes32 = BigInt(
           "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
@@ -395,7 +395,7 @@ describe("StabilityPool in Normal Mode", () => {
       await updateWalletSnapshot(contracts, alice, "after")
     }
 
-    it("leaves the correct amount of MUSD in the Stability Pool", async () => {
+    it("leaves the correct amount of mUSD in the Stability Pool", async () => {
       await setupPartialRetrieval()
       const { liquidatedDebt } =
         await getEmittedLiquidationValues(liquidationTx)
@@ -408,7 +408,7 @@ describe("StabilityPool in Normal Mode", () => {
       expect(state.stabilityPool.musd.after).to.equal(expectedMUSD)
     })
 
-    it("full retrieval - leaves the correct amount of MUSD in the Stability Pool", async () => {
+    it("full retrieval - leaves the correct amount of mUSD in the Stability Pool", async () => {
       await provideToSP(contracts, alice, to1e18("5,000"))
 
       await updateStabilityPoolUserSnapshots(
@@ -445,7 +445,7 @@ describe("StabilityPool in Normal Mode", () => {
       )
     })
 
-    it("it correctly updates the user's MUSD and collateral snapshots of entitled reward per unit staked", async () => {
+    it("it correctly updates the user's mUSD and collateral snapshots of entitled reward per unit staked", async () => {
       await provideToSP(contracts, alice, to1e18("4,000"))
 
       await createLiquidationEvent(contracts)
@@ -567,7 +567,7 @@ describe("StabilityPool in Normal Mode", () => {
       expect(whale.stabilityPool.collateralGain.after).to.equal(0n)
     })
 
-    it("withdrawing 0 MUSD doesn't alter the caller's deposit or the total MUSD in the Stability Pool", async () => {
+    it("withdrawing 0 mUSD doesn't alter the caller's deposit or the total mUSD in the Stability Pool", async () => {
       await provideToSP(contracts, whale, to1e18("20,000"))
       await createLiquidationEvent(contracts)
 
@@ -612,7 +612,7 @@ describe("StabilityPool in Normal Mode", () => {
       })
     })
 
-    it("retrieves correct MUSD amount and the entire collateral Gain, and updates deposit", async () => {
+    it("retrieves correct mUSD amount and the entire collateral Gain, and updates deposit", async () => {
       await setupPartialRetrieval()
       const { liquidatedDebt, liquidatedColl } =
         await getEmittedLiquidationValues(liquidationTx)
@@ -659,7 +659,7 @@ describe("StabilityPool in Normal Mode", () => {
       expect(alice.btc.after).to.equal(alice.btc.before)
     })
 
-    it("increases depositor's MUSD token balance by the expected amount", async () => {
+    it("increases depositor's mUSD token balance by the expected amount", async () => {
       await provideToSP(contracts, alice, to1e18("4,000"))
 
       await createLiquidationEvent(contracts)
@@ -730,7 +730,7 @@ describe("StabilityPool in Normal Mode", () => {
       expect(whale.stabilityPool.compoundedDeposit.after).to.equal(0n)
     })
 
-    it("Request to withdraw 2^256-1 MUSD only withdraws the caller's compounded deposit", async () => {
+    it("Request to withdraw 2^256-1 mUSD only withdraws the caller's compounded deposit", async () => {
       await provideToSP(contracts, whale, to1e18("20,000"))
       const maxBytes32 = BigInt(
         "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
@@ -835,14 +835,14 @@ describe("StabilityPool in Normal Mode", () => {
         await verify()
       })
 
-      it("Depositors with equal initial deposit withdraw correct compounded deposit and collateral Gain after two liquidations of increasing MUSD", async () => {
+      it("Depositors with equal initial deposit withdraw correct compounded deposit and collateral Gain after two liquidations of increasing mUSD", async () => {
         await setupIdenticalDeposits()
         await createLiquidationEvent(contracts)
         await createLiquidationEvent(contracts, "3,000")
         await verify()
       })
 
-      it("Depositors with equal initial deposit withdraw correct compounded deposit and collateral Gain after three liquidations of increasing MUSD", async () => {
+      it("Depositors with equal initial deposit withdraw correct compounded deposit and collateral Gain after three liquidations of increasing mUSD", async () => {
         await setupIdenticalDeposits()
         await createLiquidationEvent(contracts)
         await createLiquidationEvent(contracts, "3,000")
@@ -904,7 +904,7 @@ describe("StabilityPool in Normal Mode", () => {
         await verify()
       })
 
-      it("Bob, Carol, Dennis deposit -> 2 liquidations -> Eric deposits -> 2 liquidations. All deposits and liquidations = 10,000 MUSD.", async () => {
+      it("Bob, Carol, Dennis deposit -> 2 liquidations -> Eric deposits -> 2 liquidations. All deposits and liquidations = 10,000 mUSD.", async () => {
         await openTrove(contracts, {
           musdAmount: "10,000",
           ICR: "200",
@@ -942,7 +942,7 @@ describe("StabilityPool in Normal Mode", () => {
         await verify()
       })
 
-      it("Bob, Carol, Dennis deposit -> 2 liquidations -> Dennis withdraws -> 2 liquidations. All deposits and liquidations = 2,000 MUSD.", async () => {
+      it("Bob, Carol, Dennis deposit -> 2 liquidations -> Dennis withdraws -> 2 liquidations. All deposits and liquidations = 2,000 mUSD.", async () => {
         const users = [bob, carol, dennis]
         const amount = "2,000"
 
@@ -1042,7 +1042,7 @@ describe("StabilityPool in Normal Mode", () => {
     })
 
     it("deposit spans one scale factor change: Single depositor withdraws correct compounded deposit and collateral Gain after one liquidation", async () => {
-      // Add just enough MUSD to increase the scale
+      // Add just enough mUSD to increase the scale
       await provideToSP(contracts, whale, to1e18("10250") + 500000n)
 
       await createLiquidationEvent(contracts, "10,000")
@@ -1420,7 +1420,7 @@ describe("StabilityPool in Normal Mode", () => {
       expectCorrectCollateralGainWithEqualDeposits()
     })
 
-    it("Depositors with equal initial deposit withdraw correct collateral Gain after two liquidations of increasing MUSD", async () => {
+    it("Depositors with equal initial deposit withdraw correct collateral Gain after two liquidations of increasing mUSD", async () => {
       await openTrovesAndProvideStability(contracts, users, "10,000", "200")
 
       await createLiquidationEvent(contracts, "5,000")
@@ -1739,7 +1739,7 @@ describe("StabilityPool in Normal Mode", () => {
     })
 
     it("deposit spans one scale factor change: Single depositor withdraws correct collateral Gain after one liquidation", async () => {
-      // Add just enough MUSD to increase the scale
+      // Add just enough mUSD to increase the scale
       await provideToSP(contracts, whale, to1e18("10250") + 500000n)
 
       await createLiquidationEvent(contracts, "10,000")
@@ -1765,7 +1765,7 @@ describe("StabilityPool in Normal Mode", () => {
     })
 
     it("Several deposits of varying amounts span one scale factor change. Depositors withdraw correct compounded deposit and collateral Gain after one liquidation", async () => {
-      // Add just enough MUSD to increase the scale
+      // Add just enough mUSD to increase the scale
       await provideToSP(contracts, whale, to1e18("5250") + 500000n)
 
       await openTroveAndProvideStability(contracts, bob, "3,000", "200")

--- a/solidity/test/normal/TroveManager.test.ts
+++ b/solidity/test/normal/TroveManager.test.ts
@@ -476,7 +476,7 @@ describe("TroveManager in Normal Mode", () => {
         .connect(bob.wallet)
         .transfer(dennis.wallet, spDeposit, { from: bob.wallet })
 
-      // Dennis provides MUSD to SP
+      // Dennis provides mUSD to SP
       await provideToSP(contracts, dennis, spDeposit)
 
       // Alice gets liquidated
@@ -678,7 +678,7 @@ describe("TroveManager in Normal Mode", () => {
         false,
       )
 
-      // Carol's collateral less the liquidation fee and MUSD should be added to the default pool
+      // Carol's collateral less the liquidation fee and mUSD should be added to the default pool
       const liquidatedColl = to1e18(
         applyLiquidationFee(carol.trove.collateral.before),
       )
@@ -696,7 +696,7 @@ describe("TroveManager in Normal Mode", () => {
         expectedLMUSDDebtAfterCarolLiquidated,
       )
 
-      // Alice now withdraws MUSD, bring her ICR to 1.11
+      // Alice now withdraws mUSD, bring her ICR to 1.11
       const { increasedTotalDebt } = await adjustTroveToICR(
         contracts,
         alice.wallet,
@@ -960,13 +960,13 @@ describe("TroveManager in Normal Mode", () => {
       )
       expect(state.activePool.btc.before).to.equal(expectedCollateralBefore)
 
-      // check MUSD Debt
+      // check mUSD Debt
       expect(state.activePool.debt.before).to.equal(
         alice.trove.debt.before + bob.trove.debt.before,
       )
 
-      /* Close Alice's Trove. Should liquidate her collateral and MUSD,
-       * leaving Bob’s collateral and MUSD debt in the ActivePool. */
+      /* Close Alice's Trove. Should liquidate her collateral and mUSD,
+       * leaving Bob’s collateral and mUSD debt in the ActivePool. */
       await dropPriceAndLiquidate(contracts, alice)
 
       await updateContractsSnapshot(
@@ -982,11 +982,11 @@ describe("TroveManager in Normal Mode", () => {
       )
       expect(state.activePool.btc.after).to.equal(bob.trove.collateral.before)
 
-      // check ActivePool MUSD debt
+      // check ActivePool mUSD debt
       expect(state.activePool.debt.after).to.equal(bob.trove.debt.before)
     })
 
-    it("increases DefaultPool collateral and MUSD debt by correct amounts", async () => {
+    it("increases DefaultPool collateral and mUSD debt by correct amounts", async () => {
       await setupTroves()
       await updateTroveSnapshot(contracts, alice, "before")
       await updateTroveSnapshot(contracts, bob, "before")
@@ -1002,7 +1002,7 @@ describe("TroveManager in Normal Mode", () => {
       expect(state.defaultPool.collateral.before).to.equal(0n)
       expect(state.defaultPool.btc.before).to.equal(0n)
 
-      // check MUSD Debt
+      // check mUSD Debt
       expect(state.defaultPool.debt.before).to.equal(0n)
 
       await dropPriceAndLiquidate(contracts, alice)
@@ -1411,7 +1411,7 @@ describe("TroveManager in Normal Mode", () => {
         sender: carol.wallet,
       })
 
-      // Send MUSD to Carol so she can close her trove
+      // Send mUSD to Carol so she can close her trove
       await contracts.musd
         .connect(bob.wallet)
         .transfer(carol.address, to1e18("1000"))
@@ -1490,7 +1490,7 @@ describe("TroveManager in Normal Mode", () => {
         partialRedemptionAmount
 
       const maxRedeemableMUSD =
-        totalDebt - musdAmount - partialRedemptionAmount + to1e18("200") // Partial redemption amount + 200 MUSD for gas comp
+        totalDebt - musdAmount - partialRedemptionAmount + to1e18("200") // Partial redemption amount + 200 mUSD for gas comp
       const netMUSDdebt = totalDebt - to1e18("200")
       const newColl = collateral - to1e18(maxRedeemableMUSD) / price
 
@@ -1530,7 +1530,7 @@ describe("TroveManager in Normal Mode", () => {
 
       const price = await contracts.priceFeed.fetchPrice()
 
-      // Try to redeem 10k MUSD.  At least 2 iterations should be needed for total redemption of the given amount.
+      // Try to redeem 10k mUSD.  At least 2 iterations should be needed for total redemption of the given amount.
       const { partialRedemptionHintNICR } =
         await contracts.hintHelpers.getRedemptionHints(
           to1e18("10,000"),
@@ -1585,7 +1585,7 @@ describe("TroveManager in Normal Mode", () => {
       const { collateralSent, collateralFee } =
         await getEmittedRedemptionValues(redemptionTx)
 
-      // Calculate the amount of collateral needed to redeem the given amount of MUSD
+      // Calculate the amount of collateral needed to redeem the given amount of mUSD
       const collNeeded = to1e18(redemptionAmount) / price
 
       await updateTroveSnapshots(
@@ -1740,7 +1740,7 @@ describe("TroveManager in Normal Mode", () => {
     it("performs partial redemption if resultant debt is > minimum net debt", async () => {
       await setupRedemptionTroves()
 
-      const redemptionAmount = to1e18("4120") // Alice and Bob's net debt + 100 MUSD
+      const redemptionAmount = to1e18("4120") // Alice and Bob's net debt + 100 mUSD
       await performRedemption(contracts, dennis, dennis, redemptionAmount)
 
       // Check that Alice and Bob's troves are closed by redemption
@@ -1752,7 +1752,7 @@ describe("TroveManager in Normal Mode", () => {
       // Check that Carol's trove is still active
       expect(await checkTroveActive(contracts, carol)).to.equal(true)
 
-      // Check that Carol's debt has been reduced by 100 MUSD because of the partial redemption
+      // Check that Carol's debt has been reduced by 100 mUSD because of the partial redemption
       await updateTroveSnapshot(contracts, carol, "after")
       expect(carol.trove.debt.after - carol.trove.debt.before).to.equal(
         to1e18("-100"),
@@ -1762,7 +1762,7 @@ describe("TroveManager in Normal Mode", () => {
     it("doesn't perform partial redemption if resultant debt would be < minimum net debt", async () => {
       await setupRedemptionTroves()
 
-      // Alice and Bob's net debt + 300 MUSD.  A partial redemption of 300 MUSD would put Carol below minimum net debt
+      // Alice and Bob's net debt + 300 mUSD.  A partial redemption of 300 mUSD would put Carol below minimum net debt
       const redemptionAmount = to1e18("4320")
 
       await performRedemption(contracts, dennis, dennis, redemptionAmount)
@@ -1806,7 +1806,7 @@ describe("TroveManager in Normal Mode", () => {
         lowerPartialRedemptionHint: l,
       } = await getRedemptionHints(contracts, dennis, to1e18("10"), price)
 
-      // Carol redeems 10 MUSD from Alice's trove ahead of Dennis's redemption
+      // Carol redeems 10 mUSD from Alice's trove ahead of Dennis's redemption
       await contracts.troveManager
         .connect(carol.wallet)
         .redeemCollateral(to1e18("10"), f, u, l, p, 0, to1e18("1"), NO_GAS)
@@ -1913,7 +1913,7 @@ describe("TroveManager in Normal Mode", () => {
       )
     })
 
-    it("cancels the provided MUSD with debt from Troves with the lowest ICRs and sends an equivalent amount of collateral", async () => {
+    it("cancels the provided mUSD with debt from Troves with the lowest ICRs and sends an equivalent amount of collateral", async () => {
       await setupRedemptionTroves()
 
       const redemptionAmount = to1e18("200")
@@ -2012,7 +2012,7 @@ describe("TroveManager in Normal Mode", () => {
       await checkCollateralAndDebtValues(redemptionTx, redemptionAmount, price)
     })
 
-    it("caller can redeem their entire MUSDToken balance", async () => {
+    it("caller can redeem their entire mUSD balance", async () => {
       await setupRedemptionTroves()
       await updateWalletSnapshot(contracts, dennis, "before")
 
@@ -2239,7 +2239,7 @@ describe("TroveManager in Normal Mode", () => {
       )
     })
 
-    it("value of issued collateral == face value of redeemed MUSD (assuming 1 MUSD has value of $1)", async () => {
+    it("value of issued collateral == face value of redeemed mUSD (assuming 1 mUSD has value of $1)", async () => {
       await setupRedemptionTroves()
 
       await updateContractsSnapshot(
@@ -2360,14 +2360,14 @@ describe("TroveManager in Normal Mode", () => {
         ).to.be.revertedWith("Fee exceeded provided maximum")
       })
 
-      it("reverts when requested redemption amount exceeds caller's MUSD token balance", async () => {
+      it("reverts when requested redemption amount exceeds caller's mUSD token balance", async () => {
         await setupRedemptionTroves()
         await updateWalletSnapshot(contracts, dennis, "before")
 
         await expect(
           performRedemption(contracts, dennis, dennis, dennis.musd.before + 1n),
         ).to.be.revertedWith(
-          "TroveManager: Requested redemption amount must be <= user's MUSD token balance",
+          "TroveManager: Requested redemption amount must be <= user's mUSD token balance",
         )
       })
 
@@ -2446,7 +2446,7 @@ describe("TroveManager in Normal Mode", () => {
         await updateTroveSnapshot(contracts, bob, "before")
 
         const partialAmount = to1e18("10")
-        const redemptionAmount = to1e18("2010") + partialAmount // Redeem an amount equal to Alice's net debt + 10 MUSD
+        const redemptionAmount = to1e18("2010") + partialAmount // Redeem an amount equal to Alice's net debt + 10 mUSD
 
         // Perform a redemption that fully redeems Alice's trove and partially redeems Bob's
         const redemptionTx = await performRedemption(
@@ -2485,7 +2485,7 @@ describe("TroveManager in Normal Mode", () => {
   })
 
   describe("getPendingMUSDDebtReward()", () => {
-    it("returns 0 if there is no pending MUSD reward", async () => {
+    it("returns 0 if there is no pending mUSD reward", async () => {
       await setupTroves()
       await openTrove(contracts, {
         musdAmount: "5000",
@@ -2526,7 +2526,7 @@ describe("TroveManager in Normal Mode", () => {
       ).to.equal(0)
     })
 
-    it.skip("Returns 2^256-1 for collateral:USD = 100, coll = 1 BTC/token, debt = 100 MUSD", async () => {
+    it.skip("Returns 2^256-1 for collateral:USD = 100, coll = 1 BTC/token, debt = 100 mUSD", async () => {
       // This seems designed to test an edge case where we would overflow but that edge case should no longer be possible
       // THUSD Test: https://github.com/Threshold-USD/dev/blob/develop/packages/contracts/test/TroveManagerTest.js#L4043
     })

--- a/solidity/test/recovery/BorrowerOperations.test.ts
+++ b/solidity/test/recovery/BorrowerOperations.test.ts
@@ -105,7 +105,7 @@ describe("BorrowerOperations in Recovery Mode", () => {
         .liquidate(alice.wallet)
 
       /* with total stakes = 10 ether/tokens, after liquidation, L_Collateral should equal 1/10 ether/token per-ether-staked/per-tokens-staked,
-      and L_MUSD should equal 18 MUSD per-ether-staked/per-tokens-staked. */
+      and L_MUSD should equal 18 mUSD per-ether-staked/per-tokens-staked. */
 
       const liquidatedCollateral = await contracts.troveManager.L_Collateral()
       const liquidatedDebt = await contracts.troveManager.L_MUSDDebt()

--- a/solidity/test/recovery/TroveManager.test.ts
+++ b/solidity/test/recovery/TroveManager.test.ts
@@ -749,7 +749,7 @@ describe("TroveManager in Recovery Mode", () => {
       )
     })
 
-    it("with 110% < ICR < TCR, and StabilityPool MUSD > debt to liquidate: offsets the trove entirely with the pool", async () => {
+    it("with 110% < ICR < TCR, and StabilityPool mUSD > debt to liquidate: offsets the trove entirely with the pool", async () => {
       const { spDeposit, totalDebt } = await setupTrovesForStabilityPoolTests()
 
       await updateStabilityPoolSnapshot(contracts, state, "before")
@@ -760,7 +760,7 @@ describe("TroveManager in Recovery Mode", () => {
       expect(state.stabilityPool.musd.after).to.equal(spDeposit - totalDebt)
     })
 
-    it("with ICR% = 110 < TCR, and StabilityPool MUSD > debt to liquidate: offsets the trove entirely with the pool, there’s no collateral surplus", async () => {
+    it("with ICR% = 110 < TCR, and StabilityPool mUSD > debt to liquidate: offsets the trove entirely with the pool, there’s no collateral surplus", async () => {
       await setupTrovesForStabilityPoolTests()
 
       await dropPrice(contracts, bob, to1e18("110"))
@@ -771,7 +771,7 @@ describe("TroveManager in Recovery Mode", () => {
       ).to.equal(0n)
     })
 
-    it("with 110% < ICR < TCR, and StabilityPool MUSD > debt to liquidate: removes stake and updates totalStakes", async () => {
+    it("with 110% < ICR < TCR, and StabilityPool mUSD > debt to liquidate: removes stake and updates totalStakes", async () => {
       await setupTrovesForStabilityPoolTests()
 
       await updateStabilityPoolSnapshot(contracts, state, "before")
@@ -787,7 +787,7 @@ describe("TroveManager in Recovery Mode", () => {
       )
     })
 
-    it("with 110% < ICR < TCR, and StabilityPool MUSD > debt to liquidate: updates system snapshots", async () => {
+    it("with 110% < ICR < TCR, and StabilityPool mUSD > debt to liquidate: updates system snapshots", async () => {
       await setupTrovesForStabilityPoolTests()
       await updateTroveManagerSnapshot(contracts, state, "before")
       await dropPrice(contracts, bob, to1e18("112"))
@@ -801,7 +801,7 @@ describe("TroveManager in Recovery Mode", () => {
       )
     })
 
-    it("with 110% < ICR < TCR, and StabilityPool MUSD > debt to liquidate: closes the Trove", async () => {
+    it("with 110% < ICR < TCR, and StabilityPool mUSD > debt to liquidate: closes the Trove", async () => {
       await setupTrovesForStabilityPoolTests()
       await dropPrice(contracts, bob, to1e18("112"))
       await contracts.troveManager.liquidate(bob.address)
@@ -936,7 +936,7 @@ describe("TroveManager in Recovery Mode", () => {
     })
 
     context("Expected Reverts", () => {
-      it("reverts with ICR > 110%, and StabilityPool MUSD < liquidated debt", async () => {
+      it("reverts with ICR > 110%, and StabilityPool mUSD < liquidated debt", async () => {
         await setupTrovesStabilityPoolLessThanDebt()
 
         await dropPrice(contracts, bob, to1e18("112"))


### PR DESCRIPTION
We're not able to do a simple find/replace here. Notable exceptions:

- Camel casing in the middle for a word. We want `getMUSDDebt` not `getmUSDDebt`.
- First-letter-capitalization for contracts, events,  and typescript types. We want `MUSDTokenAddressChanged` not `mUSDTokenAddressChanged`.

Tagging @rwatts07 for review