### PR TITLE
Add an Interest Argument to `increaseMUSDDebt` and `decreaseMUSDDebt`

### DIFF
--- a/solidity/contracts/ActivePool.sol
+++ b/solidity/contracts/ActivePool.sol
@@ -27,7 +27,8 @@ contract ActivePool is Ownable, CheckContract, SendCollateral, IActivePool {
     address public stabilityPoolAddress;
     address public troveManagerAddress;
     uint256 internal collateral; // deposited collateral tracker
-    uint256 internal MUSDDebt;
+    uint256 internal principal;
+    uint256 internal interest;
 
     constructor() Ownable(msg.sender) {}
 
@@ -104,16 +105,24 @@ contract ActivePool is Ownable, CheckContract, SendCollateral, IActivePool {
         renounceOwnership();
     }
 
-    function increaseMUSDDebt(uint256 _amount) external override {
+    function increaseMUSDDebt(
+        uint256 _principal,
+        uint256 _interest
+    ) external override {
         _requireCallerIsBorrowerOperationsOrTroveManager();
-        MUSDDebt += _amount;
-        emit ActivePoolMUSDDebtUpdated(MUSDDebt);
+        principal += _principal;
+        interest += _interest;
+        emit ActivePoolMUSDDebtUpdated(principal, interest);
     }
 
-    function decreaseMUSDDebt(uint256 _amount) external override {
+    function decreaseMUSDDebt(
+        uint256 _principal,
+        uint256 _interest
+    ) external override {
         _requireCallerIsBOorTroveMorSP();
-        MUSDDebt -= _amount;
-        emit ActivePoolMUSDDebtUpdated(MUSDDebt);
+        principal -= _principal;
+        interest -= _interest;
+        emit ActivePoolMUSDDebtUpdated(principal, interest);
     }
 
     function sendCollateral(
@@ -138,7 +147,7 @@ contract ActivePool is Ownable, CheckContract, SendCollateral, IActivePool {
     }
 
     function getMUSDDebt() external view override returns (uint) {
-        return MUSDDebt;
+        return principal;
     }
 
     function _requireCallerIsBorrowerOperationsOrDefaultPool() internal view {

--- a/solidity/contracts/BorrowerOperations.sol
+++ b/solidity/contracts/BorrowerOperations.sol
@@ -402,7 +402,8 @@ contract BorrowerOperations is
 
         // Decrease the active pool debt by the principal (subtracting interestOwed from the total debt)
         activePoolCached.decreaseMUSDDebt(
-            debt - MUSD_GAS_COMPENSATION - interestOwed
+            debt - MUSD_GAS_COMPENSATION - interestOwed,
+            0
         );
 
         // Burn the repaid mUSD from the user's balance
@@ -701,7 +702,7 @@ contract BorrowerOperations is
         uint256 _debtAmount,
         uint256 _netDebtIncrease
     ) internal {
-        _activePool.increaseMUSDDebt(_netDebtIncrease);
+        _activePool.increaseMUSDDebt(_netDebtIncrease, 0);
         _musd.mint(_account, _debtAmount);
     }
 
@@ -712,7 +713,7 @@ contract BorrowerOperations is
         address _account,
         uint256 _MUSD
     ) internal {
-        _activePool.decreaseMUSDDebt(_MUSD);
+        _activePool.decreaseMUSDDebt(_MUSD, 0);
         _musd.burn(_account, _MUSD);
     }
 

--- a/solidity/contracts/DefaultPool.sol
+++ b/solidity/contracts/DefaultPool.sol
@@ -21,7 +21,8 @@ contract DefaultPool is Ownable, CheckContract, SendCollateral, IDefaultPool {
     address public collateralAddress;
     address public troveManagerAddress;
     uint256 internal collateral; // deposited collateral tracker
-    uint256 internal MUSDDebt; // debt
+    uint256 internal principal;
+    uint256 internal interest;
 
     constructor() Ownable(msg.sender) {}
 
@@ -69,16 +70,24 @@ contract DefaultPool is Ownable, CheckContract, SendCollateral, IDefaultPool {
         renounceOwnership();
     }
 
-    function increaseMUSDDebt(uint256 _amount) external override {
+    function increaseMUSDDebt(
+        uint256 _principal,
+        uint256 _interest
+    ) external override {
         _requireCallerIsTroveManager();
-        MUSDDebt += _amount;
-        emit DefaultPoolMUSDDebtUpdated(MUSDDebt);
+        principal += _principal;
+        interest += _interest;
+        emit DefaultPoolMUSDDebtUpdated(principal, interest);
     }
 
-    function decreaseMUSDDebt(uint256 _amount) external override {
+    function decreaseMUSDDebt(
+        uint256 _principal,
+        uint256 _interest
+    ) external override {
         _requireCallerIsTroveManager();
-        MUSDDebt -= _amount;
-        emit DefaultPoolMUSDDebtUpdated(MUSDDebt);
+        principal -= _principal;
+        interest -= _interest;
+        emit DefaultPoolMUSDDebtUpdated(principal, interest);
     }
 
     function sendCollateralToActivePool(uint256 _amount) external override {
@@ -96,7 +105,7 @@ contract DefaultPool is Ownable, CheckContract, SendCollateral, IDefaultPool {
     }
 
     function getMUSDDebt() external view override returns (uint) {
-        return MUSDDebt;
+        return principal;
     }
 
     function _requireCallerIsTroveManager() internal view {

--- a/solidity/contracts/StabilityPool.sol
+++ b/solidity/contracts/StabilityPool.sol
@@ -480,7 +480,7 @@ contract StabilityPool is
         IActivePool activePoolCached = activePool;
 
         // Cancel the liquidated mUSD debt with the mUSD in the stability pool
-        activePoolCached.decreaseMUSDDebt(_debtToOffset);
+        activePoolCached.decreaseMUSDDebt(_debtToOffset, 0);
         _decreaseMUSD(_debtToOffset);
 
         // Burn the debt that was successfully offset

--- a/solidity/contracts/TroveManager.sol
+++ b/solidity/contracts/TroveManager.sol
@@ -537,7 +537,7 @@ contract TroveManager is LiquityBase, Ownable, CheckContract, ITroveManager {
         // Burn the total mUSD that is cancelled with debt, and send the redeemed collateral to msg.sender
         contractsCache.musdToken.burn(msg.sender, totals.totalMUSDToRedeem);
         // Update Active Pool mUSD, and send collateral to account
-        contractsCache.activePool.decreaseMUSDDebt(totals.totalMUSDToRedeem);
+        contractsCache.activePool.decreaseMUSDDebt(totals.totalMUSDToRedeem, 0);
         contractsCache.activePool.sendCollateral(
             msg.sender,
             totals.collateralToSendToRedeemer
@@ -1408,8 +1408,8 @@ contract TroveManager is LiquityBase, Ownable, CheckContract, ITroveManager {
         emit LTermsUpdated(L_Collateral, L_MUSDDebt);
 
         // Transfer coll and debt from ActivePool to DefaultPool
-        _activePool.decreaseMUSDDebt(_debt);
-        _defaultPool.increaseMUSDDebt(_debt);
+        _activePool.decreaseMUSDDebt(_debt, 0);
+        _defaultPool.increaseMUSDDebt(_debt, 0);
         _activePool.sendCollateral(address(_defaultPool), _coll);
     }
 
@@ -1775,7 +1775,7 @@ contract TroveManager is LiquityBase, Ownable, CheckContract, ITroveManager {
         _contractsCache.musdToken.burn(gasPoolAddress, _MUSD);
         // Update Active Pool mUSD, and send collateral to account
         // slither-disable-next-line calls-loop
-        _contractsCache.activePool.decreaseMUSDDebt(_MUSD);
+        _contractsCache.activePool.decreaseMUSDDebt(_MUSD, 0);
 
         // send collateral from Active Pool to CollSurplus Pool
         // slither-disable-next-line calls-loop
@@ -1928,9 +1928,9 @@ contract TroveManager is LiquityBase, Ownable, CheckContract, ITroveManager {
         uint256 _collateral
     ) internal {
         // slither-disable-next-line calls-loop
-        _defaultPool.decreaseMUSDDebt(_MUSD);
+        _defaultPool.decreaseMUSDDebt(_MUSD, 0);
         // slither-disable-next-line calls-loop
-        _activePool.increaseMUSDDebt(_MUSD);
+        _activePool.increaseMUSDDebt(_MUSD, 0);
         // slither-disable-next-line calls-loop
         _defaultPool.sendCollateralToActivePool(_collateral);
     }

--- a/solidity/contracts/interfaces/IActivePool.sol
+++ b/solidity/contracts/interfaces/IActivePool.sol
@@ -10,7 +10,7 @@ interface IActivePool is IPool {
         address _newBorrowerOperationsAddress
     );
     event TroveManagerAddressChanged(address _newTroveManagerAddress);
-    event ActivePoolMUSDDebtUpdated(uint256 _MUSDDebt);
+    event ActivePoolMUSDDebtUpdated(uint256 _principal, uint256 _interest);
     event ActivePoolCollateralBalanceUpdated(uint256 _collateral);
     event CollateralAddressChanged(address _newCollateralAddress);
     event CollSurplusPoolAddressChanged(address _newCollSurplusPoolAddress);

--- a/solidity/contracts/interfaces/IDefaultPool.sol
+++ b/solidity/contracts/interfaces/IDefaultPool.sol
@@ -7,7 +7,7 @@ import "./IPool.sol";
 interface IDefaultPool is IPool {
     // --- Events ---
     event TroveManagerAddressChanged(address _newTroveManagerAddress);
-    event DefaultPoolMUSDDebtUpdated(uint256 _MUSDDebt);
+    event DefaultPoolMUSDDebtUpdated(uint256 _principal, uint256 _interest);
     event DefaultPoolCollateralBalanceUpdated(uint256 _collateral);
     event CollateralAddressChanged(address _newCollateralAddress);
 

--- a/solidity/contracts/interfaces/IPool.sol
+++ b/solidity/contracts/interfaces/IPool.sol
@@ -7,7 +7,6 @@ interface IPool {
     // --- Events ---
 
     event CollateralBalanceUpdated(uint256 _newBalance);
-    event MUSDBalanceUpdated(uint256 _newBalance);
     event ActivePoolAddressChanged(address _newActivePoolAddress);
     event DefaultPoolAddressChanged(address _newDefaultPoolAddress);
     event StabilityPoolAddressChanged(address _newStabilityPoolAddress);
@@ -15,9 +14,9 @@ interface IPool {
 
     // --- Functions ---
 
-    function increaseMUSDDebt(uint256 _amount) external;
+    function increaseMUSDDebt(uint256 _principal, uint256 _interest) external;
 
-    function decreaseMUSDDebt(uint256 _amount) external;
+    function decreaseMUSDDebt(uint256 _principal, uint256 _interest) external;
 
     function getCollateralBalance() external view returns (uint);
 

--- a/solidity/test/normal/AccessControl.test.ts
+++ b/solidity/test/normal/AccessControl.test.ts
@@ -184,7 +184,7 @@ describe("Access Control: Liquity functions with the caller restricted to Liquit
 
     it("increaseMUSDDebt(): reverts when called by an account that is not BO nor TroveM", async () => {
       await expect(
-        contracts.activePool.connect(alice.wallet).increaseMUSDDebt(100),
+        contracts.activePool.connect(alice.wallet).increaseMUSDDebt(100n, 0n),
       ).to.be.revertedWith(
         "ActivePool: Caller is neither BorrowerOperations nor TroveManager",
       )
@@ -192,7 +192,7 @@ describe("Access Control: Liquity functions with the caller restricted to Liquit
 
     it("decreaseMUSDDebt(): reverts when called by an account that is not BO nor TroveM nor SP", async () => {
       await expect(
-        contracts.activePool.connect(alice.wallet).decreaseMUSDDebt(100),
+        contracts.activePool.connect(alice.wallet).decreaseMUSDDebt(100n, 0n),
       ).to.be.revertedWith(
         "ActivePool: Caller is neither BorrowerOperations nor TroveManager nor StabilityPool",
       )
@@ -229,13 +229,13 @@ describe("Access Control: Liquity functions with the caller restricted to Liquit
 
     it("increaseMUSDDebt(): reverts when called by an account that is not TroveManager", async () => {
       await expect(
-        contracts.defaultPool.connect(alice.wallet).increaseMUSDDebt(100),
+        contracts.defaultPool.connect(alice.wallet).increaseMUSDDebt(100n, 0n),
       ).to.be.revertedWith("DefaultPool: Caller is not the TroveManager")
     })
 
     it("decreaseMUSDDebt(): reverts when called by an account that is not TroveManager", async () => {
       await expect(
-        contracts.defaultPool.connect(alice.wallet).decreaseMUSDDebt(100),
+        contracts.defaultPool.connect(alice.wallet).decreaseMUSDDebt(100n, 0n),
       ).to.be.revertedWith("DefaultPool: Caller is not the TroveManager")
     })
 

--- a/solidity/test/normal/ActivePool.test.ts
+++ b/solidity/test/normal/ActivePool.test.ts
@@ -56,7 +56,7 @@ describe("ActivePool", () => {
 
       await contracts.activePool
         .connect(borrowerOperationsSigner)
-        .increaseMUSDDebt(amount, NO_GAS)
+        .increaseMUSDDebt(amount, 0n, NO_GAS)
 
       await updateContractsSnapshot(
         contracts,
@@ -78,7 +78,7 @@ describe("ActivePool", () => {
 
       await contracts.activePool
         .connect(borrowerOperationsSigner)
-        .increaseMUSDDebt(initialAmount, NO_GAS)
+        .increaseMUSDDebt(initialAmount, 0n, NO_GAS)
 
       await updateContractsSnapshot(
         contracts,
@@ -92,7 +92,7 @@ describe("ActivePool", () => {
 
       await contracts.activePool
         .connect(borrowerOperationsSigner)
-        .decreaseMUSDDebt(subtractedAmount, NO_GAS)
+        .decreaseMUSDDebt(subtractedAmount, 0n, NO_GAS)
 
       await updateContractsSnapshot(
         contracts,

--- a/solidity/test/normal/DefaultPool.test.ts
+++ b/solidity/test/normal/DefaultPool.test.ts
@@ -73,7 +73,7 @@ describe("DefaultPool", () => {
 
       await contracts.defaultPool
         .connect(troveManagerSigner)
-        .increaseMUSDDebt(amount, NO_GAS)
+        .increaseMUSDDebt(amount, 0n, NO_GAS)
 
       await updateContractsSnapshot(
         contracts,
@@ -94,12 +94,12 @@ describe("DefaultPool", () => {
       const originalAmount = to1e18("200")
       await contracts.defaultPool
         .connect(troveManagerSigner)
-        .increaseMUSDDebt(originalAmount, NO_GAS)
+        .increaseMUSDDebt(originalAmount, 0n, NO_GAS)
 
       const subtractedAmount = to1e18("50")
       await contracts.defaultPool
         .connect(troveManagerSigner)
-        .decreaseMUSDDebt(subtractedAmount, NO_GAS)
+        .decreaseMUSDDebt(subtractedAmount, 0n, NO_GAS)
 
       await updateContractsSnapshot(
         contracts,


### PR DESCRIPTION
This PR does some boilerplate work around tracking principal and interest separately in the active and default pools.

We add an internal `interest` variable, rename `MUSDDebt` to `principal`, and then add an interest argument to all of the mutation functions

The logic is unused and all of the callers for these functions pass in an interest of 0 for now, but that'll change in follow-ups.

Tagging @rwatts07 for review