### PR TITLE
Remove Redundant MUSD Verbiage

### DIFF
--- a/solidity/contracts/ActivePool.sol
+++ b/solidity/contracts/ActivePool.sol
@@ -13,9 +13,9 @@ import "./interfaces/IDefaultPool.sol";
 import "./interfaces/IStabilityPool.sol";
 
 /*
- * The Active Pool holds the collateral and mUSD debt (but not mUSD tokens) for all active troves.
+ * The Active Pool holds the collateral and debt (but not mUSD tokens) for all active troves.
  *
- * When a trove is liquidated, it's collateral and mUSD debt are transferred from the Active Pool, to either the
+ * When a trove is liquidated, it's collateral and debt are transferred from the Active Pool, to either the
  * Stability Pool, the Default Pool, or both, depending on the liquidation conditions.
  *
  */
@@ -105,24 +105,24 @@ contract ActivePool is Ownable, CheckContract, SendCollateral, IActivePool {
         renounceOwnership();
     }
 
-    function increaseMUSDDebt(
+    function increaseDebt(
         uint256 _principal,
         uint256 _interest
     ) external override {
         _requireCallerIsBorrowerOperationsOrTroveManager();
         principal += _principal;
         interest += _interest;
-        emit ActivePoolMUSDDebtUpdated(principal, interest);
+        emit ActivePoolDebtUpdated(principal, interest);
     }
 
-    function decreaseMUSDDebt(
+    function decreaseDebt(
         uint256 _principal,
         uint256 _interest
     ) external override {
         _requireCallerIsBOorTroveMorSP();
         principal -= _principal;
         interest -= _interest;
-        emit ActivePoolMUSDDebtUpdated(principal, interest);
+        emit ActivePoolDebtUpdated(principal, interest);
     }
 
     function sendCollateral(
@@ -146,7 +146,7 @@ contract ActivePool is Ownable, CheckContract, SendCollateral, IActivePool {
         return collateral;
     }
 
-    function getMUSDDebt() external view override returns (uint) {
+    function getDebt() external view override returns (uint) {
         return principal + interest;
     }
 

--- a/solidity/contracts/DefaultPool.sol
+++ b/solidity/contracts/DefaultPool.sol
@@ -10,10 +10,10 @@ import "./interfaces/IDefaultPool.sol";
 import "./interfaces/IActivePool.sol";
 
 /*
- * The Default Pool holds the collateral and mUSD debt (but not mUSD tokens) from liquidations that have been redistributed
+ * The Default Pool holds the collateral and debt (but not mUSD tokens) from liquidations that have been redistributed
  * to active troves but not yet "applied", i.e. not yet recorded on a recipient active trove's struct.
  *
- * When a trove makes an operation that applies its pending collateral and mUSD debt, its pending collateral and mUSD debt is moved
+ * When a trove makes an operation that applies its pending collateral and debt, its pending collateral and debt is moved
  * from the Default Pool to the Active Pool.
  */
 contract DefaultPool is Ownable, CheckContract, SendCollateral, IDefaultPool {
@@ -70,24 +70,24 @@ contract DefaultPool is Ownable, CheckContract, SendCollateral, IDefaultPool {
         renounceOwnership();
     }
 
-    function increaseMUSDDebt(
+    function increaseDebt(
         uint256 _principal,
         uint256 _interest
     ) external override {
         _requireCallerIsTroveManager();
         principal += _principal;
         interest += _interest;
-        emit DefaultPoolMUSDDebtUpdated(principal, interest);
+        emit DefaultPoolDebtUpdated(principal, interest);
     }
 
-    function decreaseMUSDDebt(
+    function decreaseDebt(
         uint256 _principal,
         uint256 _interest
     ) external override {
         _requireCallerIsTroveManager();
         principal -= _principal;
         interest -= _interest;
-        emit DefaultPoolMUSDDebtUpdated(principal, interest);
+        emit DefaultPoolDebtUpdated(principal, interest);
     }
 
     function sendCollateralToActivePool(uint256 _amount) external override {
@@ -104,7 +104,7 @@ contract DefaultPool is Ownable, CheckContract, SendCollateral, IDefaultPool {
         return collateral;
     }
 
-    function getMUSDDebt() external view override returns (uint) {
+    function getDebt() external view override returns (uint) {
         return principal + interest;
     }
 

--- a/solidity/contracts/HintHelpers.sol
+++ b/solidity/contracts/HintHelpers.sol
@@ -43,15 +43,15 @@ contract HintHelpers is LiquityBase, Ownable, CheckContract {
 
     /* getRedemptionHints() - Helper function for finding the right hints to pass to redeemCollateral().
      *
-     * It simulates a redemption of `_MUSDAmount` to figure out where the redemption sequence will start and what state the final Trove
+     * It simulates a redemption of `_amount` to figure out where the redemption sequence will start and what state the final Trove
      * of the sequence will end up in.
      *
      * Returns three hints:
      *  - `firstRedemptionHint` is the address of the first Trove with ICR >= MCR (i.e. the first Trove that will be redeemed).
      *  - `partialRedemptionHintNICR` is the final nominal ICR of the last Trove of the sequence after being hit by partial redemption,
      *     or zero in case of no partial redemption.
-     *  - `truncatedMUSDamount` is the maximum amount that can be redeemed out of the the provided `_MUSDAmount`. This can be lower than
-     *    `_MUSDAmount` when redeeming the full amount would leave the last Trove of the redemption sequence with less net debt than the
+     *  - `truncatedAmount` is the maximum amount that can be redeemed out of the the provided `_amount`. This can be lower than
+     *    `_amount` when redeeming the full amount would leave the last Trove of the redemption sequence with less net debt than the
      *    minimum allowed value (i.e. MIN_NET_DEBT).
      *
      * The number of Troves to consider for redemption can be capped by passing a non-zero value as `_maxIterations`, while passing zero
@@ -59,7 +59,7 @@ contract HintHelpers is LiquityBase, Ownable, CheckContract {
      */
 
     function getRedemptionHints(
-        uint256 _MUSDAmount,
+        uint256 _amount,
         uint256 _price,
         uint256 _maxIterations
     )
@@ -68,12 +68,12 @@ contract HintHelpers is LiquityBase, Ownable, CheckContract {
         returns (
             address firstRedemptionHint,
             uint256 partialRedemptionHintNICR,
-            uint256 truncatedMUSDamount
+            uint256 truncatedAmount
         )
     {
         ISortedTroves sortedTrovesCached = sortedTroves;
 
-        uint256 remainingMUSD = _MUSDAmount;
+        uint256 remainingMUSD = _amount;
         address currentTroveuser = sortedTrovesCached.getLast();
 
         // slither-disable-start calls-loop
@@ -96,27 +96,24 @@ contract HintHelpers is LiquityBase, Ownable, CheckContract {
             _maxIterations > 0
         ) {
             _maxIterations--;
-            uint256 netMUSDDebt = _getNetDebt(
+            uint256 netDebt = _getNetDebt(
                 troveManager.getTroveDebt(currentTroveuser)
-            ) + troveManager.getPendingMUSDDebtReward(currentTroveuser);
+            ) + troveManager.getPendingDebt(currentTroveuser);
 
-            if (netMUSDDebt > remainingMUSD) {
-                if (netMUSDDebt > MIN_NET_DEBT) {
+            if (netDebt > remainingMUSD) {
+                if (netDebt > MIN_NET_DEBT) {
                     uint256 maxRedeemableMUSD = LiquityMath._min(
                         remainingMUSD,
-                        netMUSDDebt - MIN_NET_DEBT
+                        netDebt - MIN_NET_DEBT
                     );
 
                     uint256 collateral = troveManager.getTroveColl(
                         currentTroveuser
-                    ) +
-                        troveManager.getPendingCollateralReward(
-                            currentTroveuser
-                        );
+                    ) + troveManager.getPendingCollateral(currentTroveuser);
 
                     uint256 newColl = collateral -
                         ((maxRedeemableMUSD * DECIMAL_PRECISION) / _price);
-                    uint256 newDebt = netMUSDDebt - maxRedeemableMUSD;
+                    uint256 newDebt = netDebt - maxRedeemableMUSD;
 
                     uint256 compositeDebt = _getCompositeDebt(newDebt);
                     partialRedemptionHintNICR = LiquityMath._computeNominalCR(
@@ -128,14 +125,14 @@ contract HintHelpers is LiquityBase, Ownable, CheckContract {
                 }
                 break;
             } else {
-                remainingMUSD -= netMUSDDebt;
+                remainingMUSD -= netDebt;
             }
 
             currentTroveuser = sortedTrovesCached.getPrev(currentTroveuser);
         }
         // slither-disable-end calls-loop
 
-        truncatedMUSDamount = _MUSDAmount - remainingMUSD;
+        truncatedAmount = _amount - remainingMUSD;
     }
 
     /* getApproxHint() - return address of a Trove that is, on average, (length / numTrials) positions away in the

--- a/solidity/contracts/PCV.sol
+++ b/solidity/contracts/PCV.sol
@@ -121,7 +121,7 @@ contract PCV is IPCV, Ownable, CheckContract, SendCollateral {
 
     function withdrawMUSD(
         address _recipient,
-        uint256 _musdAmount
+        uint256 _amount
     )
         external
         override
@@ -130,15 +130,12 @@ contract PCV is IPCV, Ownable, CheckContract, SendCollateral {
         onlyWhitelistedRecipient(_recipient)
     {
         require(
-            _musdAmount <= musd.balanceOf(address(this)),
+            _amount <= musd.balanceOf(address(this)),
             "PCV: not enough tokens"
         );
-        require(
-            musd.transfer(_recipient, _musdAmount),
-            "PCV: sending mUSD failed"
-        );
+        require(musd.transfer(_recipient, _amount), "PCV: sending mUSD failed");
         // slither-disable-next-line reentrancy-events
-        emit MUSDWithdraw(_recipient, _musdAmount);
+        emit MUSDWithdraw(_recipient, _amount);
     }
 
     function withdrawCollateral(
@@ -247,21 +244,18 @@ contract PCV is IPCV, Ownable, CheckContract, SendCollateral {
     }
 
     function depositToStabilityPool(
-        uint256 _musdAmount
+        uint256 _amount
     ) public onlyOwnerOrCouncilOrTreasury {
         require(
-            _musdAmount <= musd.balanceOf(address(this)),
+            _amount <= musd.balanceOf(address(this)),
             "PCV: not enough tokens"
         );
         require(
-            musd.approve(
-                borrowerOperations.stabilityPoolAddress(),
-                _musdAmount
-            ),
+            musd.approve(borrowerOperations.stabilityPoolAddress(), _amount),
             "PCV: Approval failed"
         );
         IStabilityPool(borrowerOperations.stabilityPoolAddress()).provideToSP(
-            _musdAmount
+            _amount
         );
 
         // TODO Emit event

--- a/solidity/contracts/dependencies/LiquityBase.sol
+++ b/solidity/contracts/dependencies/LiquityBase.sol
@@ -61,8 +61,8 @@ abstract contract LiquityBase is BaseMath, ILiquityBase {
         view
         returns (uint256 entireSystemDebt)
     {
-        uint256 activeDebt = activePool.getMUSDDebt();
-        uint256 closedDebt = defaultPool.getMUSDDebt();
+        uint256 activeDebt = activePool.getDebt();
+        uint256 closedDebt = defaultPool.getDebt();
 
         return activeDebt + closedDebt;
     }

--- a/solidity/contracts/interfaces/IActivePool.sol
+++ b/solidity/contracts/interfaces/IActivePool.sol
@@ -10,7 +10,7 @@ interface IActivePool is IPool {
         address _newBorrowerOperationsAddress
     );
     event TroveManagerAddressChanged(address _newTroveManagerAddress);
-    event ActivePoolMUSDDebtUpdated(uint256 _principal, uint256 _interest);
+    event ActivePoolDebtUpdated(uint256 _principal, uint256 _interest);
     event ActivePoolCollateralBalanceUpdated(uint256 _collateral);
     event CollateralAddressChanged(address _newCollateralAddress);
     event CollSurplusPoolAddressChanged(address _newCollSurplusPoolAddress);

--- a/solidity/contracts/interfaces/IBorrowerOperations.sol
+++ b/solidity/contracts/interfaces/IBorrowerOperations.sol
@@ -27,7 +27,7 @@ interface IBorrowerOperations {
         uint256 stake,
         uint8 operation
     );
-    event MUSDBorrowingFeePaid(address indexed _borrower, uint256 _MUSDFee);
+    event BorrowingFeePaid(address indexed _borrower, uint256 _fee);
 
     // --- Functions ---
 

--- a/solidity/contracts/interfaces/IDefaultPool.sol
+++ b/solidity/contracts/interfaces/IDefaultPool.sol
@@ -7,7 +7,7 @@ import "./IPool.sol";
 interface IDefaultPool is IPool {
     // --- Events ---
     event TroveManagerAddressChanged(address _newTroveManagerAddress);
-    event DefaultPoolMUSDDebtUpdated(uint256 _principal, uint256 _interest);
+    event DefaultPoolDebtUpdated(uint256 _principal, uint256 _interest);
     event DefaultPoolCollateralBalanceUpdated(uint256 _collateral);
     event CollateralAddressChanged(address _newCollateralAddress);
 

--- a/solidity/contracts/interfaces/IPCV.sol
+++ b/solidity/contracts/interfaces/IPCV.sol
@@ -11,7 +11,7 @@ interface IPCV {
     event BorrowerOperationsAddressSet(address _borrowerOperationsAddress);
     event CollateralAddressSet(address _collateralAddress);
     event RolesSet(address _council, address _treasury);
-    event MUSDWithdraw(address _recipient, uint256 _musdAmount);
+    event MUSDWithdraw(address _recipient, uint256 _amount);
     event CollateralWithdraw(address _recipient, uint256 _collateralAmount);
     event PCVDebtPaid(uint256 _paidDebt);
     event RecipientAdded(address _recipient);
@@ -31,7 +31,7 @@ interface IPCV {
 
     function initialize() external;
 
-    function withdrawMUSD(address _recipient, uint256 _musdAmount) external;
+    function withdrawMUSD(address _recipient, uint256 _amount) external;
 
     function withdrawCollateral(
         address _recipient,

--- a/solidity/contracts/interfaces/IPool.sol
+++ b/solidity/contracts/interfaces/IPool.sol
@@ -14,13 +14,13 @@ interface IPool {
 
     // --- Functions ---
 
-    function increaseMUSDDebt(uint256 _principal, uint256 _interest) external;
+    function increaseDebt(uint256 _principal, uint256 _interest) external;
 
-    function decreaseMUSDDebt(uint256 _principal, uint256 _interest) external;
+    function decreaseDebt(uint256 _principal, uint256 _interest) external;
 
     function getCollateralBalance() external view returns (uint);
 
-    function getMUSDDebt() external view returns (uint);
+    function getDebt() external view returns (uint);
 
     function getPrincipal() external view returns (uint);
 

--- a/solidity/contracts/interfaces/IStabilityPool.sol
+++ b/solidity/contracts/interfaces/IStabilityPool.sol
@@ -5,11 +5,11 @@ pragma solidity ^0.8.24;
 /*
  * The Stability Pool holds mUSD tokens deposited by Stability Pool depositors.
  *
- * When a trove is liquidated, then depending on system conditions, some of its mUSD debt gets offset with
- * mUSD in the Stability Pool:  that is, the offset debt evaporates, and an equal amount of mUSD tokens in the Stability Pool is burned.
+ * When a trove is liquidated, then depending on system conditions, some of its debt gets offset with
+ * mUSD in the Stability Pool: that is, the offset debt evaporates, and an equal amount of mUSD tokens in the Stability Pool are burned.
  *
- * Thus, a liquidation causes each depositor to receive a mUSD loss, in proportion to their deposit as a share of total deposits.
- * They also receive an collateral gain, as the collateral of the liquidated trove is distributed among Stability depositors,
+ * Thus, a liquidation causes each depositor to receive a mUSD loss in proportion to their deposit as a share of total deposits.
+ * They also receive an collateral gain, as the collateral of the liquidated trove is distributed among Stability depositors
  * in the same proportion.
  *
  * When a liquidation occurs, it depletes every deposit by the same fraction: for example, a liquidation that depletes 40%

--- a/solidity/contracts/interfaces/ITroveManager.sol
+++ b/solidity/contracts/interfaces/ITroveManager.sol
@@ -40,11 +40,11 @@ interface ITroveManager {
         uint256 _liquidatedInterest,
         uint256 _liquidatedColl,
         uint256 _collGasCompensation,
-        uint256 _MUSDGasCompensation
+        uint256 _gasCompensation
     );
     event Redemption(
-        uint256 _attemptedMUSDAmount,
-        uint256 _actualMUSDAmount,
+        uint256 _attemptedAmount,
+        uint256 _actualAmount,
         uint256 _collateralSent,
         uint256 _collateralFee
     );
@@ -69,8 +69,8 @@ interface ITroveManager {
         uint256 _totalStakesSnapshot,
         uint256 _totalCollateralSnapshot
     );
-    event LTermsUpdated(uint256 _L_Collateral, uint256 _L_mUSDDebt);
-    event TroveSnapshotsUpdated(uint256 _L_Collateral, uint256 _L_mUSDDebt);
+    event LTermsUpdated(uint256 _L_Collateral, uint256 _L_Debt);
+    event TroveSnapshotsUpdated(uint256 _L_Collateral, uint256 _L_Debt);
     event TroveIndexUpdated(address _borrower, uint256 _newIndex);
     event InterestRateProposed(uint256 _proposedRate, uint256 _proposalTime);
     event InterestRateUpdated(uint256 _newInterestRate);
@@ -98,7 +98,7 @@ interface ITroveManager {
     function batchLiquidateTroves(address[] calldata _troveArray) external;
 
     function redeemCollateral(
-        uint256 _MUSDAmount,
+        uint256 _amount,
         address _firstRedemptionHint,
         address _upperPartialRedemptionHint,
         address _lowerPartialRedemptionHint,
@@ -192,13 +192,11 @@ interface ITroveManager {
         uint256 _price
     ) external view returns (uint);
 
-    function getPendingCollateralReward(
+    function getPendingCollateral(
         address _borrower
     ) external view returns (uint);
 
-    function getPendingMUSDDebtReward(
-        address _borrower
-    ) external view returns (uint);
+    function getPendingDebt(address _borrower) external view returns (uint);
 
     function hasPendingRewards(address _borrower) external view returns (bool);
 
@@ -211,8 +209,8 @@ interface ITroveManager {
             uint256 debt,
             uint256 interest,
             uint256 coll,
-            uint256 pendingMUSDDebtReward,
-            uint256 pendingCollateralReward
+            uint256 pendingDebt,
+            uint256 pendingCollateral
         );
 
     function getRedemptionRate() external view returns (uint);
@@ -227,10 +225,10 @@ interface ITroveManager {
 
     function getBorrowingRateWithDecay() external view returns (uint);
 
-    function getBorrowingFee(uint256 _mUSDDebt) external view returns (uint);
+    function getBorrowingFee(uint256 _debt) external view returns (uint);
 
     function getBorrowingFeeWithDecay(
-        uint256 _mUSDDebt
+        uint256 _debt
     ) external view returns (uint);
 
     function getTroveStatus(address _borrower) external view returns (Status);

--- a/solidity/contracts/token/IMUSD.sol
+++ b/solidity/contracts/token/IMUSD.sol
@@ -8,7 +8,7 @@ import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Permit.sol";
 interface IMUSD is IERC20Metadata, IERC20Permit {
     // --- Events ---
     event BorrowerOperationsAddressAdded(address _newBorrowerOperationsAddress);
-    event MUSDBalanceUpdated(address _user, uint256 _amount);
+    event BalanceUpdated(address _user, uint256 _amount);
     event StabilityPoolAddressAdded(address _newStabilityPoolAddress);
     event TroveManagerAddressAdded(address _troveManagerAddress);
 

--- a/solidity/test/helpers/abi.ts
+++ b/solidity/test/helpers/abi.ts
@@ -5,3 +5,7 @@ export const TROVE_UPDATED_ABI = [
 export const LIQUIDATION_ABI = [
   "event Liquidation(uint256 _liquidatedPrincipal, uint256 _liquidatedInterest, uint256 _liquidatedColl, uint256 _collGasCompensation, uint256 _MUSDGasCompensation)",
 ]
+
+export const BORROWING_FEE_PAID = [
+  "event BorrowingFeePaid(address indexed _borrower, uint256 _MUSDFee)",
+]

--- a/solidity/test/helpers/functions.ts
+++ b/solidity/test/helpers/functions.ts
@@ -141,7 +141,7 @@ export async function updateContractsSnapshot(
   state[pool].btc[checkPoint] = await ethers.provider.getBalance(
     addresses[pool],
   )
-  state[pool].debt[checkPoint] = await contracts[pool].getMUSDDebt()
+  state[pool].debt[checkPoint] = await contracts[pool].getDebt()
   state[pool].principal[checkPoint] = await contracts[pool].getPrincipal()
   state[pool].interest[checkPoint] = await contracts[pool].getInterest()
 }
@@ -185,12 +185,10 @@ export async function updatePendingSnapshot(
   user: User,
   checkPoint: CheckPoint,
 ) {
-  const collateral = await contracts.troveManager.getPendingCollateralReward(
+  const collateral = await contracts.troveManager.getPendingCollateral(
     user.address,
   )
-  const debt = await contracts.troveManager.getPendingMUSDDebtReward(
-    user.address,
-  )
+  const debt = await contracts.troveManager.getPendingDebt(user.address)
   user.pending.collateral[checkPoint] = collateral
   user.pending.debt[checkPoint] = debt
 }

--- a/solidity/test/normal/AccessControl.test.ts
+++ b/solidity/test/normal/AccessControl.test.ts
@@ -182,17 +182,17 @@ describe("Access Control: Liquity functions with the caller restricted to Liquit
       )
     })
 
-    it("increaseMUSDDebt(): reverts when called by an account that is not BO nor TroveM", async () => {
+    it("increaseDebt(): reverts when called by an account that is not BO nor TroveM", async () => {
       await expect(
-        contracts.activePool.connect(alice.wallet).increaseMUSDDebt(100n, 0n),
+        contracts.activePool.connect(alice.wallet).increaseDebt(100n, 0n),
       ).to.be.revertedWith(
         "ActivePool: Caller is neither BorrowerOperations nor TroveManager",
       )
     })
 
-    it("decreaseMUSDDebt(): reverts when called by an account that is not BO nor TroveM nor SP", async () => {
+    it("decreaseDebt(): reverts when called by an account that is not BO nor TroveM nor SP", async () => {
       await expect(
-        contracts.activePool.connect(alice.wallet).decreaseMUSDDebt(100n, 0n),
+        contracts.activePool.connect(alice.wallet).decreaseDebt(100n, 0n),
       ).to.be.revertedWith(
         "ActivePool: Caller is neither BorrowerOperations nor TroveManager nor StabilityPool",
       )
@@ -227,15 +227,15 @@ describe("Access Control: Liquity functions with the caller restricted to Liquit
       ).to.be.revertedWith("DefaultPool: Caller is not the TroveManager")
     })
 
-    it("increaseMUSDDebt(): reverts when called by an account that is not TroveManager", async () => {
+    it("increaseDebt(): reverts when called by an account that is not TroveManager", async () => {
       await expect(
-        contracts.defaultPool.connect(alice.wallet).increaseMUSDDebt(100n, 0n),
+        contracts.defaultPool.connect(alice.wallet).increaseDebt(100n, 0n),
       ).to.be.revertedWith("DefaultPool: Caller is not the TroveManager")
     })
 
-    it("decreaseMUSDDebt(): reverts when called by an account that is not TroveManager", async () => {
+    it("decreaseDebt(): reverts when called by an account that is not TroveManager", async () => {
       await expect(
-        contracts.defaultPool.connect(alice.wallet).decreaseMUSDDebt(100n, 0n),
+        contracts.defaultPool.connect(alice.wallet).decreaseDebt(100n, 0n),
       ).to.be.revertedWith("DefaultPool: Caller is not the TroveManager")
     })
 

--- a/solidity/test/normal/ActivePool.test.ts
+++ b/solidity/test/normal/ActivePool.test.ts
@@ -37,13 +37,13 @@ describe("ActivePool", () => {
     })
   })
 
-  describe("getMUSDDebt()", () => {
+  describe("getDebt()", () => {
     it("gets the recorded mUSD balance", async () => {
-      expect(await contracts.activePool.getMUSDDebt()).to.equal(0)
+      expect(await contracts.activePool.getDebt()).to.equal(0)
     })
   })
 
-  describe("increaseMUSDDebt()", () => {
+  describe("increaseDebt()", () => {
     it("increases the recorded mUSD balance by the correct amount", async () => {
       await updateContractsSnapshot(
         contracts,
@@ -56,7 +56,7 @@ describe("ActivePool", () => {
 
       await contracts.activePool
         .connect(borrowerOperationsSigner)
-        .increaseMUSDDebt(amount, 0n, NO_GAS)
+        .increaseDebt(amount, 0n, NO_GAS)
 
       await updateContractsSnapshot(
         contracts,
@@ -72,13 +72,13 @@ describe("ActivePool", () => {
     })
   })
 
-  describe("decreaseMUSDDebt()", () => {
+  describe("decreaseDebt()", () => {
     it("decreases the recorded mUSD balance by the correct amount", async () => {
       const initialAmount = to1e18("100")
 
       await contracts.activePool
         .connect(borrowerOperationsSigner)
-        .increaseMUSDDebt(initialAmount, 0n, NO_GAS)
+        .increaseDebt(initialAmount, 0n, NO_GAS)
 
       await updateContractsSnapshot(
         contracts,
@@ -92,7 +92,7 @@ describe("ActivePool", () => {
 
       await contracts.activePool
         .connect(borrowerOperationsSigner)
-        .decreaseMUSDDebt(subtractedAmount, 0n, NO_GAS)
+        .decreaseDebt(subtractedAmount, 0n, NO_GAS)
 
       await updateContractsSnapshot(
         contracts,

--- a/solidity/test/normal/DefaultPool.test.ts
+++ b/solidity/test/normal/DefaultPool.test.ts
@@ -54,13 +54,13 @@ describe("DefaultPool", () => {
     })
   })
 
-  describe("getMUSDDebt()", () => {
+  describe("getDebt()", () => {
     it("gets the recorded mUSD balance", async () => {
-      expect(await contracts.defaultPool.getMUSDDebt()).to.equal(0)
+      expect(await contracts.defaultPool.getDebt()).to.equal(0)
     })
   })
 
-  context("increaseMUSDDebt()", () => {
+  context("increaseDebt()", () => {
     it("increases the recorded mUSD balance by the correct amount", async () => {
       await updateContractsSnapshot(
         contracts,
@@ -73,7 +73,7 @@ describe("DefaultPool", () => {
 
       await contracts.defaultPool
         .connect(troveManagerSigner)
-        .increaseMUSDDebt(amount, 0n, NO_GAS)
+        .increaseDebt(amount, 0n, NO_GAS)
 
       await updateContractsSnapshot(
         contracts,
@@ -89,17 +89,17 @@ describe("DefaultPool", () => {
     })
   })
 
-  describe("decreaseMUSDDebt()", () => {
+  describe("decreaseDebt()", () => {
     it("decreases the recorded mUSD balance by the correct amount", async () => {
       const originalAmount = to1e18("200")
       await contracts.defaultPool
         .connect(troveManagerSigner)
-        .increaseMUSDDebt(originalAmount, 0n, NO_GAS)
+        .increaseDebt(originalAmount, 0n, NO_GAS)
 
       const subtractedAmount = to1e18("50")
       await contracts.defaultPool
         .connect(troveManagerSigner)
-        .decreaseMUSDDebt(subtractedAmount, 0n, NO_GAS)
+        .decreaseDebt(subtractedAmount, 0n, NO_GAS)
 
       await updateContractsSnapshot(
         contracts,

--- a/solidity/test/normal/TroveManager.test.ts
+++ b/solidity/test/normal/TroveManager.test.ts
@@ -746,7 +746,7 @@ describe("TroveManager in Normal Mode", () => {
       )
     })
 
-    it("updates the L_Collateral and L_MUSDDebt reward-per-unit-staked totals", async () => {
+    it("updates the L_Collateral and L_Debt reward-per-unit-staked totals", async () => {
       await setupTroves()
       await openTrove(contracts, {
         musdAmount: "5000",
@@ -779,7 +779,7 @@ describe("TroveManager in Normal Mode", () => {
 
       const expectedLMUSDDebtAfterCarolLiquidated =
         to1e18(carol.trove.debt.before) / remainingColl
-      expect(await contracts.troveManager.L_MUSDDebt()).to.equal(
+      expect(await contracts.troveManager.L_Debt()).to.equal(
         expectedLMUSDDebtAfterCarolLiquidated,
       )
 
@@ -833,7 +833,7 @@ describe("TroveManager in Normal Mode", () => {
           bob.trove.collateral.before
 
       const tolerance = 100n
-      expect(await contracts.troveManager.L_MUSDDebt()).to.be.closeTo(
+      expect(await contracts.troveManager.L_Debt()).to.be.closeTo(
         expectedLMUSDDebtAfterAliceLiquidated,
         tolerance,
       )
@@ -2549,7 +2549,7 @@ describe("TroveManager in Normal Mode", () => {
           sender: dennis.wallet,
         })
         const totalDebt = carolTotalDebt + dennisTotalDebt
-        expect(await contracts.activePool.getMUSDDebt()).to.equal(totalDebt)
+        expect(await contracts.activePool.getDebt()).to.equal(totalDebt)
 
         const price = await contracts.priceFeed.fetchPrice()
         const { firstRedemptionHint, partialRedemptionHintNICR } =

--- a/solidity/test/recovery/BorrowerOperations.test.ts
+++ b/solidity/test/recovery/BorrowerOperations.test.ts
@@ -1,6 +1,7 @@
 import { expect } from "chai"
 
 import {
+  BORROWING_FEE_PAID,
   Contracts,
   ContractsState,
   TestingAddresses,
@@ -108,7 +109,7 @@ describe("BorrowerOperations in Recovery Mode", () => {
       and L_MUSD should equal 18 mUSD per-ether-staked/per-tokens-staked. */
 
       const liquidatedCollateral = await contracts.troveManager.L_Collateral()
-      const liquidatedDebt = await contracts.troveManager.L_MUSDDebt()
+      const liquidatedDebt = await contracts.troveManager.L_Debt()
 
       expect(liquidatedCollateral).is.greaterThan(0n)
       expect(liquidatedDebt).is.greaterThan(0n)
@@ -186,7 +187,7 @@ describe("BorrowerOperations in Recovery Mode", () => {
       state.troveManager.liquidation.collateral.before =
         await contracts.troveManager.L_Collateral()
       state.troveManager.liquidation.debt.before =
-        await contracts.troveManager.L_MUSDDebt()
+        await contracts.troveManager.L_Debt()
 
       await updateTroveSnapshot(contracts, bob, "before")
       await updateTroveSnapshot(contracts, carol, "before")
@@ -514,10 +515,6 @@ describe("BorrowerOperations in Recovery Mode", () => {
       const maxFeePercentage = to1e18(1)
       const collChange = to1e18("20")
       const debtChange = to1e18("2,000")
-      const abi = [
-        // Add your contract ABI here
-        "event MUSDBorrowingFeePaid(address indexed _borrower, uint256 _MUSDFee)",
-      ]
 
       await setupCarolsTrove()
 
@@ -540,8 +537,8 @@ describe("BorrowerOperations in Recovery Mode", () => {
 
       const emittedFee = await getEventArgByName(
         tx,
-        abi,
-        "MUSDBorrowingFeePaid",
+        BORROWING_FEE_PAID,
+        "BorrowingFeePaid",
         1,
       )
       expect(emittedFee).to.be.equal(0)


### PR DESCRIPTION
This PR is a broad cleaning pass aiming to reduce the verbosity of the codebase by removing a lot of redundant instances of "MUSD".

I was first clued into this by repetitions of `MUSDDebt`, which is simpler as `debt`.

Broadly we:

- Remove `MUSD` anywhere where the quantity is unambiguously MUSD (like debt)
- Keep `MUSD` anywhere we want to differentiate MUSD from collateral (like the stability pool)
- lower-case the `m` in `mUSD` when mUSD is the leading word in a compound word (like `_mUSDChange`)

Along the way, we simplify the pending reward verbiage. We'd previously say stuff like `pendingCollateralReward` or `pendingMUSDDebtReward` which I found very confusing. When someone is liquidated without support of the stability pool, their debt and collateral are divided amongst the troves, and marked "pending" for gas efficiency (to avoid loops). The debt is *hardly* a reward, so we simplify the whole concept by just saying that it's "pending".

Tagging @rwatts07 for review