### PR TITLE
Reduce max-states-count and fix solhint-disable annotations

### DIFF
--- a/solidity/.solhint.json
+++ b/solidity/.solhint.json
@@ -2,6 +2,6 @@
   "extends": "thesis",
   "plugins": [],
   "rules": {
-    "max-states-count": ["warn", 30]
+    "max-states-count": ["warn", 25]
   }
 }

--- a/solidity/contracts/TroveManager.sol
+++ b/solidity/contracts/TroveManager.sol
@@ -716,7 +716,7 @@ contract TroveManager is LiquityBase, Ownable, CheckContract, ITroveManager {
         Trove storage trove = Troves[_borrower];
         // slither-disable-start calls-loop
         interestRateManager.updateSystemInterest(trove.interestRate);
-        // solhint-disable-start not-rely-on-time
+        // solhint-disable not-rely-on-time
         trove.interestOwed += interestRateManager.calculateInterestOwed(
             trove.principal,
             trove.interestRate,
@@ -725,7 +725,7 @@ contract TroveManager is LiquityBase, Ownable, CheckContract, ITroveManager {
         );
         trove.lastInterestUpdateTime = block.timestamp;
         // slither-disable-end calls-loop
-        // solhint-disable-end not-rely-on-time
+        // solhint-enable not-rely-on-time
     }
 
     /*


### PR DESCRIPTION
- Reduce `max-states-count` back down to 25 (we're at 22).  For comparison, Liquity v2's TroveManager.sol has 30 state variables.
- Fix solhint annotation (it is slightly different than slither's start/end)

