### PR TITLE
Cleaning up the README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -47,17 +47,17 @@ The three main contracts - `BorrowerOperations.sol`, `TroveManager.sol` and `Sta
 
 `finalizeAddMintList()`: This function adds the minting capability to the borrower operations contract, previously designated in the `pendingAddedMintAddress`. It executes only after the governance delay has elapsed following the `addMintListInitiated` timestamp. By finalizing the revoke mint process it resets the `pendingAddedMintAddress` and `addMintListInitiated`.
 
-`startAddContracts(address _troveManagerAddress, address _stabilityPoolAddress, address _borrowerOperationsAddress)`: This function initiates the process of integrating borrower operations, trove manager, and stability pool contracts, enabling them to mint and burn mUSD tokens. It begins by verifying that the contract addresses provided as parameters are indeed contracts. Once confirmed, it assigns the addresses to `pendingTroveManager`, `pendingStabilityPool`, and `pendingBorrowerOperations` using `_troveManagerAddress`, `_stabilityPoolAddress`, and `_borrowerOperationsAddress`, respectively. Additionally, it records the initiation of adding these contracts by setting `addContractsInitiated` to the current block timestamp when the transaction is executed.
+`startAddContracts(address _troveManagerAddress, address _stabilityPoolAddress, address _borrowerOperationsAddress, address _interestRateManagerAddress)`: This function initiates the process of integrating borrower operations, trove manager, stability pool, and interest rate manager contracts, enabling them to mint and burn mUSD tokens. 
 
-`cancelAddContracts()`: This function terminates the current process of adding contracts. Initially, it checks that `addContractsInitiated` is not zero, which indicates an active process of adding contracts is underway. Upon confirmation, it resets `addContractsInitiated`, `pendingTroveManager`, `pendingStabilityPool`, and `pendingRevokedMintAddress` to 0, `address(0)`, `address(0)`, and `address(0)` respectively. This action effectively concludes the process of adding contracts.
+`cancelAddContracts()`: This function terminates the current process of adding contracts. 
 
-`finalizeAddContracts()`: This function adds the minting and burning capabilities to the borrower operations, trove manager, and stability pool contracts previously designated in the `pendingBorrowerOperations`, `pendingStabilityPool` and `pendingTroveManager`. It executes only after the governance delay has elapsed following the `addContractsInitiated` timestamp. By finalizing the process of adding new contracts, it resets the `pendingBorrowerOperations`, `pendingStabilityPool`,`pendingTroveManager` and `addContractsInitiated`.
+`finalizeAddContracts()`: This function adds the minting and burning capabilities to the borrower operations, trove manager, interest rate manager, and stability pool contracts previously designated in the `pendingBorrowerOperations`, `pendingStabilityPool`, `pendingInterestRateManager`, and `pendingTroveManager`. It executes only after the governance delay has elapsed following the `addContractsInitiated` timestamp. 
 
-`startRevokeBurnList(address _account)`: This function initiates the process of revoking a borrower operations contract's capability to burn mUSD tokens. It first validates that the address provided in `_account` parameter is included in the `burnList`. Once verified, the function initializes the revocation process by updating `revokeBurnListInitiated` with the current block timestamp and `pendingRevokedBurnAddress` with the address passed in `_account` parameter.
+`startRevokeBurnList(address _account)`: This function initiates the process of revoking a contract's capability to burn mUSD tokens. 
 
-`cancelRevokeBurnList()`: It cancels the existing revoking mint process. The function first validates whether the `pendingRevokedBurnAddress` is non-zero to confirm the presence of an ongoing pending revoking process. Once verified, it resets both `revokeBurnListInitiated` and `pendingRevokedBurnAddress` to zero and `address(0)` respectively. Effectively finalizing the existing revoking process.
+`cancelRevokeBurnList()`: Cancels the existing revoking mint process. 
 
-`finalizeRevokeBurnList()`: This function revokes the minting capability to the borrower operations contract, previously designated in the `pendingRevokedBurnAddress`. It executes only after the governance delay has elapsed following the `revokeBurnListInitiated` timestamp. By finalizing the revoke mint process it resets the `pendingRevokedBurnAddress` and `revokeBurnListInitiated`.
+`finalizeRevokeBurnList()`: This function revokes the minting capability from a contract, previously designated in the `pendingRevokedBurnAddress`. It executes only after the governance delay has elapsed following the `revokeBurnListInitiated` timestamp. By finalizing the revoke mint process it resets the `pendingRevokedBurnAddress` and `revokeBurnListInitiated`.
 
 ### TroveManager Functions - `TroveManager.sol`
 
@@ -71,9 +71,9 @@ The three main contracts - `BorrowerOperations.sol`, `TroveManager.sol` and `Sta
 
 `getTroveOwnersCount()`: get the number of active Troves in the system.
 
-`getPendingETHReward(address _borrower)`: get the pending collateral reward from liquidation redistribution events, for the given Trove.
+`getPendingCollateral(address _borrower)`: get the pending collateral from liquidation redistribution events, for the given Trove.
 
-`getPendingMUSDDebtReward(address _borrower)`: get the pending Trove debt "reward" (i.e. the amount of extra debt assigned to the Trove) from liquidation redistribution events.
+`getPendingDebt(address _borrower)`: get the pending Trove debt (i.e. the amount of extra debt assigned to the Trove) from liquidation redistribution events.
 
 `getEntireDebtAndColl(address _borrower)`: returns a Trove’s entire debt and collateral, which respectively include any pending debt rewards and collateral rewards from prior redistributions.
 


### PR DESCRIPTION
Fairly self-explanatory -- first pass to clean up the README, add a few more definitions and remove any out of date information.