### PR TITLE
Remove External Calls from Convenience Methods

### DIFF
--- a/solidity/test/normal/BorrowerOperations.test.ts
+++ b/solidity/test/normal/BorrowerOperations.test.ts
@@ -1205,7 +1205,7 @@ describe("BorrowerOperations in Normal Mode", () => {
               lowerHint,
             ),
         ).to.be.revertedWith(
-          "BorrowerOps: Caller is not BorrowerOperations or BorrowerOperationsSignatures",
+          "BorrowerOps: Caller is not authorized to perform this operation",
         )
       })
     })
@@ -2124,7 +2124,7 @@ describe("BorrowerOperations in Normal Mode", () => {
             .connect(alice.wallet)
             .restrictedCloseTrove(bob.address),
         ).to.be.revertedWith(
-          "BorrowerOps: Caller is not BorrowerOperations or BorrowerOperationsSignatures",
+          "BorrowerOps: Caller is not authorized to perform this operation",
         )
       })
     })
@@ -6443,7 +6443,7 @@ describe("BorrowerOperations in Normal Mode", () => {
               maxFeePercentage,
             ),
         ).to.be.revertedWith(
-          "BorrowerOps: Caller is not BorrowerOperations or BorrowerOperationsSignatures",
+          "BorrowerOps: Caller is not authorized to perform this operation",
         )
       })
     })


### PR DESCRIPTION
## Summary

This PR is a followup from the discussion here: https://github.com/mezo-org/musd/pull/146#discussion_r1956141545

We change the `require` to check the borrower's address directly, ensuring that either a signature has been verified (via BorrowerOperationsSignatures) or that the caller is operating on their own behalf (the case of msg.sender == _borrower).

As a result of this, we can change the previously external calls (`this.functionName`) to internal calls, saving gas costs.

## Testing Notes

The functionality remains the same, so the only test changes were to the revert messages in the existing tests.