### PR TITLE
Resolve the real price oracle on matsnet

### DIFF
--- a/solidity/deploy/88_set_price_feed_oracle.ts
+++ b/solidity/deploy/88_set_price_feed_oracle.ts
@@ -1,15 +1,26 @@
 import { DeployFunction } from "hardhat-deploy/dist/types"
 import { HardhatRuntimeEnvironment } from "hardhat/types"
 import {
+  EXTERNAL_ADDRESSES,
   fetchAllDeployedContracts,
   setupDeploymentBoilerplate,
 } from "../helpers/deploy-helpers"
 
 const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
-  const { execute, isHardhatNetwork } = await setupDeploymentBoilerplate(hre)
-  const { mockAggregator } = await fetchAllDeployedContracts(isHardhatNetwork)
+  const { execute, isHardhatNetwork, network } =
+    await setupDeploymentBoilerplate(hre)
 
-  await execute("PriceFeed", "setOracle", await mockAggregator.getAddress())
+  let aggregatorAddress
+  if (isHardhatNetwork) {
+    const { mockAggregator } = await fetchAllDeployedContracts(isHardhatNetwork)
+    aggregatorAddress = await mockAggregator.getAddress()
+  } else if (network.name in EXTERNAL_ADDRESSES) {
+    aggregatorAddress = EXTERNAL_ADDRESSES[network.name].PriceOracleCaller
+  } else {
+    throw Error(`${network.name} does not have a PriceOracleCaller set`)
+  }
+
+  await execute("PriceFeed", "setOracle", aggregatorAddress)
 }
 
 export default func

--- a/solidity/hardhat.config.ts
+++ b/solidity/hardhat.config.ts
@@ -8,19 +8,20 @@ import "hardhat-contract-sizer"
 import "hardhat-gas-reporter"
 import dotenv from "dotenv-safer"
 
-const MATSNET_PRIVATE_KEY = process.env.MATSNET_PRIVATE_KEY
-  ? [process.env.MATSNET_PRIVATE_KEY]
-  : []
-
 dotenv.config({
   allowEmptyValues: true,
   example: process.env.CI ? ".env.ci.example" : ".env.example",
 })
 
+const MATSNET_PRIVATE_KEY = process.env.MATSNET_PRIVATE_KEY
+  ? [process.env.MATSNET_PRIVATE_KEY]
+  : []
+
 const config: HardhatUserConfig = {
   solidity: {
     version: "0.8.24",
     settings: {
+      evmVersion: "london",
       optimizer: {
         enabled: true,
         runs: 100,

--- a/solidity/helpers/deploy-helpers.ts
+++ b/solidity/helpers/deploy-helpers.ts
@@ -30,6 +30,18 @@ function waitConfirmationsNumber(networkName: string): number {
   }
 }
 
+type ExternalAddresses = {
+  [networkName: string]: {
+    PriceOracleCaller: string
+  }
+}
+
+export const EXTERNAL_ADDRESSES: ExternalAddresses = {
+  matsnet: {
+    PriceOracleCaller: "0x7b7c000000000000000000000000000000000015",
+  },
+}
+
 export default async function waitForTransaction(
   hre: HardhatRuntimeEnvironment,
   txHash: string,


### PR DESCRIPTION
This PR lightly modifies our deploy script to resolve a supplied price oracle.

We're currently unable to test it due to a quirk with how openzeppelin's deploy proxy code interacts with mezo's format for `getVersion`:

https://discord.com/channels/1079490158639976609/1346158663013896314/1346176896873926840

```
const [name] = clientVersion.split('/', 1);
```
is expecting a string like
```
HardhatNetwork/2.22.10/@nomicfoundation/edr/0.3.5
```
but is getting one like
```
{
  app_version: '0.6.0-rc0',
  build_date: '2025-02-10T16:09:37Z',
  commit: '34fedb2080c56d2a5b14a9147de68ba9c38627c5-modified',
  go: 'go1.22.8',
  go_arch: 'amd64'
}
```

After this gets fixed, I'll take it out of draft mode and give it a whirl