### PR TITLE
Remove Unnecessary Check on Composite Debt

### DIFF
--- a/solidity/contracts/BorrowerOperations.sol
+++ b/solidity/contracts/BorrowerOperations.sol
@@ -474,7 +474,6 @@ contract BorrowerOperations is
 
         // ICR is based on the composite debt, i.e. the requested amount + borrowing fee + gas comp.
         vars.compositeDebt = getCompositeDebt(vars.netDebt);
-        assert(vars.compositeDebt > 0);
 
         // if BTC overwrite the asset value
         vars.ICR = LiquityMath._computeCR(


### PR DESCRIPTION
`compositeDebt` is `netDebt + gasComp`, and `gasComp` is non-zero, so the sum will also be non-zero.

Additionally, we call `_requireAtLeastMinNetDebt(netDebt)` a few lines above.

addresses https://cantina.xyz/code/47e5f647-36ea-4de3-bc70-0ef3ef10ee25/comments#comment-a680e42e-dd49-4757-97a9-d17be5ada711

Tagging @rwatts07 for review