### PR TITLE
Lower Borrowing Limit on Collateral Withdrawal

### DIFF
--- a/solidity/contracts/BorrowerOperations.sol
+++ b/solidity/contracts/BorrowerOperations.sol
@@ -839,9 +839,9 @@ contract BorrowerOperations is
                 vars.price
             );
 
-            uint256 currentMaxBorrowingCapacity = contractsCache.troveManager.getTroveMaxBorrowingCapacity(
-                _borrower
-            );
+            uint256 currentMaxBorrowingCapacity = contractsCache
+                .troveManager
+                .getTroveMaxBorrowingCapacity(_borrower);
 
             uint256 finalMaxBorrowingCapacity = LiquityMath._min(
                 currentMaxBorrowingCapacity,

--- a/solidity/test/normal/BorrowerOperations.test.ts
+++ b/solidity/test/normal/BorrowerOperations.test.ts
@@ -3872,6 +3872,30 @@ describe("BorrowerOperations in Normal Mode", () => {
       )
     })
 
+    it("decreases maxBorrowingCapacity on collateral withdrawal if price has fallen", async () => {
+      await setupCarolsTrove()
+      await updateTroveSnapshot(contracts, carol, "before")
+
+      const price = await dropPrice(contracts, deployer, carol, to1e18("290"))
+
+      const collWithdrawal = 1n
+      await contracts.borrowerOperations
+        .connect(carol.wallet)
+        .adjustTrove(collWithdrawal, 0, false, carol.wallet, carol.wallet)
+
+      await updateTroveSnapshot(contracts, carol, "after")
+
+      const expectedMaxBorrowingCapacity =
+        (carol.trove.collateral.after * price) / to1e18("1.1")
+
+      expect(carol.trove.maxBorrowingCapacity.after).to.be.lessThan(
+        carol.trove.maxBorrowingCapacity.before,
+      )
+      expect(carol.trove.maxBorrowingCapacity.after).to.be.equal(
+        expectedMaxBorrowingCapacity,
+      )
+    })
+
     it("Borrowing at zero base rate sends total requested mUSD to the user", async () => {
       const amount = to1e18(37)
 


### PR DESCRIPTION
Previously, it was possible to abuse borrowing capacity by opening a trove with a large amount of collateral to get a high borrowing limit and then withdrawing it.  Now we recalculate maxBorrowingCapacity on collateral withdrawal using by taking the minimum of the current value and what the value would be based on the current price.  This means that on a price increase, borrowing capacity will not increase on a withdrawal.  