### PR TITLE
Remove Hint Signing

### DIFF
--- a/solidity/contracts/BorrowerOperationsSignatures.sol
+++ b/solidity/contracts/BorrowerOperationsSignatures.sol
@@ -92,32 +92,32 @@ contract BorrowerOperationsSignatures is
 
     bytes32 private constant OPEN_TROVE_TYPEHASH =
         keccak256(
-            "OpenTrove(uint256 debtAmount,address upperHint,address lowerHint,address borrower,address recipient,uint256 nonce,uint256 deadline)"
+            "OpenTrove(uint256 debtAmount,address borrower,address recipient,uint256 nonce,uint256 deadline)"
         );
 
     bytes32 private constant ADD_COLL_TYPEHASH =
         keccak256(
-            "AddColl(uint256 assetAmount,address upperHint,address lowerHint,address borrower,uint256 nonce,uint256 deadline)"
+            "AddColl(uint256 assetAmount,address borrower,uint256 nonce,uint256 deadline)"
         );
 
     bytes32 private constant WITHDRAW_COLL_TYPEHASH =
         keccak256(
-            "WithdrawColl(uint256 amount,address upperHint,address lowerHint,address borrower,address recipient,uint256 nonce,uint256 deadline)"
+            "WithdrawColl(uint256 amount,address borrower,address recipient,uint256 nonce,uint256 deadline)"
         );
 
     bytes32 private constant REPAY_MUSD_TYPEHASH =
         keccak256(
-            "RepayMUSD(uint256 amount,address upperHint,address lowerHint,address borrower,uint256 nonce,uint256 deadline)"
+            "RepayMUSD(uint256 amount,address borrower,uint256 nonce,uint256 deadline)"
         );
 
     bytes32 private constant WITHDRAW_MUSD_TYPEHASH =
         keccak256(
-            "WithdrawMUSD(uint256 amount,address upperHint,address lowerHint,address borrower,address recipient,uint256 nonce,uint256 deadline)"
+            "WithdrawMUSD(uint256 amount,address borrower,address recipient,uint256 nonce,uint256 deadline)"
         );
 
     bytes32 private constant ADJUST_TROVE_TYPEHASH =
         keccak256(
-            "AdjustTrove(uint256 collWithdrawal,uint256 debtChange,bool isDebtIncrease,uint256 assetAmount,address upperHint,address lowerHint,address borrower,address recipient,uint256 nonce,uint256 deadline)"
+            "AdjustTrove(uint256 collWithdrawal,uint256 debtChange,bool isDebtIncrease,uint256 assetAmount,address borrower,address recipient,uint256 nonce,uint256 deadline)"
         );
 
     bytes32 private constant CLOSE_TROVE_TYPEHASH =
@@ -180,12 +180,7 @@ contract BorrowerOperationsSignatures is
 
         _verifySignature(
             ADD_COLL_TYPEHASH,
-            abi.encode(
-                msg.value,
-                addCollData.upperHint,
-                addCollData.lowerHint,
-                addCollData.borrower
-            ),
+            abi.encode(msg.value, addCollData.borrower),
             addCollData.borrower,
             _signature,
             addCollData.deadline
@@ -258,8 +253,6 @@ contract BorrowerOperationsSignatures is
                 adjustTroveData.debtChange,
                 adjustTroveData.isDebtIncrease,
                 msg.value,
-                adjustTroveData.upperHint,
-                adjustTroveData.lowerHint,
                 adjustTroveData.borrower,
                 adjustTroveData.recipient
             ),
@@ -302,8 +295,6 @@ contract BorrowerOperationsSignatures is
             WITHDRAW_COLL_TYPEHASH,
             abi.encode(
                 withdrawCollData.amount,
-                withdrawCollData.upperHint,
-                withdrawCollData.lowerHint,
                 withdrawCollData.borrower,
                 withdrawCollData.recipient
             ),
@@ -346,8 +337,6 @@ contract BorrowerOperationsSignatures is
             OPEN_TROVE_TYPEHASH,
             abi.encode(
                 openTroveData.debtAmount,
-                openTroveData.upperHint,
-                openTroveData.lowerHint,
                 openTroveData.borrower,
                 openTroveData.recipient
             ),
@@ -387,8 +376,6 @@ contract BorrowerOperationsSignatures is
             WITHDRAW_MUSD_TYPEHASH,
             abi.encode(
                 withdrawMUSDData.amount,
-                withdrawMUSDData.upperHint,
-                withdrawMUSDData.lowerHint,
                 withdrawMUSDData.borrower,
                 withdrawMUSDData.recipient
             ),
@@ -427,12 +414,7 @@ contract BorrowerOperationsSignatures is
 
         _verifySignature(
             REPAY_MUSD_TYPEHASH,
-            abi.encode(
-                repayMUSDData.amount,
-                repayMUSDData.upperHint,
-                repayMUSDData.lowerHint,
-                repayMUSDData.borrower
-            ),
+            abi.encode(repayMUSDData.amount, repayMUSDData.borrower),
             repayMUSDData.borrower,
             _signature,
             repayMUSDData.deadline

--- a/solidity/test/normal/BorrowerOperations.test.ts
+++ b/solidity/test/normal/BorrowerOperations.test.ts
@@ -699,8 +699,6 @@ describe("BorrowerOperations in Normal Mode", () => {
     const types = {
       OpenTrove: [
         { name: "debtAmount", type: "uint256" },
-        { name: "upperHint", type: "address" },
-        { name: "lowerHint", type: "address" },
         { name: "borrower", type: "address" },
         { name: "recipient", type: "address" },
         { name: "nonce", type: "uint256" },
@@ -714,8 +712,6 @@ describe("BorrowerOperations in Normal Mode", () => {
 
       const value = {
         debtAmount,
-        upperHint,
-        lowerHint,
         borrower,
         recipient,
         nonce,
@@ -751,8 +747,6 @@ describe("BorrowerOperations in Normal Mode", () => {
 
       const value = {
         debtAmount,
-        upperHint,
-        lowerHint,
         borrower,
         recipient,
         nonce,
@@ -787,8 +781,6 @@ describe("BorrowerOperations in Normal Mode", () => {
 
       const value = {
         debtAmount,
-        upperHint,
-        lowerHint,
         borrower,
         recipient,
         nonce,
@@ -854,8 +846,6 @@ describe("BorrowerOperations in Normal Mode", () => {
           borrower: data.borrower,
           recipient: data.recipient,
           debtAmount: data.debtAmount,
-          upperHint: data.upperHint,
-          lowerHint: data.lowerHint,
           nonce: overridenData.nonce,
           deadline: data.deadline,
         }
@@ -1924,8 +1914,6 @@ describe("BorrowerOperations in Normal Mode", () => {
     const types = {
       AddColl: [
         { name: "assetAmount", type: "uint256" },
-        { name: "upperHint", type: "address" },
-        { name: "lowerHint", type: "address" },
         { name: "borrower", type: "address" },
         { name: "nonce", type: "uint256" },
         { name: "deadline", type: "uint256" },
@@ -1939,8 +1927,6 @@ describe("BorrowerOperations in Normal Mode", () => {
 
       const value = {
         assetAmount,
-        upperHint,
-        lowerHint,
         borrower,
         nonce,
         deadline,
@@ -1973,8 +1959,6 @@ describe("BorrowerOperations in Normal Mode", () => {
       const value = {
         borrower,
         assetAmount,
-        upperHint,
-        lowerHint,
         nonce,
         deadline,
       }
@@ -2024,8 +2008,6 @@ describe("BorrowerOperations in Normal Mode", () => {
 
         const value = {
           assetAmount: data.assetAmount,
-          upperHint: data.upperHint,
-          lowerHint: data.lowerHint,
           borrower: data.borrower,
           nonce: overridenData.nonce,
           deadline: data.deadline,
@@ -2400,8 +2382,6 @@ describe("BorrowerOperations in Normal Mode", () => {
     const types = {
       WithdrawColl: [
         { name: "amount", type: "uint256" },
-        { name: "upperHint", type: "address" },
-        { name: "lowerHint", type: "address" },
         { name: "borrower", type: "address" },
         { name: "recipient", type: "address" },
         { name: "nonce", type: "uint256" },
@@ -2417,8 +2397,6 @@ describe("BorrowerOperations in Normal Mode", () => {
 
       const value = {
         amount,
-        upperHint,
-        lowerHint,
         borrower,
         recipient,
         nonce,
@@ -2455,8 +2433,6 @@ describe("BorrowerOperations in Normal Mode", () => {
 
       const value = {
         amount,
-        upperHint,
-        lowerHint,
         borrower,
         recipient,
         nonce,
@@ -2493,8 +2469,6 @@ describe("BorrowerOperations in Normal Mode", () => {
         borrower,
         recipient,
         amount,
-        upperHint,
-        lowerHint,
         nonce,
         deadline,
       }
@@ -2530,8 +2504,6 @@ describe("BorrowerOperations in Normal Mode", () => {
 
         const data = {
           amount,
-          upperHint,
-          lowerHint,
           borrower,
           recipient,
           nonce,
@@ -2548,8 +2520,6 @@ describe("BorrowerOperations in Normal Mode", () => {
 
         const value = {
           amount: data.amount,
-          upperHint: data.upperHint,
-          lowerHint: data.lowerHint,
           borrower: data.borrower,
           recipient: data.recipient,
           nonce: overriddenData.nonce,
@@ -2574,8 +2544,8 @@ describe("BorrowerOperations in Normal Mode", () => {
             .connect(overriddenData.caller)
             .withdrawCollWithSignature(
               overriddenData.amount,
-              overriddenData.upperHint,
-              overriddenData.lowerHint,
+              upperHint,
+              lowerHint,
               overriddenData.borrower,
               overriddenData.recipient,
               signature,
@@ -2917,8 +2887,6 @@ describe("BorrowerOperations in Normal Mode", () => {
     const types = {
       WithdrawMUSD: [
         { name: "amount", type: "uint256" },
-        { name: "upperHint", type: "address" },
-        { name: "lowerHint", type: "address" },
         { name: "borrower", type: "address" },
         { name: "recipient", type: "address" },
         { name: "nonce", type: "uint256" },
@@ -2940,8 +2908,6 @@ describe("BorrowerOperations in Normal Mode", () => {
         await contracts.borrowerOperationsSignatures.getNonce(borrower)
       const value = {
         amount,
-        upperHint,
-        lowerHint,
         borrower,
         recipient,
         nonce,
@@ -2977,8 +2943,6 @@ describe("BorrowerOperations in Normal Mode", () => {
 
       const value = {
         amount,
-        upperHint,
-        lowerHint,
         borrower,
         recipient,
         nonce,
@@ -3011,8 +2975,6 @@ describe("BorrowerOperations in Normal Mode", () => {
 
       const value = {
         amount,
-        upperHint,
-        lowerHint,
         borrower,
         recipient,
         nonce,
@@ -3073,8 +3035,6 @@ describe("BorrowerOperations in Normal Mode", () => {
 
         const signedValues = {
           amount: overridenData.amount,
-          upperHint: data.upperHint,
-          lowerHint: data.lowerHint,
           borrower: data.borrower,
           recipient: data.recipient,
           nonce: overridenData.nonce,
@@ -3506,8 +3466,6 @@ describe("BorrowerOperations in Normal Mode", () => {
     const types = {
       RepayMUSD: [
         { name: "amount", type: "uint256" },
-        { name: "upperHint", type: "address" },
-        { name: "lowerHint", type: "address" },
         { name: "borrower", type: "address" },
         { name: "nonce", type: "uint256" },
         { name: "deadline", type: "uint256" },
@@ -3520,8 +3478,6 @@ describe("BorrowerOperations in Normal Mode", () => {
         await setupSignatureTests(bob)
       const value = {
         amount,
-        upperHint,
-        lowerHint,
         borrower,
         nonce,
         deadline,
@@ -3548,8 +3504,6 @@ describe("BorrowerOperations in Normal Mode", () => {
         await setupSignatureTests(bob)
       const value = {
         amount,
-        upperHint,
-        lowerHint,
         borrower,
         nonce,
         deadline,
@@ -3582,8 +3536,6 @@ describe("BorrowerOperations in Normal Mode", () => {
         await setupSignatureTests(bob)
       const value = {
         amount,
-        upperHint,
-        lowerHint,
         borrower,
         nonce,
         deadline,
@@ -3632,8 +3584,6 @@ describe("BorrowerOperations in Normal Mode", () => {
 
         const value = {
           amount: data.amount,
-          upperHint: data.upperHint,
-          lowerHint: data.lowerHint,
           borrower: data.borrower,
           nonce: overriddenData.nonce,
           deadline: data.deadline,
@@ -4709,8 +4659,6 @@ describe("BorrowerOperations in Normal Mode", () => {
         { name: "debtChange", type: "uint256" },
         { name: "isDebtIncrease", type: "bool" },
         { name: "assetAmount", type: "uint256" },
-        { name: "upperHint", type: "address" },
-        { name: "lowerHint", type: "address" },
         { name: "borrower", type: "address" },
         { name: "recipient", type: "address" },
         { name: "nonce", type: "uint256" },
@@ -4733,8 +4681,6 @@ describe("BorrowerOperations in Normal Mode", () => {
         debtChange,
         isDebtIncrease,
         assetAmount,
-        upperHint,
-        lowerHint,
         borrower,
         recipient,
         nonce,
@@ -4774,8 +4720,6 @@ describe("BorrowerOperations in Normal Mode", () => {
         debtChange,
         isDebtIncrease: false,
         assetAmount,
-        upperHint,
-        lowerHint,
         borrower,
         recipient,
         nonce,
@@ -4821,8 +4765,6 @@ describe("BorrowerOperations in Normal Mode", () => {
         debtChange,
         isDebtIncrease,
         assetAmount,
-        upperHint,
-        lowerHint,
         borrower,
         recipient,
         nonce,
@@ -4865,8 +4807,6 @@ describe("BorrowerOperations in Normal Mode", () => {
         debtChange: 0n,
         isDebtIncrease: false,
         assetAmount: addedCollateral,
-        upperHint,
-        lowerHint,
         borrower,
         recipient,
         nonce,
@@ -4883,8 +4823,8 @@ describe("BorrowerOperations in Normal Mode", () => {
           value.collWithdrawal,
           value.debtChange,
           value.isDebtIncrease,
-          value.upperHint,
-          value.lowerHint,
+          upperHint,
+          lowerHint,
           value.borrower,
           value.recipient,
           signature,
@@ -4910,8 +4850,6 @@ describe("BorrowerOperations in Normal Mode", () => {
         debtChange,
         isDebtIncrease,
         assetAmount,
-        upperHint,
-        lowerHint,
         borrower,
         recipient,
         nonce,
@@ -4950,8 +4888,6 @@ describe("BorrowerOperations in Normal Mode", () => {
         debtChange,
         isDebtIncrease,
         assetAmount,
-        upperHint,
-        lowerHint,
         borrower,
         recipient,
         nonce,
@@ -5012,8 +4948,6 @@ describe("BorrowerOperations in Normal Mode", () => {
           debtChange: data.debtChange,
           isDebtIncrease: data.isDebtIncrease,
           assetAmount: data.assetAmount,
-          upperHint: data.upperHint,
-          lowerHint: data.lowerHint,
           borrower: data.borrower,
           recipient: data.recipient,
           nonce: overriddenData.nonce,


### PR DESCRIPTION
Hints are used to help find insert positions, not anything to do with user-facing behavior. Additionally, they change moment-to-moment, so trying to sign a hint is obnoxious.

inspired by https://cantina.xyz/code/47e5f647-36ea-4de3-bc70-0ef3ef10ee25/comments#comment-be801560-92aa-4639-b2c7-baa90d2d1fff

tagging @rwatts07 for review