### PR TITLE
Increase the Active Pool's Debt Tracking during a refinance

### DIFF
--- a/solidity/contracts/BorrowerOperations.sol
+++ b/solidity/contracts/BorrowerOperations.sol
@@ -662,6 +662,7 @@ contract BorrowerOperations is
         uint256 fee = _triggerBorrowingFee(troveManagerCached, musd, amount);
         // slither-disable-next-line unused-return
         troveManagerCached.increaseTroveDebt(_borrower, fee);
+        activePool.increaseDebt(fee, 0);
 
         uint256 oldPrincipal = troveManagerCached.getTrovePrincipal(_borrower);
 


### PR DESCRIPTION
Previously, we did not increase the active pool's total principal whenever we would charge a refinancing fee. Now we do!

addresses https://cantina.xyz/code/47e5f647-36ea-4de3-bc70-0ef3ef10ee25/findings?finding=20

Tagging @rwatts07 for review