### PR TITLE
The Stability Pool Offsets Principal and Interest

### DIFF
--- a/solidity/contracts/interfaces/IStabilityPool.sol
+++ b/solidity/contracts/interfaces/IStabilityPool.sol
@@ -115,7 +115,11 @@ interface IStabilityPool {
      * and transfers the Trove's collateral from ActivePool to StabilityPool.
      * Only called by liquidation functions in the TroveManager.
      */
-    function offset(uint256 _debt, uint256 _coll) external;
+    function offset(
+        uint256 _principal,
+        uint256 _interest,
+        uint256 _coll
+    ) external;
 
     /*
      * Returns the total amount of collateral held by the pool, accounted in an internal variable instead of `balance`,

--- a/solidity/test/normal/AccessControl.test.ts
+++ b/solidity/test/normal/AccessControl.test.ts
@@ -355,7 +355,7 @@ describe("Access Control: Liquity functions with the caller restricted to Liquit
   describe("StabilityPool", () => {
     it("offset(): reverts when called by an account that is not TroveManager", async () => {
       await expect(
-        contracts.stabilityPool.connect(alice.wallet).offset(100, 10),
+        contracts.stabilityPool.connect(alice.wallet).offset(100, 0, 10),
       ).to.be.revertedWith("StabilityPool: Caller is not TroveManager")
     })
 


### PR DESCRIPTION
Previously, the stability pool was adding principal and interest together to get debt, and then subtracting debt from the active pool's principal. This was horribly wrong.

addresses https://cantina.xyz/code/47e5f647-36ea-4de3-bc70-0ef3ef10ee25/findings?finding=22

DEPENDS ON #176 

Tagging @rwatts07 for review