### PR TITLE
Remove Unnecessary `_requireTroveIsActive` Check

### DIFF
--- a/solidity/contracts/TroveManager.sol
+++ b/solidity/contracts/TroveManager.sol
@@ -937,8 +937,6 @@ contract TroveManager is
     ) internal {
         Trove storage trove = Troves[_borrower];
         if (hasPendingRewards(_borrower)) {
-            _requireTroveIsActive(_borrower);
-
             // Compute pending rewards
             uint256 pendingCollateral = getPendingCollateral(_borrower);
             (


### PR DESCRIPTION
`_applyPendingRewards` is called from:

- `redeemCollateral` which loops over active troves
- `restrictedCloseTrove` which already checks that the trove is active
- `restrictedAdjustTrove` which also already checks that the trove is active

In general, we should do checks like this at the top of external/public functions rather than in the middle of internal functions, hence the deletion

addresses https://cantina.xyz/code/47e5f647-36ea-4de3-bc70-0ef3ef10ee25/comments#comment-4fb78f22-b7b0-47bd-9c4e-40f697299514

tagging @rwatts07 for review