### PR TITLE
Return early in `_updateDefaultPoolInterest`

### DIFF
--- a/solidity/contracts/TroveManager.sol
+++ b/solidity/contracts/TroveManager.sol
@@ -899,34 +899,35 @@ contract TroveManager is
     }
 
     function _updateDefaultPoolInterest() internal {
-        if (totalStakes > 0) {
-            // solhint-disable not-rely-on-time
-            uint256 interest = InterestRateMath.calculateInterestOwed(
-                defaultPool.getPrincipal(),
-                interestRateManager.interestRate(),
-                defaultPool.getLastInterestUpdatedTime(),
-                block.timestamp
-            );
-            // solhint-enable not-rely-on-time
-
-            // slither-disable-start divide-before-multiply
-            uint256 interestNumerator = interest *
-                DECIMAL_PRECISION +
-                lastInterestError_Redistribution;
-
-            uint256 pendingInterestPerUnitStaked = interestNumerator /
-                totalStakes;
-
-            lastInterestError_Redistribution =
-                interestNumerator -
-                (pendingInterestPerUnitStaked * totalStakes);
-            // slither-disable-end divide-before-multiply
-
-            L_Interest += pendingInterestPerUnitStaked;
-
-            defaultPool.increaseDebt(0, interest);
-            emit LTermsUpdated(L_Collateral, L_Principal, L_Interest);
+        if (totalStakes == 0) {
+            return;
         }
+
+        // solhint-disable not-rely-on-time
+        uint256 interest = InterestRateMath.calculateInterestOwed(
+            defaultPool.getPrincipal(),
+            interestRateManager.interestRate(),
+            defaultPool.getLastInterestUpdatedTime(),
+            block.timestamp
+        );
+        // solhint-enable not-rely-on-time
+
+        // slither-disable-start divide-before-multiply
+        uint256 interestNumerator = interest *
+            DECIMAL_PRECISION +
+            lastInterestError_Redistribution;
+
+        uint256 pendingInterestPerUnitStaked = interestNumerator / totalStakes;
+
+        lastInterestError_Redistribution =
+            interestNumerator -
+            (pendingInterestPerUnitStaked * totalStakes);
+        // slither-disable-end divide-before-multiply
+
+        L_Interest += pendingInterestPerUnitStaked;
+
+        defaultPool.increaseDebt(0, interest);
+        emit LTermsUpdated(L_Collateral, L_Principal, L_Interest);
     }
 
     // Add the borrowers's coll and debt rewards earned from redistributions, to their Trove


### PR DESCRIPTION
Quick code quality change. Rather than wrapping the entire function in an `if`, we return early if the if fails.

addresses https://cantina.xyz/code/47e5f647-36ea-4de3-bc70-0ef3ef10ee25/comments#comment-d8bdd47e-a90b-4f48-8cf7-fe3426ca12ad

tagging @rwatts07 for review