### PR TITLE
Move the `_requireActiveTrove` check to inside `batchLiquidate`

### DIFF
--- a/solidity/contracts/TroveManager.sol
+++ b/solidity/contracts/TroveManager.sol
@@ -275,8 +275,6 @@ contract TroveManager is
     }
 
     function liquidate(address _borrower) external override {
-        _requireTroveIsActive(_borrower);
-
         address[] memory borrowers = new address[](1);
         borrowers[0] = _borrower;
         batchLiquidateTroves(borrowers);
@@ -684,6 +682,7 @@ contract TroveManager is
         for (uint i = 0; i < _troveArray.length; i++) {
             address borrower = _troveArray[i];
 
+            _requireTroveIsActive(borrower);
             _updateTroveInterest(borrower);
         }
 


### PR DESCRIPTION
`liquidate` calls `batchLiquidate`, so this unifies the flows

addresses https://cantina.xyz/code/47e5f647-36ea-4de3-bc70-0ef3ef10ee25/comments#comment-3be24506-96e1-441b-a89b-b2ddc4f2b30c

tagging @rwatts07 for review