### PR TITLE
Remove unused `MAX_BORROWING_FEE`

### DIFF
--- a/solidity/contracts/TroveManager.sol
+++ b/solidity/contracts/TroveManager.sol
@@ -171,7 +171,6 @@ contract TroveManager is
 
     uint256 public constant REDEMPTION_FEE_FLOOR =
         (DECIMAL_PRECISION * 5) / 1000; // 0.5%
-    uint256 public constant MAX_BORROWING_FEE = (DECIMAL_PRECISION * 5) / 100; // 5%
 
     mapping(address => Trove) public Troves;
 


### PR DESCRIPTION
This was vestigial after we reworked the decay rate stuff.

addresses https://cantina.xyz/code/47e5f647-36ea-4de3-bc70-0ef3ef10ee25/comments#comment-ca0faa26-7fbb-4a62-8eec-74a01c3c5229

tagging @rwatts07 for review