### PR TITLE
Use `31556952` Seconds in a Year For Interest

### DIFF
--- a/solidity/contracts/dependencies/InterestRateMath.sol
+++ b/solidity/contracts/dependencies/InterestRateMath.sol
@@ -3,7 +3,11 @@
 pragma solidity ^0.8.24;
 
 library InterestRateMath {
-    uint256 private constant SECONDS_IN_A_YEAR = 365 * 24 * 60 * 60;
+    // https://sibenotes.com/maths/how-many-seconds-are-in-a-year/
+    // 365.2425 days per year * 24 hours per day *
+    // 60 minutes per hour * 60 seconds per minute
+    uint256 public constant SECONDS_IN_A_YEAR = 31_556_952;
+    uint256 private constant BPS = 10_000;
 
     function calculateInterestOwed(
         uint256 _principal,
@@ -14,7 +18,7 @@ library InterestRateMath {
         uint256 timeElapsed = _endTime - _startTime;
         return
             (_principal * _interestRate * timeElapsed) /
-            (10000 * SECONDS_IN_A_YEAR);
+            (BPS * SECONDS_IN_A_YEAR);
     }
 
     function calculateAggregatedInterestOwed(
@@ -23,6 +27,6 @@ library InterestRateMath {
         uint256 _endTime
     ) internal pure returns (uint256) {
         uint256 timeElapsed = _endTime - _startTime;
-        return (timeElapsed * _interestNumerator) / (10000 * SECONDS_IN_A_YEAR);
+        return (timeElapsed * _interestNumerator) / (BPS * SECONDS_IN_A_YEAR);
     }
 }

--- a/solidity/test/helpers/functions.ts
+++ b/solidity/test/helpers/functions.ts
@@ -15,7 +15,7 @@ import {
   WithdrawCollParams,
 } from "./interfaces"
 import { LIQUIDATION_ABI } from "./abi"
-import { fastForwardTime } from "./time"
+import { SECONDS_IN_ONE_YEAR, fastForwardTime } from "./time"
 import { getAddresses, loadTestSetup } from "./context"
 
 export const NO_GAS = {
@@ -918,11 +918,10 @@ export function calculateInterestOwed(
   endTimeSeconds: bigint,
 ) {
   const elapsedSeconds = endTimeSeconds - startTimeSeconds
-  const secondsInOneYear = 31536000n
 
   return (
     (principal * BigInt(interestRateBips) * elapsedSeconds) /
-    (10000n * secondsInOneYear)
+    (10000n * SECONDS_IN_ONE_YEAR)
   )
 }
 

--- a/solidity/test/helpers/time.ts
+++ b/solidity/test/helpers/time.ts
@@ -1,5 +1,10 @@
 import { ethers } from "hardhat"
 
+// https://sibenotes.com/maths/how-many-seconds-are-in-a-year/
+// 365.2425 days per year * 24 hours per day *
+// 60 minutes per hour * 60 seconds per minute
+export const SECONDS_IN_ONE_YEAR = 31_556_952n
+
 export async function getLatestBlockTimestamp() {
   const { provider } = ethers
   const latestBlock = await provider.getBlock("latest")

--- a/solidity/test/normal/BorrowerOperations.test.ts
+++ b/solidity/test/normal/BorrowerOperations.test.ts
@@ -5128,8 +5128,9 @@ describe("BorrowerOperations in Normal Mode", () => {
         carol.trove.lastInterestUpdateTime.after,
       )
 
-      expect(state.activePool.interest.after).to.equal(
+      expect(state.activePool.interest.after).to.be.closeTo(
         carolInterest + dennisInterest,
+        2n,
       )
       expect(state.activePool.principal.after).to.equal(
         state.activePool.principal.before + carolFee,

--- a/solidity/test/normal/TroveManager.test.ts
+++ b/solidity/test/normal/TroveManager.test.ts
@@ -307,13 +307,14 @@ describe("TroveManager in Normal Mode", () => {
         addresses,
       )
       expect(state.activePool.principal.after).to.equal(bob.trove.debt.after)
-      expect(state.activePool.interest.after).to.equal(
+      expect(state.activePool.interest.after).to.be.closeTo(
         calculateInterestOwed(
           bob.trove.debt.before,
           1000,
           bob.trove.lastInterestUpdateTime.before,
           after,
         ),
+        2n,
       )
     })
 
@@ -1393,7 +1394,10 @@ describe("TroveManager in Normal Mode", () => {
         BigInt(after),
       )
 
-      expect(state.activePool.interest.after).to.equal(expectedInterest)
+      expect(state.activePool.interest.after).to.be.closeTo(
+        expectedInterest,
+        2n,
+      )
       expect(state.activePool.principal.after).to.equal(bob.trove.debt.before)
       expect(stabilityPoolLoss).to.equal(
         alice.trove.debt.before + aliceInterest,
@@ -3513,8 +3517,9 @@ describe("TroveManager in Normal Mode", () => {
         alice.trove.lastInterestUpdateTime.after,
       )
 
-      expect(alice.trove.interestOwed.after).to.be.equal(
+      expect(alice.trove.interestOwed.after).to.be.closeTo(
         alice.trove.interestOwed.before + expectedInterest,
+        2n,
       )
     })
 
@@ -3676,8 +3681,9 @@ describe("TroveManager in Normal Mode", () => {
         bob.trove.lastInterestUpdateTime.after,
       )
 
-      expect(state.activePool.interest.after).to.equal(
+      expect(state.activePool.interest.after).to.be.closeTo(
         state.activePool.interest.before + aliceInterest + bobInterest,
+        2n,
       )
     })
   })


### PR DESCRIPTION
https://sibenotes.com/maths/how-many-seconds-are-in-a-year/ gives that as the correct value for the gregorian calendar

No more calendar drift!

addresses https://cantina.xyz/code/47e5f647-36ea-4de3-bc70-0ef3ef10ee25/comments#comment-19f9af40-8742-4e8c-b333-64ff2fd3042b and https://cantina.xyz/code/47e5f647-36ea-4de3-bc70-0ef3ef10ee25/comments#comment-4cfced07-e3eb-4416-b493-bf310d98ff83

Tagging @rwatts07 for review