### PR TITLE
Remove unused return variables

### DIFF
--- a/solidity/contracts/tests/MockAggregator.sol
+++ b/solidity/contracts/tests/MockAggregator.sol
@@ -42,20 +42,15 @@ contract MockAggregator is ChainlinkAggregatorV3Interface, Ownable {
     function latestRoundData()
         external
         view
-        returns (
-            uint80 roundId,
-            int256 answer,
-            uint256 startedAt,
-            uint256 updatedAt,
-            uint80 answeredInRound
-        )
+        returns (uint80, int256, uint256, uint256, uint80)
     {
         require(precision <= 77, "Decimals too large"); // Prevent overflow
-        updatedAt = blockTime;
+        uint256 updatedAt = blockTime;
         if (updatedAt == 0) {
             updatedAt = block.timestamp;
         }
-        answer = int256(_price);
+        int256 answer = int256(_price);
+        return (0, answer, updatedAt, updatedAt, 0);
     }
 
     function decimals() public view returns (uint8) {


### PR DESCRIPTION
Previously, we were getting this warning:

---

Warning: Unused function parameter. Remove or comment out the variable name to silence this warning.
  --> contracts/tests/MockAggregator.sol:46:13:
   |
46 |             uint80 roundId,
   |             ^^^^^^^^^^^^^^


Warning: Unused function parameter. Remove or comment out the variable name to silence this warning.
  --> contracts/tests/MockAggregator.sol:48:13:
   |
48 |             uint256 startedAt,
   |             ^^^^^^^^^^^^^^^^^


Warning: Unused function parameter. Remove or comment out the variable name to silence this warning.
  --> contracts/tests/MockAggregator.sol:50:13:
   |
50 |             uint80 answeredInRound
   |             ^^^^^^^^^^^^^^^^^^^^^^

---


Now, we don't!

Tagging @benthesis for review