### PR TITLE
Use `getEntireDebtAndColl` in `HintHelpers.getRedemptionHints`

### DIFF
--- a/solidity/contracts/HintHelpers.sol
+++ b/solidity/contracts/HintHelpers.sol
@@ -129,29 +129,30 @@ contract HintHelpers is CheckContract, LiquityBase, OwnableUpgradeable {
             uint256 netDebt = _getNetDebt(principal + interest);
 
             if (netDebt > remainingMUSD) {
-                if (netDebt > minNetDebt) {
-                    uint256 maxRedeemableMUSD = LiquityMath._min(
-                        remainingMUSD,
-                        netDebt - minNetDebt
-                    );
-
-                    coll -= ((maxRedeemableMUSD * DECIMAL_PRECISION) / _price);
-
-                    // slither-disable-start unused-return
-                    (uint256 principalAdjustment, ) = InterestRateMath
-                        .calculateDebtAdjustment(interest, maxRedeemableMUSD);
-                    // slither-disable-end unused-return
-
-                    principal -= principalAdjustment;
-
-                    partialRedemptionHintNICR = LiquityMath._computeNominalCR(
-                        coll,
-                        principal
-                    );
-
-                    remainingMUSD -= maxRedeemableMUSD;
+                if (netDebt <= minNetDebt) {
+                    break;
                 }
-                break;
+
+                uint256 maxRedeemableMUSD = LiquityMath._min(
+                    remainingMUSD,
+                    netDebt - minNetDebt
+                );
+
+                coll -= ((maxRedeemableMUSD * DECIMAL_PRECISION) / _price);
+
+                // slither-disable-start unused-return
+                (uint256 principalAdjustment, ) = InterestRateMath
+                    .calculateDebtAdjustment(interest, maxRedeemableMUSD);
+                // slither-disable-end unused-return
+
+                principal -= principalAdjustment;
+
+                partialRedemptionHintNICR = LiquityMath._computeNominalCR(
+                    coll,
+                    principal
+                );
+
+                remainingMUSD -= maxRedeemableMUSD;
             } else {
                 remainingMUSD -= netDebt;
             }


### PR DESCRIPTION
Previously, the hint calculations were hard to follow and made many external calls. Thanks to the API improvements we've been making, we can now clean up the hint calculation to be clean and readable.

Tagging @benthesis for review