### PR TITLE
Make the Default Pool Not Accrue Interest

### DIFF
--- a/solidity/contracts/DefaultPool.sol
+++ b/solidity/contracts/DefaultPool.sol
@@ -29,7 +29,6 @@ contract DefaultPool is
     uint256 internal collateral; // deposited collateral tracker
     uint256 internal principal;
     uint256 internal interest;
-    uint256 internal lastInterestUpdatedTime;
 
     function initialize() external initializer {
         __Ownable_init(msg.sender);
@@ -74,8 +73,6 @@ contract DefaultPool is
         _requireCallerIsTroveManager();
         principal += _principal;
         interest += _interest;
-        // solhint-disable-next-line not-rely-on-time
-        lastInterestUpdatedTime = block.timestamp;
         emit DefaultPoolDebtUpdated(principal, interest);
     }
 
@@ -86,8 +83,6 @@ contract DefaultPool is
         _requireCallerIsTroveManager();
         principal -= _principal;
         interest -= _interest;
-        // solhint-disable-next-line not-rely-on-time
-        lastInterestUpdatedTime = block.timestamp;
         emit DefaultPoolDebtUpdated(principal, interest);
     }
 
@@ -115,15 +110,6 @@ contract DefaultPool is
 
     function getInterest() external view override returns (uint) {
         return interest;
-    }
-
-    function getLastInterestUpdatedTime()
-        external
-        view
-        override
-        returns (uint)
-    {
-        return lastInterestUpdatedTime;
     }
 
     function _requireCallerIsTroveManager() internal view {

--- a/solidity/contracts/dependencies/LiquityBase.sol
+++ b/solidity/contracts/dependencies/LiquityBase.sol
@@ -71,21 +71,7 @@ abstract contract LiquityBase is BaseMath, ILiquityBase {
         uint256 closedDebt = defaultPool.getDebt();
         uint256 accruedInterest = interestRateManager.getAccruedInterest();
 
-        //solhint-disable not-rely-on-time
-        uint256 accruedDefaultPoolInterest = InterestRateMath
-            .calculateInterestOwed(
-                defaultPool.getPrincipal(),
-                interestRateManager.interestRate(),
-                defaultPool.getLastInterestUpdatedTime(),
-                block.timestamp
-            );
-        //solhint-enable not-rely-on-time
-
-        return
-            activeDebt +
-            closedDebt +
-            accruedInterest +
-            accruedDefaultPoolInterest;
+        return activeDebt + closedDebt + accruedInterest;
     }
 
     function _getTCR(

--- a/solidity/contracts/interfaces/IDefaultPool.sol
+++ b/solidity/contracts/interfaces/IDefaultPool.sol
@@ -12,6 +12,4 @@ interface IDefaultPool is IPool {
 
     // --- Functions ---
     function sendCollateralToActivePool(uint256 _amount) external;
-
-    function getLastInterestUpdatedTime() external view returns (uint);
 }

--- a/solidity/contracts/tests/TroveManagerTester.sol
+++ b/solidity/contracts/tests/TroveManagerTester.sol
@@ -8,10 +8,6 @@ import "../TroveManager.sol";
 for testing the parent's internal functions. */
 
 contract TroveManagerTester is TroveManager {
-    function callUpdateDefaultPoolInterest() external {
-        _updateDefaultPoolInterest();
-    }
-
     function getCompositeDebt(uint256 _debt) external pure returns (uint) {
         return _getCompositeDebt(_debt);
     }

--- a/solidity/test/helpers/functions.ts
+++ b/solidity/test/helpers/functions.ts
@@ -903,7 +903,6 @@ export async function getRedemptionHints(
   redemptionAmount: bigint,
   price: bigint,
 ) {
-  await contracts.troveManager.callUpdateDefaultPoolInterest(NO_GAS)
   const { firstRedemptionHint, partialRedemptionHintNICR } =
     await contracts.hintHelpers.getRedemptionHints(redemptionAmount, price, 0)
 


### PR DESCRIPTION
Previously, the default pool accrued interest at the global rate. Now, any debt in the default pool sits there until it is claimed, where it starts accruing again at the user's rate.

Tagging @benthesis for review