### PR TITLE
Make `ActivePool.getInterest` virtually accrue

### DIFF
--- a/solidity/contracts/dependencies/LiquityBase.sol
+++ b/solidity/contracts/dependencies/LiquityBase.sol
@@ -69,9 +69,8 @@ abstract contract LiquityBase is BaseMath, ILiquityBase {
     {
         uint256 activeDebt = activePool.getDebt();
         uint256 closedDebt = defaultPool.getDebt();
-        uint256 accruedInterest = interestRateManager.getAccruedInterest();
 
-        return activeDebt + closedDebt + accruedInterest;
+        return activeDebt + closedDebt;
     }
 
     function _getTCR(

--- a/solidity/test/normal/BorrowerOperations.test.ts
+++ b/solidity/test/normal/BorrowerOperations.test.ts
@@ -3351,7 +3351,7 @@ describe("BorrowerOperations in Normal Mode", () => {
       )
 
       expect(state.activePool.debt.after).to.equal(
-        state.activePool.debt.before - amount + expectedInterest,
+        state.activePool.principal.before + expectedInterest - amount,
       )
     })
 


### PR DESCRIPTION
Funny enough, the original [finding](https://cantina.xyz/code/47e5f647-36ea-4de3-bc70-0ef3ef10ee25/findings?finding=31) specifically mentioned that `ActivePool.getDebt` is a stale value, and I updated *basically everything else*.

This PR pushes the accrual a little further down stream (to .getInterest, which is called in .getDebt, which is called in .getEntireSystemDebt and son)

Tagging @rwatts07 for review