### PR TITLE
Do Not Double Count Interest When Check Max Borrowing Capacity

### DIFF
--- a/solidity/contracts/BorrowerOperations.sol
+++ b/solidity/contracts/BorrowerOperations.sol
@@ -1352,8 +1352,7 @@ contract BorrowerOperations is
         LocalVariables_adjustTrove memory _vars
     ) internal pure {
         require(
-            _vars.maxBorrowingCapacity >=
-                _vars.netDebtChange + _vars.debt + _vars.interestOwed,
+            _vars.maxBorrowingCapacity >= _vars.netDebtChange + _vars.debt,
             "BorrowerOps: An operation that exceeds maxBorrowingCapacity is not permitted"
         );
     }

--- a/solidity/test/normal/BorrowerOperations.test.ts
+++ b/solidity/test/normal/BorrowerOperations.test.ts
@@ -4105,7 +4105,7 @@ describe("BorrowerOperations in Normal Mode", () => {
       )
     })
 
-    it.only("does not double count interest when checking maxBorrowingCapacity", async () => {
+    it("does not double count interest when checking maxBorrowingCapacity", async () => {
       await setInterestRate(contracts, council, 1000)
       await setupCarolsTrove()
 

--- a/solidity/test/normal/BorrowerOperations.test.ts
+++ b/solidity/test/normal/BorrowerOperations.test.ts
@@ -4105,6 +4105,30 @@ describe("BorrowerOperations in Normal Mode", () => {
       )
     })
 
+    it("decreases maxBorrowingCapacity on collateral withdrawal if price has fallen", async () => {
+      await setupCarolsTrove()
+      await updateTroveSnapshot(contracts, carol, "before")
+
+      const price = await dropPrice(contracts, deployer, carol, to1e18("290"))
+
+      const collWithdrawal = 1n
+      await contracts.borrowerOperations
+        .connect(carol.wallet)
+        .adjustTrove(collWithdrawal, 0, false, carol.wallet, carol.wallet)
+
+      await updateTroveSnapshot(contracts, carol, "after")
+
+      const expectedMaxBorrowingCapacity =
+        (carol.trove.collateral.after * price) / to1e18("1.1")
+
+      expect(carol.trove.maxBorrowingCapacity.after).to.be.lessThan(
+        carol.trove.maxBorrowingCapacity.before,
+      )
+      expect(carol.trove.maxBorrowingCapacity.after).to.be.equal(
+        expectedMaxBorrowingCapacity,
+      )
+    })
+
     it("does not double count interest when checking maxBorrowingCapacity", async () => {
       await setInterestRate(contracts, council, 1000)
       await setupCarolsTrove()


### PR DESCRIPTION
# Summary

Previously, we were double counting interest when checking that a trove did not exceed `maxBorrowingCapacity` when adjusting the trove.  We added interest to the debt, but the debt already includes interest.  The fix is pretty straightforward -- remove the extra interest from the check.

# Details

The only tricky part about this is the test.  We need to calculate a value such that Carol will be close to her maxBorrowingCapacity (but not over) if we count interest once, but she will be over if we count it twice.  The additional wrinkle is that we need to account for the borrowing fee on the additional amount.  We can calculate this value with some algebra such that currentDebt + additionalBorrow + fee = maxBorrowingCapacity (with a 1 MUSD buffer to account for rounding).  If you revert the contract changes, you'll see that it reverts with because of max borrowing capacity.  With the changes in place, it passes.  The expectation is just to check that the transaction does not revert -- we are not actually interested in any of the values in this case.