### PR TITLE
_adjustTrove should verify that the caller, not the borrower, has enough funds

### DIFF
--- a/solidity/contracts/BorrowerOperations.sol
+++ b/solidity/contracts/BorrowerOperations.sol
@@ -17,8 +17,6 @@ import "./interfaces/ISortedTroves.sol";
 import "./interfaces/ITroveManager.sol";
 import "./token/IMUSD.sol";
 
-import "hardhat/console.sol";
-
 contract BorrowerOperations is
     CheckContract,
     IBorrowerOperations,
@@ -1225,8 +1223,6 @@ contract BorrowerOperations is
         address _borrower,
         uint256 _debtRepayment
     ) internal view {
-        console.log("hit this");
-        console.log(musd.balanceOf(_borrower));
         require(
             musd.balanceOf(_borrower) >= _debtRepayment,
             "BorrowerOps: Caller doesnt have enough mUSD to make repayment"

--- a/solidity/contracts/BorrowerOperations.sol
+++ b/solidity/contracts/BorrowerOperations.sol
@@ -17,6 +17,8 @@ import "./interfaces/ISortedTroves.sol";
 import "./interfaces/ITroveManager.sol";
 import "./token/IMUSD.sol";
 
+import "hardhat/console.sol";
+
 contract BorrowerOperations is
     CheckContract,
     IBorrowerOperations,
@@ -857,7 +859,7 @@ contract BorrowerOperations is
                 _getNetDebt(vars.debt) - vars.netDebtChange
             );
             _requireValidMUSDRepayment(vars.debt, vars.netDebtChange);
-            _requireSufficientMUSDBalance(_borrower, vars.netDebtChange);
+            _requireSufficientMUSDBalance(_caller, vars.netDebtChange);
         }
 
         (
@@ -1223,6 +1225,8 @@ contract BorrowerOperations is
         address _borrower,
         uint256 _debtRepayment
     ) internal view {
+        console.log("hit this");
+        console.log(musd.balanceOf(_borrower));
         require(
             musd.balanceOf(_borrower) >= _debtRepayment,
             "BorrowerOps: Caller doesnt have enough mUSD to make repayment"

--- a/solidity/test/normal/BorrowerOperations.test.ts
+++ b/solidity/test/normal/BorrowerOperations.test.ts
@@ -5263,7 +5263,7 @@ describe("BorrowerOperations in Normal Mode", () => {
         const value = {
           collWithdrawal: data.collWithdrawal,
           debtChange: data.debtChange,
-          isDebtIncrease: data.isDebtIncrease,
+          isDebtIncrease: overriddenData.isDebtIncrease,
           assetAmount: data.assetAmount,
           borrower: data.borrower,
           recipient: data.recipient,
@@ -5368,6 +5368,14 @@ describe("BorrowerOperations in Normal Mode", () => {
             ),
         ).to.be.revertedWith(
           "BorrowerOps: Caller is not BorrowerOperationsSignatures",
+        )
+      })
+
+      it.only("reverts when the caller does not have sufficient MUSD to repay debt", async () => {
+        // Dennis (the caller) does not have any MUSD
+        await testRevert(
+          { isDebtIncrease: false, caller: dennis.wallet },
+          "BorrowerOps: Caller doesnt have enough mUSD to make repayment",
         )
       })
     })

--- a/solidity/test/normal/BorrowerOperations.test.ts
+++ b/solidity/test/normal/BorrowerOperations.test.ts
@@ -5263,7 +5263,7 @@ describe("BorrowerOperations in Normal Mode", () => {
         const value = {
           collWithdrawal: data.collWithdrawal,
           debtChange: data.debtChange,
-          isDebtIncrease: overriddenData.isDebtIncrease,
+          isDebtIncrease: data.isDebtIncrease,
           assetAmount: data.assetAmount,
           borrower: data.borrower,
           recipient: data.recipient,
@@ -5371,10 +5371,65 @@ describe("BorrowerOperations in Normal Mode", () => {
         )
       })
 
-      it.only("reverts when the caller does not have sufficient MUSD to repay debt", async () => {
-        // Dennis (the caller) does not have any MUSD
-        await testRevert(
-          { isDebtIncrease: false, caller: dennis.wallet },
+      it("reverts when the caller does not have sufficient MUSD to repay debt", async () => {
+        const { borrower, recipient, nonce, deadline } =
+          await setupSignatureTests(bob)
+
+        const data = {
+          collWithdrawal,
+          debtChange,
+          isDebtIncrease: false,
+          assetAmount,
+          upperHint,
+          lowerHint,
+          borrower,
+          recipient,
+          nonce,
+          deadline,
+          signer: bob.wallet,
+          caller: dennis.wallet, // Dennis does not have enough MUSD to repay debt
+          domainName: "BorrowerOperationsSignatures",
+          domainVersion: "1",
+          chainId: (await ethers.provider.getNetwork()).chainId,
+          verifyingContract: addresses.borrowerOperationsSignatures,
+        }
+
+        const value = {
+          collWithdrawal: data.collWithdrawal,
+          debtChange: data.debtChange,
+          isDebtIncrease: data.isDebtIncrease,
+          assetAmount: data.assetAmount,
+          borrower: data.borrower,
+          recipient: data.recipient,
+          nonce: data.nonce,
+          deadline: data.deadline,
+        }
+
+        const domain = {
+          name: data.domainName,
+          version: data.domainVersion,
+          chainId: data.chainId,
+          verifyingContract: data.verifyingContract,
+        }
+
+        const signature = await data.signer.signTypedData(domain, types, value)
+
+        await expect(
+          contracts.borrowerOperationsSignatures
+            .connect(data.caller)
+            .adjustTroveWithSignature(
+              data.collWithdrawal,
+              data.debtChange,
+              data.isDebtIncrease,
+              data.upperHint,
+              data.lowerHint,
+              data.borrower,
+              data.recipient,
+              signature,
+              data.deadline,
+              { value: data.assetAmount },
+            ),
+        ).to.be.revertedWith(
           "BorrowerOps: Caller doesnt have enough mUSD to make repayment",
         )
       })


### PR DESCRIPTION
# Summary

Similar to the issue with `closeTrove`, we have a `require` that checks the borrower's balance but not the caller's.  This PR fixes that to check the caller's balance and adds a corresponding test.