### PR TITLE
Check ICR for Each Trove Before Redeeming

### DIFF
--- a/solidity/contracts/HintHelpers.sol
+++ b/solidity/contracts/HintHelpers.sol
@@ -117,6 +117,11 @@ contract HintHelpers is
         ) {
             _maxIterations--;
 
+            if (troveManager.getCurrentICR(currentTroveuser, _price) < MCR) {
+                currentTroveuser = sortedTrovesCached.getPrev(currentTroveuser);
+                continue;
+            }
+
             // slither-disable-start unused-return
             (
                 uint256 coll,
@@ -159,6 +164,7 @@ contract HintHelpers is
                 remainingMUSD -= netDebt;
             }
 
+            // slither-disable-start write-after-write
             currentTroveuser = sortedTrovesCached.getPrev(currentTroveuser);
         }
         // slither-disable-end calls-loop

--- a/solidity/contracts/TroveManager.sol
+++ b/solidity/contracts/TroveManager.sol
@@ -371,6 +371,12 @@ contract TroveManager is
                 currentBorrower
             );
 
+            // Skip troves with ICR < MCR
+            if (getCurrentICR(currentBorrower, totals.price) < MCR) {
+                currentBorrower = nextUserToCheck;
+                continue;
+            }
+
             SingleRedemptionValues
                 memory singleRedemption = _redeemCollateralFromTrove(
                     contractsCache,

--- a/solidity/contracts/TroveManager.sol
+++ b/solidity/contracts/TroveManager.sol
@@ -399,6 +399,8 @@ contract TroveManager is
                 singleRedemption.principal +
                 singleRedemption.interest;
 
+            // Previous write to this value would hit `continue` statement
+            // slither-disable-next-line write-after-write
             currentBorrower = nextUserToCheck;
         }
         require(

--- a/solidity/test/normal/TroveManager.test.ts
+++ b/solidity/test/normal/TroveManager.test.ts
@@ -2386,6 +2386,59 @@ describe("TroveManager in Normal Mode", () => {
       ).to.equal(0n)
     })
 
+    it.only("doesn't touch Troves with ICR < 110% even if they are out of order in SortedTroves due to interest", async () => {
+      // Open a trove for Alice with a high ICR so we don't go into recovery mode
+      await openTrove(contracts, {
+        musdAmount: "20000",
+        ICR: "500",
+        sender: alice.wallet,
+      })
+
+      // Open a trove for Bob with a lower ICR and no interest
+      await openTrove(contracts, {
+        musdAmount: "2000",
+        ICR: "200",
+        sender: bob.wallet,
+      })
+
+      // Open a trove for Carol with the same ICR as Bob but a high interest rate
+      await setInterestRate(contracts, council, 5000)
+      await openTrove(contracts, {
+        musdAmount: "2000",
+        ICR: "200",
+        sender: carol.wallet,
+      })
+
+      // Open a trove for Dennis with the same ICR as Bob and Carol but no interest
+      await setInterestRate(contracts, council, 0)
+      await openTrove(contracts, {
+        musdAmount: "2000",
+        ICR: "200",
+        sender: dennis.wallet,
+      })
+      // Fast-forward time so that Carol's trove is out of order in the sorted list due to interest
+      await fastForwardTime(365 * 24 * 60 * 60) // 1 year in seconds
+
+      // Drop the price so that Dennis and Bob are at 110% ICR and Carol is below due to interest
+      await dropPrice(contracts, deployer, dennis, to1e18("110"))
+
+      // Attempt a redemption
+      await updateTroveSnapshots(contracts, [bob, carol, dennis], "before")
+      const redemptionAmount = dennis.trove.debt.before + bob.trove.debt.before
+      await performRedemption(contracts, alice, dennis, redemptionAmount)
+
+      // Check that Carol's trove is untouched
+      expect(await checkTroveClosedByRedemption(contracts, carol)).to.equal(
+        false,
+      )
+
+      // Bob and Dennis's troves should be closed by redemption
+      expect(await checkTroveClosedByRedemption(contracts, bob)).to.equal(true)
+      expect(await checkTroveClosedByRedemption(contracts, dennis)).to.equal(
+        true,
+      )
+    })
+
     it("finds the last Trove with ICR == 110% even if there is more than one", async () => {
       // Open 3 troves with the same ICR
       const users = [alice, bob, carol]


### PR DESCRIPTION
# Problem 

After incorporating interest into the system, the ordering of troves in SortedTroves by NICR no longer matches their actual ICR ordering. Previously, this meant redeemCollateral could safely process troves in order, assuming all subsequent troves after a valid one (with ICR ≥ MCR) were also valid. With the updated interest logic (interest excluded from NICR), this assumption no longer holds—so it’s possible for the loop to encounter troves with ICR < MCR after already redeeming against a valid trove.

# Solution

Updated the redeemCollateral loop to check each trove’s ICR on every iteration. The code now skips troves whose ICR falls below MCR, ensuring only eligible troves participate in redemptions regardless of NICR list ordering.

# Testing 

Ensured that the redemption process correctly skips ineligible troves (ICR < MCR) even if they are encountered mid-loop.

# Review Notes

- The approach is straightforward, but please consider potential side effects in any component interacting with trove order or redemption flows.
- Feedback on edge cases or overlooked integration issues is welcome.