### PR TITLE
Emit event for interest rate manager address change

### DIFF
--- a/solidity/contracts/TroveManager.sol
+++ b/solidity/contracts/TroveManager.sol
@@ -253,6 +253,7 @@ contract TroveManager is
         emit CollSurplusPoolAddressChanged(_collSurplusPoolAddress);
         emit DefaultPoolAddressChanged(_defaultPoolAddress);
         emit GasPoolAddressChanged(_gasPoolAddress);
+        emit InterestRateManagerAddressChanged(_interestRateManagerAddress);
         emit MUSDTokenAddressChanged(_musdTokenAddress);
         emit PCVAddressChanged(_pcvAddress);
         emit PriceFeedAddressChanged(_priceFeedAddress);


### PR DESCRIPTION
Closes TET-911

Emit `InterestRateManagerAddressChanged` event from `TroveManager.setAddresses`. This event is already declared, we just missed to emit it.