### PR TITLE
Lock solidity version to 0.8.24

### DIFF
--- a/solidity/contracts/ActivePool.sol
+++ b/solidity/contracts/ActivePool.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/solidity/contracts/BorrowerOperations.sol
+++ b/solidity/contracts/BorrowerOperations.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 

--- a/solidity/contracts/BorrowerOperationsSignatures.sol
+++ b/solidity/contracts/BorrowerOperationsSignatures.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol";

--- a/solidity/contracts/CollSurplusPool.sol
+++ b/solidity/contracts/CollSurplusPool.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 

--- a/solidity/contracts/DefaultPool.sol
+++ b/solidity/contracts/DefaultPool.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/solidity/contracts/GasPool.sol
+++ b/solidity/contracts/GasPool.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 

--- a/solidity/contracts/GovernableVariables.sol
+++ b/solidity/contracts/GovernableVariables.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 

--- a/solidity/contracts/HintHelpers.sol
+++ b/solidity/contracts/HintHelpers.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 

--- a/solidity/contracts/InterestRateManager.sol
+++ b/solidity/contracts/InterestRateManager.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 

--- a/solidity/contracts/PCV.sol
+++ b/solidity/contracts/PCV.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 import "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/solidity/contracts/PriceFeed.sol
+++ b/solidity/contracts/PriceFeed.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 import "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 

--- a/solidity/contracts/SortedTroves.sol
+++ b/solidity/contracts/SortedTroves.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 

--- a/solidity/contracts/StabilityPool.sol
+++ b/solidity/contracts/StabilityPool.sol
@@ -4,7 +4,7 @@
 
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 

--- a/solidity/contracts/TroveManager.sol
+++ b/solidity/contracts/TroveManager.sol
@@ -4,7 +4,7 @@
 
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 

--- a/solidity/contracts/debugging/console.sol
+++ b/solidity/contracts/debugging/console.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // solhint-disable state-visibility
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 // Buidler's helper contract for console logging
 library console {

--- a/solidity/contracts/dependencies/BaseMath.sol
+++ b/solidity/contracts/dependencies/BaseMath.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 contract BaseMath {
     uint256 public constant DECIMAL_PRECISION = 1e18;

--- a/solidity/contracts/dependencies/CheckContract.sol
+++ b/solidity/contracts/dependencies/CheckContract.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 contract CheckContract {
     /**

--- a/solidity/contracts/dependencies/InterestRateMath.sol
+++ b/solidity/contracts/dependencies/InterestRateMath.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 library InterestRateMath {
     // https://sibenotes.com/maths/how-many-seconds-are-in-a-year/

--- a/solidity/contracts/dependencies/LiquityBase.sol
+++ b/solidity/contracts/dependencies/LiquityBase.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 import "./BaseMath.sol";
 import "./InterestRateMath.sol";

--- a/solidity/contracts/dependencies/LiquityMath.sol
+++ b/solidity/contracts/dependencies/LiquityMath.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 library LiquityMath {
     /* Precision for Nominal ICR (independent of price). Rationale for the value:

--- a/solidity/contracts/dependencies/SendCollateral.sol
+++ b/solidity/contracts/dependencies/SendCollateral.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 contract SendCollateral {
     /**

--- a/solidity/contracts/echidna/BorrowerOperationsFuzzTester.sol
+++ b/solidity/contracts/echidna/BorrowerOperationsFuzzTester.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 import "../BorrowerOperations.sol";
 import "./IBorrowerOperationsFuzzTester.sol";

--- a/solidity/contracts/echidna/EchidnaProxy.sol
+++ b/solidity/contracts/echidna/EchidnaProxy.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 import "../TroveManager.sol";
 import "../BorrowerOperations.sol";

--- a/solidity/contracts/echidna/EchidnaTest.sol
+++ b/solidity/contracts/echidna/EchidnaTest.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 import "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
 import "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";

--- a/solidity/contracts/echidna/IBorrowerOperationsFuzzTester.sol
+++ b/solidity/contracts/echidna/IBorrowerOperationsFuzzTester.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 import "../interfaces/IBorrowerOperations.sol";
 

--- a/solidity/contracts/echidna/ITroveManagerFuzzTester.sol
+++ b/solidity/contracts/echidna/ITroveManagerFuzzTester.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 import "../interfaces/ITroveManager.sol";
 

--- a/solidity/contracts/echidna/TroveManagerFuzzTester.sol
+++ b/solidity/contracts/echidna/TroveManagerFuzzTester.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 import "../TroveManager.sol";
 import "./ITroveManagerFuzzTester.sol";

--- a/solidity/contracts/interfaces/ChainlinkAggregatorV3Interface.sol
+++ b/solidity/contracts/interfaces/ChainlinkAggregatorV3Interface.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 interface ChainlinkAggregatorV3Interface {
     function decimals() external view returns (uint8);

--- a/solidity/contracts/interfaces/IActivePool.sol
+++ b/solidity/contracts/interfaces/IActivePool.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 import "./IPool.sol";
 

--- a/solidity/contracts/interfaces/IApproveAndCall.sol
+++ b/solidity/contracts/interfaces/IApproveAndCall.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 /// @notice An interface that should be implemented by tokens supporting
 ///         `approveAndCall`/`receiveApproval` pattern.

--- a/solidity/contracts/interfaces/IBorrowerOperations.sol
+++ b/solidity/contracts/interfaces/IBorrowerOperations.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 // Common interface for the Trove Manager.
 interface IBorrowerOperations {

--- a/solidity/contracts/interfaces/IBorrowerOperationsSignatures.sol
+++ b/solidity/contracts/interfaces/IBorrowerOperationsSignatures.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 interface IBorrowerOperationsSignatures {
     function setAddresses(

--- a/solidity/contracts/interfaces/ICollSurplusPool.sol
+++ b/solidity/contracts/interfaces/ICollSurplusPool.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 interface ICollSurplusPool {
     // --- Events ---

--- a/solidity/contracts/interfaces/IDefaultPool.sol
+++ b/solidity/contracts/interfaces/IDefaultPool.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 import "./IPool.sol";
 

--- a/solidity/contracts/interfaces/IGasPool.sol
+++ b/solidity/contracts/interfaces/IGasPool.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 interface IGasPool {
     // --- Events ---

--- a/solidity/contracts/interfaces/IGovernableVariables.sol
+++ b/solidity/contracts/interfaces/IGovernableVariables.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 interface IGovernableVariables {
     event FeeExemptAccountAdded(address _account);

--- a/solidity/contracts/interfaces/IHintHelpers.sol
+++ b/solidity/contracts/interfaces/IHintHelpers.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 interface IHintHelpers {
     // --- Events --

--- a/solidity/contracts/interfaces/IInterestRateManager.sol
+++ b/solidity/contracts/interfaces/IInterestRateManager.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 interface IInterestRateManager {
     struct InterestRateInfo {

--- a/solidity/contracts/interfaces/ILiquityBase.sol
+++ b/solidity/contracts/interfaces/ILiquityBase.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 import "./IPriceFeed.sol";
 

--- a/solidity/contracts/interfaces/IPCV.sol
+++ b/solidity/contracts/interfaces/IPCV.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "../token/IMUSD.sol";

--- a/solidity/contracts/interfaces/IPool.sol
+++ b/solidity/contracts/interfaces/IPool.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 // Common interface for the Pools.
 interface IPool {

--- a/solidity/contracts/interfaces/IPriceFeed.sol
+++ b/solidity/contracts/interfaces/IPriceFeed.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 interface IPriceFeed {
     // --- Events ---

--- a/solidity/contracts/interfaces/IReceiveApproval.sol
+++ b/solidity/contracts/interfaces/IReceiveApproval.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 /// @notice An interface that should be implemented by contracts supporting
 ///         `approveAndCall`/`receiveApproval` pattern.

--- a/solidity/contracts/interfaces/ISortedTroves.sol
+++ b/solidity/contracts/interfaces/ISortedTroves.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 // Common interface for the SortedTroves Doubly Linked List.
 interface ISortedTroves {

--- a/solidity/contracts/interfaces/IStabilityPool.sol
+++ b/solidity/contracts/interfaces/IStabilityPool.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 /*
  * The Stability Pool holds mUSD tokens deposited by Stability Pool depositors.

--- a/solidity/contracts/interfaces/ITroveManager.sol
+++ b/solidity/contracts/interfaces/ITroveManager.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 import "./IStabilityPool.sol";
 import "./IPCV.sol";

--- a/solidity/contracts/tests/InterestRateManagerTester.sol
+++ b/solidity/contracts/tests/InterestRateManagerTester.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 import "../InterestRateManager.sol";
 

--- a/solidity/contracts/tests/MUSDTester.sol
+++ b/solidity/contracts/tests/MUSDTester.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 import "../token/MUSD.sol";
 

--- a/solidity/contracts/tests/MockAggregator.sol
+++ b/solidity/contracts/tests/MockAggregator.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 import "../interfaces/ChainlinkAggregatorV3Interface.sol";
 

--- a/solidity/contracts/tests/TroveManagerTester.sol
+++ b/solidity/contracts/tests/TroveManagerTester.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 import "../TroveManager.sol";
 

--- a/solidity/contracts/tests/upgrades/ActivePoolV2.sol
+++ b/solidity/contracts/tests/upgrades/ActivePoolV2.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 import "../../ActivePool.sol";
 

--- a/solidity/contracts/tests/upgrades/BorrowerOperationsSignaturesV2.sol
+++ b/solidity/contracts/tests/upgrades/BorrowerOperationsSignaturesV2.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 import "../../BorrowerOperationsSignatures.sol";
 

--- a/solidity/contracts/tests/upgrades/BorrowerOperationsV2.sol
+++ b/solidity/contracts/tests/upgrades/BorrowerOperationsV2.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 import "../../BorrowerOperations.sol";
 

--- a/solidity/contracts/tests/upgrades/CollSurplusPoolV2.sol
+++ b/solidity/contracts/tests/upgrades/CollSurplusPoolV2.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 import "../../CollSurplusPool.sol";
 

--- a/solidity/contracts/tests/upgrades/DefaultPoolV2.sol
+++ b/solidity/contracts/tests/upgrades/DefaultPoolV2.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 import "../../DefaultPool.sol";
 

--- a/solidity/contracts/tests/upgrades/GasPoolV2.sol
+++ b/solidity/contracts/tests/upgrades/GasPoolV2.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 import "../../GasPool.sol";
 

--- a/solidity/contracts/tests/upgrades/GovernableVariablesV2.sol
+++ b/solidity/contracts/tests/upgrades/GovernableVariablesV2.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 import "../../GovernableVariables.sol";
 

--- a/solidity/contracts/tests/upgrades/HintHelpersV2.sol
+++ b/solidity/contracts/tests/upgrades/HintHelpersV2.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 import "../../HintHelpers.sol";
 

--- a/solidity/contracts/tests/upgrades/InterestRateManagerV2.sol
+++ b/solidity/contracts/tests/upgrades/InterestRateManagerV2.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 import "../../InterestRateManager.sol";
 

--- a/solidity/contracts/tests/upgrades/PCVv2.sol
+++ b/solidity/contracts/tests/upgrades/PCVv2.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 import "../../PCV.sol";
 

--- a/solidity/contracts/tests/upgrades/PriceFeedV2.sol
+++ b/solidity/contracts/tests/upgrades/PriceFeedV2.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 import "../../PriceFeed.sol";
 

--- a/solidity/contracts/tests/upgrades/SortedTrovesV2.sol
+++ b/solidity/contracts/tests/upgrades/SortedTrovesV2.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 import "../../SortedTroves.sol";
 

--- a/solidity/contracts/tests/upgrades/StabilityPoolV2.sol
+++ b/solidity/contracts/tests/upgrades/StabilityPoolV2.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 import "../../StabilityPool.sol";
 

--- a/solidity/contracts/tests/upgrades/TroveManagerV2.sol
+++ b/solidity/contracts/tests/upgrades/TroveManagerV2.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 import "../../TroveManager.sol";
 

--- a/solidity/contracts/token/IMUSD.sol
+++ b/solidity/contracts/token/IMUSD.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Permit.sol";

--- a/solidity/contracts/token/MUSD.sol
+++ b/solidity/contracts/token/MUSD.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";

--- a/solidity/contracts/token/TokenDeployer.sol
+++ b/solidity/contracts/token/TokenDeployer.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 import "./MUSD.sol";
 


### PR DESCRIPTION
This is a standard procedure before deploying contracts to mainnet. We want to pin to the very specific version we are sure those contracts work well with. This version has to be aligned with the one set in HH compiler settings.