### PR TITLE
Add migration documentation

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,0 +1,80 @@
+# Contract Migration Guide
+
+## Summary
+
+This guide describes the process for migrating to an entirely new set of contracts while keeping the old contract set in place.
+The end result will be two sets of contracts both connected to the same MUSD token contract.  Trove operations can be performed
+on both new and old contract sets simultaneously.
+
+## 1. Contract Code Preparation
+- Prepare new contract code
+- Same contract names in Solidity code are fine
+
+## 2. Deployment Strategy
+- Create new deployment scripts starting at `100_` to avoid conflicts with existing deployments
+- Skip MUSD and TokenDeployer as we will be reusing those contracts.
+- Either skip PriceFeed or update the old contracts to use a new PriceFeed.  There is no need for multiple PriceFeed contracts.
+- If you have the same .sol filename, you can give the contract a different name for deployment like this:
+```typescript
+const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
+  const { getOrDeployProxy } = await setupDeploymentBoilerplate(hre)
+  await getOrDeployProxy("NewBorrowerOperations", {
+    contractName: "BorrowerOperations",
+  })
+}
+```
+
+## 3. Setting Contract Addresses
+- Modify or add a new `fetchAllDeployedContracts` helper to get new contract addresses.  For example:
+```typescript
+export async function newFetchAllDeployedContracts(
+  isHardhatNetwork: boolean,
+  isFuzzTestingNetwork: boolean,
+) {
+  const activePool: ActivePool = await getDeployedContract("NewActivePool")
+  // Rest of the function follows the same pattern of replacing the contract names...
+```
+- Example address setting script with a `newFetchAllDeployedContracts` that gets our new versions of each contract:
+```typescript
+const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
+  const { execute, isHardhatNetwork, isFuzzTestingNetwork } =
+    await setupDeploymentBoilerplate(hre)
+
+  const { borrowerOperations, sortedTroves, troveManager } =
+    await newFetchAllDeployedContracts(isHardhatNetwork, isFuzzTestingNetwork)
+
+  await execute(
+    "NewHintHelpers",
+    "setAddresses",
+    await borrowerOperations.getAddress(),
+    await sortedTroves.getAddress(),
+    await troveManager.getAddress(),
+  )
+}
+```
+
+## 4. MUSD System Contract Update
+- Create script `200_set_new_contracts_in_musd.ts`
+- Use `setSystemContracts` to add new contracts to MUSD:
+```typescript
+await execute(
+  "MUSD",
+  "setSystemContracts",
+  await troveManager.getAddress(),
+  await stabilityPool.getAddress(),
+  await borrowerOperations.getAddress(),
+  await interestRateManager.getAddress(),
+)
+```
+
+## 5. PCV Initialization
+- Call `initializeDebt` on new PCV contract if creating new bootstrap loan
+
+## 6. Testing Steps
+- Verify system contracts are added by checking MUSD's `mintList` and `burnList`
+    - Both old and new contract addresses should return `true`
+- Test `openTrove` and other Trove operations against new BorrowerOperations and TroveManager
+
+## 7. Network Considerations
+- This process is for testnet deployment
+- Mainnet deployments may have different deployer accounts and configurations


### PR DESCRIPTION
# Summary

I went through the process of performing a contract migration on testnet and wrote up a guide on how to do so in the future.  Initially, I was hoping to have some reusable scripts for the future but because migrations involve significant changes to the codebase (such that we can't accomplish the changes with an upgrade), it's not really clear that those *exact* scripts will be useful.  In the interest of not bloating the codebase, I excluded them and opted instead for documenting the process.

# Details

1) Deployed a fresh set of the latest contracts, opened some troves and added collateral to a few. Ex: https://explorer.test.mezo.org/tx/0xff189d3d408d44f981708e7d29232359ec3d946c5420e7615c247f3a7b69e5e2 
This is using the BorrowerOperations at 0x1F7ec18f62BddDf65e651eCd44983407054EeA4a. 

2) Deployed another set of contracts and wired them up. Checked the mint/burn list to make sure they were added, then opened some troves on the old set to make sure we didn't break anything. Example: https://explorer.test.mezo.org/tx/0x6519b32b2c54dee7a79f6d18250e7dbd4e0a66b26b85cb1cfb2e4e7de567602a 
Note we're still using the BorrowerOperations at 0x1F7ec18f62BddDf65e651eCd44983407054EeA4a. 

3) Opened some troves on the new set of contracts. Example: https://explorer.test.mezo.org/tx/0x87a06ffdf78007e96dba1fac847144ba4e71c56b7dfa39fe66f2a627408c9ffa You'll see we're now using a different BorrowerOperations contract at 0x5A5dbAA2e97C48cE2De73356CC55D8B51a6F85cE. 

To summarize, we did it! We can perform trove operations against two sets of contracts simultaneously using the same MUSD contract (I also kept the PriceFeed the same since we'd never want two).

I will try to clean up the branch a bit and see if there is anything we can reuse from the deployment scripts.  In practice the deployment process for a migration will likely be different so it may be that we just need the validation this is possible.  I have the "results" in the form of scale testing output here:

Old contract initial open trove: https://github.com/mezo-org/musd/blob/migration-test-TET-618/solidity/scale-testing/results/open-troves-test-2025-05-08T20-12-02.988Z.json
Old contract initial addColl: https://github.com/mezo-org/musd/blob/migration-test-TET-618/solidity/scale-testing/results/add-collateral-test-2025-05-08T20-13-07.750Z.json
Old contract second open trove (after deploying new set): https://github.com/mezo-org/musd/blob/migration-test-TET-618/solidity/scale-testing/results/open-troves-test-2025-05-08T21-05-07.864Z.json
New contract open trove: https://github.com/mezo-org/musd/blob/migration-test-TET-618/solidity/scale-testing/results/new-open-troves-test-2025-05-08T21-06-39.386Z.json

# Review Notes

Let met know if anything seems to be missing or if any portion needs more detail. 