### PR TITLE
SPDX license identifier cleanup

### DIFF
--- a/solidity/contracts/BorrowerOperationsSignatures.sol
+++ b/solidity/contracts/BorrowerOperationsSignatures.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: GPL-3.0
 
 pragma solidity 0.8.24;
 

--- a/solidity/contracts/GovernableVariables.sol
+++ b/solidity/contracts/GovernableVariables.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: GPL-3.0
 
 pragma solidity 0.8.24;
 

--- a/solidity/contracts/PCV.sol
+++ b/solidity/contracts/PCV.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: GPL-3.0
 
 pragma solidity 0.8.24;
 

--- a/solidity/contracts/echidna/BorrowerOperationsFuzzTester.sol
+++ b/solidity/contracts/echidna/BorrowerOperationsFuzzTester.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: GPL-3.0
 
 pragma solidity 0.8.24;
 

--- a/solidity/contracts/echidna/EchidnaProxy.sol
+++ b/solidity/contracts/echidna/EchidnaProxy.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: GPL-3.0
 
 pragma solidity 0.8.24;
 

--- a/solidity/contracts/echidna/EchidnaTest.sol
+++ b/solidity/contracts/echidna/EchidnaTest.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: GPL-3.0
 
 pragma solidity 0.8.24;
 

--- a/solidity/contracts/echidna/IBorrowerOperationsFuzzTester.sol
+++ b/solidity/contracts/echidna/IBorrowerOperationsFuzzTester.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: GPL-3.0
 
 pragma solidity 0.8.24;
 

--- a/solidity/contracts/echidna/ITroveManagerFuzzTester.sol
+++ b/solidity/contracts/echidna/ITroveManagerFuzzTester.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: GPL-3.0
 
 pragma solidity 0.8.24;
 

--- a/solidity/contracts/echidna/TroveManagerFuzzTester.sol
+++ b/solidity/contracts/echidna/TroveManagerFuzzTester.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: GPL-3.0
 
 pragma solidity 0.8.24;
 

--- a/solidity/contracts/interfaces/IGovernableVariables.sol
+++ b/solidity/contracts/interfaces/IGovernableVariables.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: GPL-3.0
 
 pragma solidity 0.8.24;
 

--- a/solidity/contracts/tests/upgrades/ActivePoolV2.sol
+++ b/solidity/contracts/tests/upgrades/ActivePoolV2.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: GPL-3.0
 
 pragma solidity 0.8.24;
 

--- a/solidity/contracts/tests/upgrades/BorrowerOperationsSignaturesV2.sol
+++ b/solidity/contracts/tests/upgrades/BorrowerOperationsSignaturesV2.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: GPL-3.0
 
 pragma solidity 0.8.24;
 

--- a/solidity/contracts/tests/upgrades/BorrowerOperationsV2.sol
+++ b/solidity/contracts/tests/upgrades/BorrowerOperationsV2.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: GPL-3.0
 
 pragma solidity 0.8.24;
 

--- a/solidity/contracts/tests/upgrades/CollSurplusPoolV2.sol
+++ b/solidity/contracts/tests/upgrades/CollSurplusPoolV2.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: GPL-3.0
 
 pragma solidity 0.8.24;
 

--- a/solidity/contracts/tests/upgrades/DefaultPoolV2.sol
+++ b/solidity/contracts/tests/upgrades/DefaultPoolV2.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: GPL-3.0
 
 pragma solidity 0.8.24;
 

--- a/solidity/contracts/tests/upgrades/GasPoolV2.sol
+++ b/solidity/contracts/tests/upgrades/GasPoolV2.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: GPL-3.0
 
 pragma solidity 0.8.24;
 

--- a/solidity/contracts/tests/upgrades/GovernableVariablesV2.sol
+++ b/solidity/contracts/tests/upgrades/GovernableVariablesV2.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: GPL-3.0
 
 pragma solidity 0.8.24;
 

--- a/solidity/contracts/tests/upgrades/HintHelpersV2.sol
+++ b/solidity/contracts/tests/upgrades/HintHelpersV2.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: GPL-3.0
 
 pragma solidity 0.8.24;
 

--- a/solidity/contracts/tests/upgrades/InterestRateManagerV2.sol
+++ b/solidity/contracts/tests/upgrades/InterestRateManagerV2.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: GPL-3.0
 
 pragma solidity 0.8.24;
 

--- a/solidity/contracts/tests/upgrades/PCVv2.sol
+++ b/solidity/contracts/tests/upgrades/PCVv2.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: GPL-3.0
 
 pragma solidity 0.8.24;
 

--- a/solidity/contracts/tests/upgrades/PriceFeedV2.sol
+++ b/solidity/contracts/tests/upgrades/PriceFeedV2.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: GPL-3.0
 
 pragma solidity 0.8.24;
 

--- a/solidity/contracts/tests/upgrades/SortedTrovesV2.sol
+++ b/solidity/contracts/tests/upgrades/SortedTrovesV2.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: GPL-3.0
 
 pragma solidity 0.8.24;
 

--- a/solidity/contracts/tests/upgrades/StabilityPoolV2.sol
+++ b/solidity/contracts/tests/upgrades/StabilityPoolV2.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: GPL-3.0
 
 pragma solidity 0.8.24;
 

--- a/solidity/contracts/tests/upgrades/TroveManagerV2.sol
+++ b/solidity/contracts/tests/upgrades/TroveManagerV2.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: GPL-3.0
 
 pragma solidity 0.8.24;
 

--- a/solidity/contracts/token/IMUSD.sol
+++ b/solidity/contracts/token/IMUSD.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: GPL-3.0
 
 pragma solidity 0.8.24;
 

--- a/solidity/contracts/token/MUSD.sol
+++ b/solidity/contracts/token/MUSD.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-License-Identifier: GPL-3.0
 
 pragma solidity 0.8.24;
 

--- a/solidity/contracts/token/TokenDeployer.sol
+++ b/solidity/contracts/token/TokenDeployer.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: GPL-3.0
 
 pragma solidity 0.8.24;
 


### PR DESCRIPTION
All contracts marked in liquity and thUSD as MIT-licensed remain as such. All new contracts added during MUSD development are marked as GPL-3.0, according to the LICENSE.

Closes TET-935