### PR TITLE
Update semantic versioning to 1.0.0

### DIFF
--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "contracts",
-  "version": "0.1.0",
+  "name": "musd-contracts",
+  "version": "1.0.0",
   "packageManager": "pnpm@8.13.1",
   "license": "GPL-3.0",
   "scripts": {


### PR DESCRIPTION
This PR bumps the semantic version for MUSD up to `1.0.0`. We also change the package name to `musd-contracts` so we don't conflict with https://www.npmjs.com/package/@mezo-org/contracts

Tagging @rwatts07 for review

refs TET-943