### PR TITLE
Bump to 1.0.1, Fixing the Readme

### DIFF
--- a/solidity/README.md
+++ b/solidity/README.md
@@ -67,17 +67,10 @@ detailed in `.env.example`.
 pnpm run deploy
 ```
 
-**Sepolia**
+**matsnet**
 
 To deploy contracts on Sepolia run:
 
 ```
-$ pnpm run deploy --network sepolia
+$ pnpm run deploy --network matsnet
 ```
-
-Or, alternatively, manually trigger the [`Solidity`
-workflow](https://github.com/thesis/mezo-portal/actions/workflows/solidity.yml)
-(this will not only deploy the contracts, but also update the values of
-`TBTC_CONTRACT_ADDRESS`, `WBTC_CONTRACT_ADDRESS` and `PORTAL_CONTRACT_ADDRESS`
-environment variables in the settings of Netlify builds deploying dApp and its
-previews).

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "musd-contracts",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "packageManager": "pnpm@8.13.1",
   "license": "GPL-3.0",
   "scripts": {


### PR DESCRIPTION
Trim some fat at the bottom of the readme and improve the network deployment example