### PR TITLE
Setting package name to @mezo-org/musd-contracts and version to 1.0.0

### DIFF
--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "musd-contracts",
-  "version": "1.0.1",
+  "name": "@mezo-org/musd-contracts",
+  "version": "1.0.0",
   "packageManager": "pnpm@8.13.1",
   "license": "GPL-3.0",
   "scripts": {


### PR DESCRIPTION
We should publish under the @mezo-org and given the package was not previously published under @mezo-org we can set version back to v1.0.0, tag it properly on the main branch, and publish as a new package.