### PR TITLE
Version 1.0.1

### DIFF
--- a/solidity/artifacts/package.json
+++ b/solidity/artifacts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mezo-org/musd-contracts",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "GPL-3.0",
   "files": [
     "deployments/"

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mezo-org/musd",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "packageManager": "pnpm@8.13.1",
   "license": "GPL-3.0",
   "private": "true",


### PR DESCRIPTION
1.0.1 adds no new functionalities compared to 1.0.0. It adds the recent testnet deployment artifacts and fixes the `openTrove` documentation in the README.

This version was already published to the NPM registry as [`@mezo-org/musd-contracts@1.0.1`](https://www.npmjs.com/package/@mezo-org/musd-contracts/v/1.0.1).