### PR TITLE
Update Trove Updated

### DIFF
--- a/solidity/contracts/interfaces/IBorrowerOperations.sol
+++ b/solidity/contracts/interfaces/IBorrowerOperations.sol
@@ -45,7 +45,7 @@ interface IBorrowerOperations {
         uint256 _interest,
         uint256 _coll,
         uint256 _stake,
-        uint256 _interestRate,
+        uint16 _interestRate,
         uint256 _lastInterestUpdateTime,
         uint8 _operation
     );

--- a/solidity/contracts/interfaces/IBorrowerOperations.sol
+++ b/solidity/contracts/interfaces/IBorrowerOperations.sol
@@ -44,8 +44,10 @@ interface IBorrowerOperations {
         uint256 _principal,
         uint256 _interest,
         uint256 _coll,
-        uint256 stake,
-        uint8 operation
+        uint256 _stake,
+        uint256 _interestRate,
+        uint256 _lastInterestUpdateTime,
+        uint8 _operation
     );
     event BorrowingFeePaid(address indexed _borrower, uint256 _fee);
     event RefinancingFeePaid(address indexed _borrower, uint256 _fee);

--- a/solidity/contracts/interfaces/ITroveManager.sol
+++ b/solidity/contracts/interfaces/ITroveManager.sol
@@ -56,8 +56,10 @@ interface ITroveManager {
         uint256 _principal,
         uint256 _interest,
         uint256 _coll,
-        uint256 stake,
-        uint8 operation
+        uint256 _stake,
+        uint256 _interestRate,
+        uint256 _lastInterestUpdateTime,
+        uint8 _operation
     );
     event TroveLiquidated(
         address indexed _borrower,

--- a/solidity/contracts/interfaces/ITroveManager.sol
+++ b/solidity/contracts/interfaces/ITroveManager.sol
@@ -57,7 +57,7 @@ interface ITroveManager {
         uint256 _interest,
         uint256 _coll,
         uint256 _stake,
-        uint256 _interestRate,
+        uint16 _interestRate,
         uint256 _lastInterestUpdateTime,
         uint8 _operation
     );

--- a/solidity/hardhat.config.ts
+++ b/solidity/hardhat.config.ts
@@ -187,7 +187,11 @@ const config: HardhatUserConfig = {
     alphaSort: true,
     runOnCompile: true,
     strict: true,
-    except: ["EchidnaTest", "BorrowerOperationsV2"],
+    except: [
+      "EchidnaTest",
+      "BorrowerOperationsV2",
+      "BorrowerOperationsFuzzTester",
+    ],
   },
   gasReporter: {
     enabled: true,

--- a/solidity/test/helpers/abi.ts
+++ b/solidity/test/helpers/abi.ts
@@ -1,5 +1,5 @@
 export const TROVE_UPDATED_ABI = [
-  "event TroveUpdated(address indexed _borrower, uint256 _principal, uint256 _interest, uint256 _coll, uint256 _stake, uint256 _interestRate, uint256 _lastInterestUpdateTime, uint8 _operation)",
+  "event TroveUpdated(address indexed _borrower, uint256 _principal, uint256 _interest, uint256 _coll, uint256 _stake, uint16 _interestRate, uint256 _lastInterestUpdateTime, uint8 _operation)",
 ]
 
 export const LIQUIDATION_ABI = [

--- a/solidity/test/helpers/abi.ts
+++ b/solidity/test/helpers/abi.ts
@@ -1,5 +1,5 @@
 export const TROVE_UPDATED_ABI = [
-  "event TroveUpdated(address indexed borrower, uint256 principal, uint256 interest, uint256 coll, uint256 stake, uint8 operation)",
+  "event TroveUpdated(address indexed _borrower, uint256 _principal, uint256 _interest, uint256 _coll, uint256 _stake, uint256 _interestRate, uint256 _lastInterestUpdateTime, uint8 _operation)",
 ]
 
 export const LIQUIDATION_ABI = [

--- a/solidity/types/dotenv-safer.d.ts
+++ b/solidity/types/dotenv-safer.d.ts
@@ -1,0 +1,1 @@
+declare module "dotenv-safer"


### PR DESCRIPTION
Our `TroveUpdated` event did not include either the interest rate on the trove or when interest last accrued. This made it tricky to keep track of trove state off-chain (especially for the purposes of writing a liquidation bot).

Tagging @rwatts07 for review.