### PR TITLE
Upgrade TroveManager and BorrowerOperations

### DIFF
--- a/solidity/deploy/32_upgrade_borrower_operations.ts
+++ b/solidity/deploy/32_upgrade_borrower_operations.ts
@@ -19,12 +19,10 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
     `prepared transaction: ${JSON.stringify(preparedTransaction)}`,
   )
 
-  if (["mainnet", "matsnet"].includes(hre.network.name)) {
-    return
+  if (hre.network.name !== "mainnet") {
+    deployments.log("Sending transaction to upgrade implementation...")
+    await deployer.sendTransaction(preparedTransaction)
   }
-
-  deployments.log("Sending transaction to upgrade implementation...")
-  await deployer.sendTransaction(preparedTransaction)
 
   if (hre.network.tags.etherscan) {
     // We use `verify` instead of `verify:verify` as the `verify` task is defined

--- a/solidity/deploy/32_upgrade_borrower_operations.ts
+++ b/solidity/deploy/32_upgrade_borrower_operations.ts
@@ -1,0 +1,45 @@
+import type { HardhatRuntimeEnvironment } from "hardhat/types"
+import type { DeployFunction } from "hardhat-deploy/types"
+
+const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
+  const { helpers, deployments } = hre
+
+  const { deployer } = await helpers.signers.getNamedSigners()
+
+  const { newImplementationAddress, preparedTransaction } =
+    await helpers.upgrades.prepareProxyUpgrade(
+      "BorrowerOperations",
+      "BorrowerOperations",
+      {
+        contractName: "contracts/BorrowerOperations.sol:BorrowerOperations",
+      },
+    )
+
+  deployments.log(
+    `prepared transaction: ${JSON.stringify(preparedTransaction)}`,
+  )
+
+  if (["mainnet", "matsnet"].includes(hre.network.name)) {
+    return
+  }
+
+  deployments.log("Sending transaction to upgrade implementation...")
+  await deployer.sendTransaction(preparedTransaction)
+
+  if (hre.network.tags.etherscan) {
+    // We use `verify` instead of `verify:verify` as the `verify` task is defined
+    // in "@openzeppelin/hardhat-upgrades" to verify the proxy’s implementation
+    // contract, the proxy itself and any proxy-related contracts, as well as
+    // link the proxy to the implementation contract’s ABI on (Ether)scan.
+    await hre.run("verify", {
+      address: newImplementationAddress,
+    })
+  }
+}
+
+export default func
+
+func.tags = ["UpgradeBorrowerOperations"]
+
+// Comment this line when running an upgrade.
+func.skip = async () => true

--- a/solidity/deploy/33_upgrade_trove_manager.ts
+++ b/solidity/deploy/33_upgrade_trove_manager.ts
@@ -15,12 +15,10 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
     `prepared transaction: ${JSON.stringify(preparedTransaction)}`,
   )
 
-  if (["mainnet", "matsnet"].includes(hre.network.name)) {
-    return
+  if (hre.network.name !== "mainnet") {
+    deployments.log("Sending transaction to upgrade implementation...")
+    await deployer.sendTransaction(preparedTransaction)
   }
-
-  deployments.log("Sending transaction to upgrade implementation...")
-  await deployer.sendTransaction(preparedTransaction)
 
   if (hre.network.tags.etherscan) {
     // We use `verify` instead of `verify:verify` as the `verify` task is defined

--- a/solidity/deploy/33_upgrade_trove_manager.ts
+++ b/solidity/deploy/33_upgrade_trove_manager.ts
@@ -1,0 +1,41 @@
+import type { HardhatRuntimeEnvironment } from "hardhat/types"
+import type { DeployFunction } from "hardhat-deploy/types"
+
+const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
+  const { helpers, deployments } = hre
+
+  const { deployer } = await helpers.signers.getNamedSigners()
+
+  const { newImplementationAddress, preparedTransaction } =
+    await helpers.upgrades.prepareProxyUpgrade("TroveManager", "TroveManager", {
+      contractName: "contracts/TroveManager.sol:TroveManager",
+    })
+
+  deployments.log(
+    `prepared transaction: ${JSON.stringify(preparedTransaction)}`,
+  )
+
+  if (["mainnet", "matsnet"].includes(hre.network.name)) {
+    return
+  }
+
+  deployments.log("Sending transaction to upgrade implementation...")
+  await deployer.sendTransaction(preparedTransaction)
+
+  if (hre.network.tags.etherscan) {
+    // We use `verify` instead of `verify:verify` as the `verify` task is defined
+    // in "@openzeppelin/hardhat-upgrades" to verify the proxy’s implementation
+    // contract, the proxy itself and any proxy-related contracts, as well as
+    // link the proxy to the implementation contract’s ABI on (Ether)scan.
+    await hre.run("verify", {
+      address: newImplementationAddress,
+    })
+  }
+}
+
+export default func
+
+func.tags = ["UpgradeTroveManager"]
+
+// Comment this line when running an upgrade.
+func.skip = async () => true


### PR DESCRIPTION
depends on #231 

This PR adds deployment scripts to upgrade trove manager and borrower operations, based on a similar script in portal: https://github.com/thesis/mezo-portal/blob/main/solidity/deploy/08_upgrade_portal.ts

I'm not sure how to test this, but open to ideas!

Tagging @rwatts07 for review (cc @pdyraga)