### PR TITLE
Fill In Echidna Gaps

### DIFF
--- a/solidity/contracts/BorrowerOperations.sol
+++ b/solidity/contracts/BorrowerOperations.sol
@@ -808,7 +808,6 @@ contract BorrowerOperations is
                 (msg.sender == stabilityPoolAddress &&
                     msg.value > 0 &&
                     _mUSDChange == 0) ||
-                msg.sender == address(this) ||
                 msg.sender == borrowerOperationsSignaturesAddress
         );
 

--- a/solidity/contracts/TroveManager.sol
+++ b/solidity/contracts/TroveManager.sol
@@ -470,12 +470,6 @@ contract TroveManager is
         return _addTroveOwnerToArray(_borrower);
     }
 
-    function applyPendingRewards(address _borrower) external override {
-        _requireCallerIsBorrowerOperations();
-
-        return _applyPendingRewards(activePool, defaultPool, _borrower);
-    }
-
     function closeTrove(address _borrower) external override {
         _requireCallerIsBorrowerOperations();
         return _closeTrove(_borrower, Status.closedByOwner);

--- a/solidity/contracts/echidna/EchidnaTest.sol
+++ b/solidity/contracts/echidna/EchidnaTest.sol
@@ -470,7 +470,8 @@ contract EchidnaTest {
         uint musdAmount = 1800e18 + addedMUSD;
         uint collatRatio = 110 + (_collatRatio % 1000);
         uint price = priceFeed.fetchPrice();
-        uint amountWithFees = musdAmount + musdAmount / 1000 + 200e18;
+        uint fee = borrowerOperations.getBorrowingFee(musdAmount);
+        uint amountWithFees = musdAmount + fee + 200e18;
 
         uint BTC = (amountWithFees * collatRatio * 1e18) / (100 * price);
 

--- a/solidity/contracts/echidna/EchidnaTest.sol
+++ b/solidity/contracts/echidna/EchidnaTest.sol
@@ -877,6 +877,22 @@ contract EchidnaTest {
     ) external {
         pcv.removeRecipientsFromWhitelist(_accounts);
     }
+
+    function startChangingRolesExt(
+        address _council,
+        address _treasury
+    ) external {
+        pcv.startChangingRoles(_council, _treasury);
+    }
+
+    function cancelChangingRolesExt() external {
+        pcv.cancelChangingRoles();
+    }
+
+    function finalizeChangingRoles() external {
+        pcv.finalizeChangingRoles();
+    }
+
     // Governable Variables
 
     function gvStartChangingRolesExt(

--- a/solidity/contracts/echidna/EchidnaTest.sol
+++ b/solidity/contracts/echidna/EchidnaTest.sol
@@ -470,7 +470,7 @@ contract EchidnaTest {
         uint musdAmount = 1800e18 + addedMUSD;
         uint collatRatio = 110 + (_collatRatio % 1000);
         uint price = priceFeed.fetchPrice();
-        uint amountWithFees = musdAmount + musdAmount / 200 + 200e18;
+        uint amountWithFees = musdAmount + musdAmount / 1000 + 200e18;
 
         uint BTC = (amountWithFees * collatRatio * 1e18) / (100 * price);
 

--- a/solidity/contracts/echidna/EchidnaTest.sol
+++ b/solidity/contracts/echidna/EchidnaTest.sol
@@ -670,6 +670,30 @@ contract EchidnaTest {
         borrowerOperations.proposeMinNetDebt(_minNetDebt);
     }
 
+    function proposeBorrowingRateExt(uint256 _rate) external {
+        borrowerOperations.proposeBorrowingRate(_rate);
+    }
+
+    function proposeBorrowingRateSafeExt(uint256 _rate) external {
+        borrowerOperations.proposeBorrowingRate(_rate % 1e18);
+    }
+
+    function approveBorrowingRateExt() external {
+        borrowerOperations.approveBorrowingRate();
+    }
+
+    function proposeRedemptionRateExt(uint256 _rate) external {
+        borrowerOperations.proposeRedemptionRate(_rate);
+    }
+
+    function proposeRedemptionRateSafeExt(uint256 _rate) external {
+        borrowerOperations.proposeRedemptionRate(_rate % 1e18);
+    }
+
+    function approveRedemptionRateExt() external {
+        borrowerOperations.approveRedemptionRate();
+    }
+
     // Interest Rate Manager
 
     function proposeInterestRateExt(uint256 _rate) external {

--- a/solidity/contracts/echidna/EchidnaTest.sol
+++ b/solidity/contracts/echidna/EchidnaTest.sol
@@ -324,6 +324,9 @@ contract EchidnaTest {
         pcv.startChangingRoles(address(this), address(this));
         pcv.finalizeChangingRoles();
         pcv.addRecipientToWhitelist(address(this));
+
+        governableVariables.startChangingRoles(address(this), address(this));
+        governableVariables.finalizeChangingRoles();
     }
 
     // TroveManager
@@ -788,6 +791,51 @@ contract EchidnaTest {
 
         // slither-disable-next-line unused-return
         actor.transferPrx(address(pcv), musdAmount);
+    }
+
+    // Governable Variables
+
+    function gvStartChangingRolesExt(
+        address _council,
+        address _treasury
+    ) external {
+        governableVariables.startChangingRoles(_council, _treasury);
+    }
+
+    function gvCancelChangingRolesExt() external {
+        governableVariables.cancelChangingRoles();
+    }
+
+    function finalizeChangingRolesExt() external {
+        governableVariables.finalizeChangingRoles();
+    }
+
+    function removeFeeExemptAccountExt(address _account) external {
+        governableVariables.removeFeeExemptAccount(_account);
+    }
+
+    function addFeeExemptAccountExt(address _account) external {
+        governableVariables.addFeeExemptAccount(_account);
+    }
+
+    function removeFeeExemptAccountSafeExt(uint _i) external {
+        uint actor = _i % NUMBER_OF_ACTORS;
+        governableVariables.removeFeeExemptAccount(
+            address(echidnaProxies[actor])
+        );
+    }
+
+    function addFeeExemptAccountSafeExt(uint _i) external {
+        uint actor = _i % NUMBER_OF_ACTORS;
+        governableVariables.addFeeExemptAccount(address(echidnaProxies[actor]));
+    }
+
+    function addFeeExemptAccountsExt(address[] calldata _accounts) external {
+        governableVariables.addFeeExemptAccounts(_accounts);
+    }
+
+    function removeFeeExemptAccountsExt(address[] calldata _accounts) external {
+        governableVariables.removeFeeExemptAccounts(_accounts);
     }
 
     // debugging

--- a/solidity/contracts/echidna/EchidnaTest.sol
+++ b/solidity/contracts/echidna/EchidnaTest.sol
@@ -866,6 +866,17 @@ contract EchidnaTest {
         actor.transferPrx(address(pcv), musdAmount);
     }
 
+    function addRecipientsToWhitelistExt(
+        address[] calldata _accounts
+    ) external {
+        pcv.addRecipientsToWhitelist(_accounts);
+    }
+
+    function removeRecipientsFromWhitelistExt(
+        address[] calldata _accounts
+    ) external {
+        pcv.removeRecipientsFromWhitelist(_accounts);
+    }
     // Governable Variables
 
     function gvStartChangingRolesExt(

--- a/solidity/contracts/echidna/EchidnaTest.sol
+++ b/solidity/contracts/echidna/EchidnaTest.sol
@@ -687,6 +687,12 @@ contract EchidnaTest {
         echidnaProxies[actor].provideToSPPrx(_amount);
     }
 
+    function provideToSPSafeExt(uint _i, uint _amount) external {
+        EchidnaProxy actor = echidnaProxies[_i % NUMBER_OF_ACTORS];
+        uint256 balance = musd.balanceOf(address(actor));
+        actor.provideToSPPrx(_amount % balance);
+    }
+
     function withdrawFromSPExt(uint _i, uint _amount) external {
         uint actor = _i % NUMBER_OF_ACTORS;
         echidnaProxies[actor].withdrawFromSPPrx(_amount);

--- a/solidity/contracts/echidna/EchidnaTest.sol
+++ b/solidity/contracts/echidna/EchidnaTest.sol
@@ -508,6 +508,7 @@ contract EchidnaTest {
         uint BTC = (amountWithFees * collatRatio * 1e18) / (100 * price);
         uint nicr = hintHelpers.computeNominalCR(BTC, amountWithFees);
 
+        // slither-disable-next-line unused-return
         (address hintAddress, , ) = hintHelpers.getApproxHint(
             nicr,
             500,

--- a/solidity/contracts/interfaces/IBorrowerOperations.sol
+++ b/solidity/contracts/interfaces/IBorrowerOperations.sol
@@ -78,6 +78,14 @@ interface IBorrowerOperations {
 
     function approveMinNetDebt() external;
 
+    function proposeBorrowingRate(uint256 _fee) external;
+
+    function approveBorrowingRate() external;
+
+    function proposeRedemptionRate(uint256 _fee) external;
+
+    function approveRedemptionRate() external;
+
     function addColl(address _upperHint, address _lowerHint) external payable;
 
     function moveCollateralGainToTrove(

--- a/solidity/contracts/interfaces/ITroveManager.sol
+++ b/solidity/contracts/interfaces/ITroveManager.sol
@@ -124,8 +124,6 @@ interface ITroveManager {
         address _borrower
     ) external returns (uint256 index);
 
-    function applyPendingRewards(address _borrower) external;
-
     function closeTrove(address _borrower) external;
 
     function removeStake(address _borrower) external;

--- a/solidity/test/normal/AccessControl.test.ts
+++ b/solidity/test/normal/AccessControl.test.ts
@@ -159,16 +159,6 @@ describe("Access Control: Liquity functions with the caller restricted to Liquit
   })
 
   describe("TroveManager", () => {
-    it("applyPendingRewards(): reverts when called by an account that is not BorrowerOperations", async () => {
-      await expect(
-        contracts.troveManager
-          .connect(alice.wallet)
-          .applyPendingRewards(alice.address),
-      ).to.be.revertedWith(
-        "TroveManager: Caller is not the BorrowerOperations contract",
-      )
-    })
-
     it("updateTroveRewardSnapshots(): reverts when called by an account that is not BorrowerOperations", async () => {
       await expect(
         contracts.troveManager


### PR DESCRIPTION
This PR fills in some gaps from echidna's code coverage. According to the cov report, the only thing we're not fuzz testing now is the signature stuff, which is a can of worms since right now contracts can't generate signatures for MUSD. We'll save that for another card.

Areas shored up:

**Removed** 
- a useless guard in `adjustTrove`
- the unused `TroveManager.applyPendingRewards`

**Added** surfaces for
- GovernableVariable functions
- borrowing and redemption rate
- opening troves with hints (which also touches un-hit sorted troves code)
- stability pool deposits
- adding/removing whitelist addresses
- PCV roles

**Fixed**
- The hard-coded borrowing rate to match launch params

Tagging @rwatts07 for review