### PR TITLE
Rip Out `totalCollSurplus` From The Liquidation Flow

### DIFF
--- a/solidity/contracts/TroveManager.sol
+++ b/solidity/contracts/TroveManager.sol
@@ -88,7 +88,6 @@ contract TroveManager is
         uint256 totalPrincipalToRedistribute;
         uint256 totalInterestToRedistribute;
         uint256 totalCollToRedistribute;
-        uint256 totalCollSurplus;
     }
 
     struct LocalVariables_LiquidationSequence {
@@ -712,12 +711,6 @@ contract TroveManager is
             totals.totalInterestToRedistribute,
             totals.totalCollToRedistribute
         );
-        if (totals.totalCollSurplus > 0) {
-            activePoolCached.sendCollateral(
-                address(collSurplusPool),
-                totals.totalCollSurplus
-            );
-        }
 
         // Update system snapshots
         _updateSystemSnapshotsExcludeCollRemainder(
@@ -727,8 +720,8 @@ contract TroveManager is
 
         vars.liquidatedColl =
             totals.totalCollInSequence -
-            totals.totalCollGasCompensation -
-            totals.totalCollSurplus;
+            totals.totalCollGasCompensation;
+
         emit Liquidation(
             totals.totalPrincipalInSequence,
             totals.totalInterestInSequence,
@@ -1674,10 +1667,6 @@ contract TroveManager is
         newTotals.totalCollToRedistribute =
             oldTotals.totalCollToRedistribute +
             singleLiquidation.collToRedistribute;
-
-        newTotals.totalCollSurplus =
-            oldTotals.totalCollSurplus +
-            singleLiquidation.collSurplus;
 
         return newTotals;
     }


### PR DESCRIPTION
Previously, recovery mode liquidations could be performed on troves under 150% ICR (instead of under 110%), but would only liquidate enough collateral to cover 110% of the debt. The remaining collateral was sent to the CollSurplusPool, where it waited for its owner to pick it up.

Now, liquidations in recovery mode follow the same rules as normal mode, so there is no excess collateral. Thus, we can safely remove this code path.

Tagging @rwatts07 for review