### PR TITLE
Claude Code Review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -38,6 +38,7 @@ jobs:
           
           # Custom prompt for DeFi/smart contract review
           direct_prompt: |
+            You are an experienced, professional smart contract auditor.
             Please review this MUSD protocol pull request with focus on:
             
             **Smart Contract Security:**

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,73 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    # Focus on core smart contract and test files
+    paths:
+      - "solidity/contracts/**/*.sol"
+      - "solidity/test/**/*.ts"
+      - "solidity/deploy/**/*.ts"
+      - "solidity/scripts/**/*.ts"
+      - "solidity/helpers/**/*.ts"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  claude-review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@beta
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          
+          # Custom prompt for DeFi/smart contract review
+          direct_prompt: |
+            Please review this MUSD protocol pull request with focus on:
+            
+            **Smart Contract Security:**
+            - Access controls and authorization patterns
+            - Reentrancy vulnerabilities
+            - Liquidation logic correctness
+            
+            **DeFi Protocol Considerations:**
+            - Collateralization ratio calculations
+            - Interest rate math accuracy
+            - State consistency across pool contracts
+            - Gas optimization for liquidators
+            - Recovery mode behavior
+            
+            **Code Quality:**
+            - Solidity best practices (0.8.24)
+            - OpenZeppelin upgradeable pattern usage
+            - Error handling and custom errors
+            - Test coverage for edge cases
+            
+            **Protocol-Specific:**
+            - Trove state management
+            - Stability pool mechanics
+            - Liquidation processes
+            
+            Be _succinct_ but thorough on security concerns. Use <details></details> 
+            blocks for implementation suggestions to keep the review focused.
+
+          # Allow Claude to run basic linting and compilation checks
+          allowed_tools: "Bash(cd solidity && pnpm format),Bash(cd solidity && pnpm build)"
+          
+          # Use sticky comments for cleaner PR experience
+          use_sticky_comment: true

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -30,6 +30,35 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Hide previous Claude comments
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Get all comments from the Claude Code bot on this PR
+          gh api \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments \
+            --jq '.[] | select(.performed_via_github_app.name == "Claude") | .node_id' \
+          | while read -r comment_id; do
+            if [ -n "$comment_id" ]; then
+              echo "Hiding comment: $comment_id"
+              gh api \
+                --method POST \
+                -H "Accept: application/vnd.github+json" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                /graphql \
+                -f query='
+                  mutation {
+                    minimizeComment(input: {subjectId: "'$comment_id'", classifier: OUTDATED}) {
+                      minimizedComment {
+                        isMinimized
+                      }
+                    }
+                  }'
+            fi
+          done
+
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@beta

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,64 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@beta
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+
+          # This is an optional setting that allows Claude to read CI results on PRs
+          additional_permissions: |
+            actions: read
+
+          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4.1)
+          # model: "claude-opus-4-1-20250805"
+
+          # Optional: Customize the trigger phrase (default: @claude)
+          # trigger_phrase: "/claude"
+
+          # Optional: Trigger when specific user is assigned to an issue
+          # assignee_trigger: "claude-bot"
+
+          # Optional: Allow Claude to run specific commands
+          # allowed_tools: "Bash(npm install),Bash(npm run build),Bash(npm run test:*),Bash(npm run lint:*)"
+
+          # Optional: Add custom instructions for Claude to customize its behavior for your project
+          # custom_instructions: |
+          #   Follow our coding standards
+          #   Ensure all new code has tests
+          #   Use TypeScript for new files
+
+          # Optional: Custom environment variables for Claude
+          # claude_env: |
+          #   NODE_ENV: test
+


### PR DESCRIPTION
# Summary

This PR adds automated code review via Claude.  Whenever a new PR is opened that targets files in the specified directories (smart contracts and test files), the "Claude Code Review" workflow will start running in Github actions.  PR comments should appear with Claude's review.

## Details

### Tasks
- [X] Added Github workflow for Claude PR review partly based on https://github.com/thesis/lolli-v2/blob/main/.github/workflows/claude-code-review.yml
- [x] Added GitHub workflow for interacting with Claude in comments and issues with `@claude`
- [x] Add ANTHROPIC_API_KEY to GitHub Secrets
- [x] Added step to workflow file to hide previous Claude comments to reduce PR noise 
- [x] Merge https://github.com/mezo-org/musd/pull/253 first so that we can make use of the CLAUDE.md.

### Security
- Our Anthropic API key is securely stored as a GitHub Actions secret
- Only users with write access to the repository can trigger the workflow
- All Claude runs are stored in the GitHub Actions run history
- Claude's default tools are limited to reading/writing files and interacting with our repo by creating comments, branches, and commits.
- We can add more allowed tools by adding them to the workflow file

There's more info at: https://github.com/anthropics/claude-code-action


### Testing

The fun part: we will have to merge this to test it.  

Once merged, we can open a test PR with a nominal change to one of the files mentioned (e.g. change a test description) and it should trigger a code review from Claude.  We can then also test @claude mentions.  Once we know it's working, we can just close the test PR.