### PR TITLE
BTC distribution updates

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -122,9 +122,13 @@ The `feeRecipient` address (MUSD Savings Rate vault) and `feeSplitPercentage` in
 
 #### Distribution of BTC
 
-The PCV contract has the ability to distribute `BTC` that it accrues from redemption actions. The `btcRecipient` address
-is the address that will receive the BTC and handle it according to its implementation, e.g. convert it to another asset such as
-`MUSD`. Collateral (`BTC`) was not directly used for loan repayment. It can be withdrawn from the PCV contract and distributed in a form of `MUSD` which is used for loan repayment.
+The PCV contract distributes BTC that it accrues from redemption fees via `distributeBTC()`. The `btcRecipient` address is the address that will receive the BTC and handle it according to its implementation, e.g. convert it to another asset such as `MUSD`.
+
+The PCV separates BTC from two sources:
+- **Redemption fee BTC**: Sent to the PCV by TroveManager when redemptions occur. This BTC is distributed to `btcRecipient` via `distributeBTC()`.
+- **Stability Pool BTC**: BTC received from the StabilityPool as liquidation gains (tracked by `stabilityPoolBTC`). This BTC is **not** distributed by `distributeBTC()` and must instead be withdrawn explicitly via `withdrawStabilityBTC()` or `withdrawFromStabilityPool()`.
+
+A `distributor` role can be set by governance to authorize a bot to call `distributeBTC()`, in addition to the owner, council, and treasury.
 
 #### Withdrawing MUSD
 

--- a/docs/rebalancing.md
+++ b/docs/rebalancing.md
@@ -45,9 +45,17 @@ If the recipient address is not already whitelisted, governance must first add i
 pcv.addRecipientToWhitelist(recipientAddress);
 ```
 
-### Step 3: Withdraw BTC from Stability Pool to Recipient
+### Step 3: Withdraw BTC to Recipient
 
-Governance calls PCV to withdraw funds directly to a whitelisted recipient. The BTC collateral gain and any excess MUSD (after debt repayment) will be sent directly to the recipient.
+Governance calls PCV to withdraw BTC to a whitelisted recipient. There are two paths:
+
+**Option A – Withdraw directly from StabilityPool:** Use `withdrawFromStabilityPool()`
+to claim BTC collateral gains from the StabilityPool and send them directly to
+the recipient in a single call.
+
+**Option B – Withdraw BTC already held by PCV:** If BTC was previously claimed
+from the StabilityPool and is being held in PCV (tracked by `stabilityPoolBTC`),
+use `withdrawStabilityBTC()` to send it to a whitelisted recipient.
 
 ### Step 4: Swap BTC for MUSD
 
@@ -93,12 +101,22 @@ If the recipient address is not already whitelisted:
 pcv.addRecipientToWhitelist(recipientAddress);
 ```
 
-### Step 3: Withdraw BTC from Stability Pool to Recipient
+### Step 3: Withdraw BTC to Recipient
 
-Governance calls PCV to withdraw funds directly to the whitelisted recipient:
+Governance calls PCV to withdraw BTC to the whitelisted recipient. There are two options:
+
+**Option A – Withdraw directly from StabilityPool:**
 ```solidity
 // Withdraw BTC collateral gain to recipient (0 means withdraw only collateral, no MUSD)
 pcv.withdrawFromStabilityPool(0, recipientAddress);
+```
+
+**Option B – Withdraw BTC already held by PCV:**
+
+If BTC was previously claimed from the StabilityPool and is sitting in PCV
+(tracked by `stabilityPoolBTC`):
+```solidity
+pcv.withdrawStabilityBTC(amount, recipientAddress);
 ```
 
 ### Step 4: Swap BTC for MUSD

--- a/solidity/contracts/PCV.sol
+++ b/solidity/contracts/PCV.sol
@@ -396,9 +396,8 @@ contract PCV is
         // Send BTC collateral to recipient. The BTC arrived via receive()
         // which incremented stabilityPoolBTC, so decrement it here.
         if (btcClaimed > 0) {
-            // Stability Pool is a trusted contract and we need to call
-            // withdrawFromSP first to compute btcClaimed.
-            // slither-disable-next-line reentrancy-benign
+            // Stability Pool and BorrowerOperations are trusted contracts.
+            // slither-disable-next-line reentrancy-benign,reentrancy-no-eth
             stabilityPoolBTC -= btcClaimed;
             _sendCollateral(_recipient, btcClaimed);
         }

--- a/solidity/contracts/PCV.sol
+++ b/solidity/contracts/PCV.sol
@@ -59,6 +59,13 @@ contract PCV is
     /// @dev BTC redemption fees recipient. Must implement IBTCFeeRecipient.
     address public btcRecipient;
 
+    /// @dev Tracks BTC received from StabilityPool liquidation gains.
+    ///      This BTC is not distributed by distributeBTC().
+    uint256 public stabilityPoolBTC;
+
+    /// @dev Authorized address that can call distributeBTC().
+    address public distributor;
+
     modifier onlyOwnerOrCouncilOrTreasury() {
         require(
             msg.sender == owner() ||
@@ -97,7 +104,14 @@ contract PCV is
     }
 
     // solhint-disable-next-line ordering
-    receive() external payable {}
+    receive() external payable {
+        if (
+            address(borrowerOperations) != address(0) &&
+            msg.sender == borrowerOperations.stabilityPoolAddress()
+        ) {
+            stabilityPoolBTC += msg.value;
+        }
+    }
 
     function setAddresses(
         address _borrowerOperations,
@@ -146,6 +160,18 @@ contract PCV is
         );
         btcRecipient = _btcRecipient;
         emit BTCRecipientSet(_btcRecipient);
+    }
+
+    /// @notice Sets the distributor address that can call distributeBTC().
+    /// @param _distributor The address of the distributor bot. Can be set to
+    ///        address(0) to disable the bot role; governance can still call
+    ///        distributeBTC() directly.
+    function setDistributor(
+        address _distributor
+    ) external onlyOwnerOrCouncilOrTreasury {
+        // slither-disable-next-line missing-zero-check
+        distributor = _distributor;
+        emit DistributorSet(_distributor);
     }
 
     /// @notice Set the fee split percentage
@@ -279,9 +305,19 @@ contract PCV is
     }
 
     /// @notice Distributes accumulated BTC from redemption fees to Tigris as
-    ///         yield.
+    ///         yield. Only callable by the distributor bot, owner, council, or
+    ///         treasury. BTC from StabilityPool liquidation gains (tracked by
+    ///         stabilityPoolBTC) is excluded from distribution.
     function distributeBTC() external override nonReentrant {
-        uint256 collateralAmount = address(this).balance;
+        require(
+            msg.sender == distributor ||
+                msg.sender == owner() ||
+                msg.sender == council ||
+                msg.sender == treasury,
+            "PCV: caller not authorized"
+        );
+
+        uint256 collateralAmount = address(this).balance - stabilityPoolBTC;
         // If there is not enough collateral to distribute, do nothing.
         // This approach is less descriptive but more bot-friendly, which in the case
         // of this function is more appropriate.
@@ -297,6 +333,31 @@ contract PCV is
         );
         // slither-disable-next-line reentrancy-events
         emit PCVDistributionBTC(btcRecipient, collateralAmount);
+    }
+
+    /// @notice Withdraws BTC that was claimed from the StabilityPool and is
+    ///         being held in this contract, tracked by stabilityPoolBTC. This
+    ///         is distinct from withdrawFromStabilityPool(), which pulls MUSD
+    ///         and BTC gains out of the StabilityPool contract itself (reducing
+    ///         PCV's deposit position). This function sends BTC that has
+    ///         already been claimed and is sitting in PCV's balance.
+    /// @param _amount The amount of stability BTC to withdraw
+    /// @param _recipient The whitelisted recipient address
+    function withdrawStabilityBTC(
+        uint256 _amount,
+        address _recipient
+    )
+        external
+        onlyOwnerOrCouncilOrTreasury
+        onlyWhitelistedRecipient(_recipient)
+    {
+        require(
+            _amount <= stabilityPoolBTC,
+            "PCV: amount exceeds stability BTC"
+        );
+        emit StabilityBTCWithdrawn(_recipient, _amount);
+        stabilityPoolBTC -= _amount;
+        _sendCollateral(_recipient, _amount);
     }
 
     /// @notice Allows anyone to deposit MUSD to the stability pool. Note that
@@ -332,8 +393,13 @@ contract PCV is
         uint256 debtRepayment = _repayDebt(musdChange);
         uint256 excessMusd = musdChange - debtRepayment;
 
-        // Send BTC collateral to recipient
+        // Send BTC collateral to recipient. The BTC arrived via receive()
+        // which incremented stabilityPoolBTC, so decrement it here.
         if (collateralChange > 0) {
+            // Stability Pool is a trusted contract and we need to call
+            // withdrawFromSP first to compute collateralChange.
+            // slither-disable-next-line reentrancy-benign
+            stabilityPoolBTC -= collateralChange;
             _sendCollateral(_recipient, collateralChange);
         }
 

--- a/solidity/contracts/PCV.sol
+++ b/solidity/contracts/PCV.sol
@@ -381,13 +381,13 @@ contract PCV is
         onlyOwnerOrCouncilOrTreasury
         onlyWhitelistedRecipient(_recipient)
     {
-        uint256 collateralBefore = address(this).balance;
+        uint256 btcBefore = stabilityPoolBTC;
         uint256 musdBefore = musd.balanceOf(address(this));
 
         IStabilityPool(borrowerOperations.stabilityPoolAddress())
             .withdrawFromSP(_amount);
 
-        uint256 collateralChange = address(this).balance - collateralBefore;
+        uint256 btcClaimed = stabilityPoolBTC - btcBefore;
         uint256 musdChange = musd.balanceOf(address(this)) - musdBefore;
 
         uint256 debtRepayment = _repayDebt(musdChange);
@@ -395,12 +395,12 @@ contract PCV is
 
         // Send BTC collateral to recipient. The BTC arrived via receive()
         // which incremented stabilityPoolBTC, so decrement it here.
-        if (collateralChange > 0) {
+        if (btcClaimed > 0) {
             // Stability Pool is a trusted contract and we need to call
-            // withdrawFromSP first to compute collateralChange.
+            // withdrawFromSP first to compute btcClaimed.
             // slither-disable-next-line reentrancy-benign
-            stabilityPoolBTC -= collateralChange;
-            _sendCollateral(_recipient, collateralChange);
+            stabilityPoolBTC -= btcClaimed;
+            _sendCollateral(_recipient, btcClaimed);
         }
 
         // Send excess MUSD to recipient (after debt repayment)
@@ -409,7 +409,7 @@ contract PCV is
         }
 
         // slither-disable-next-line reentrancy-events
-        emit PCVWithdrawSP(msg.sender, musdChange, collateralChange);
+        emit PCVWithdrawSP(msg.sender, musdChange, btcClaimed);
     }
 
     function _repayDebt(uint _repayment) internal returns (uint256) {

--- a/solidity/contracts/interfaces/IPCV.sol
+++ b/solidity/contracts/interfaces/IPCV.sol
@@ -27,6 +27,8 @@ interface IPCV {
     event RecipientRemoved(address _recipient);
     event BTCRecipientSet(address _btcRecipient);
     event PCVDistributionBTC(address _recipient, uint256 _amount);
+    event StabilityBTCWithdrawn(address _recipient, uint256 _amount);
+    event DistributorSet(address _distributor);
 
     // --- Functions ---
 
@@ -63,6 +65,14 @@ interface IPCV {
         uint256 _amount,
         address _recipient
     ) external;
+
+    function withdrawStabilityBTC(uint256 _amount, address _recipient) external;
+
+    function setDistributor(address _distributor) external;
+
+    function stabilityPoolBTC() external view returns (uint256);
+
+    function distributor() external view returns (address);
 
     function musd() external view returns (IMUSD);
 

--- a/solidity/test/normal/PCV.test.ts
+++ b/solidity/test/normal/PCV.test.ts
@@ -587,6 +587,60 @@ describe("PCV", () => {
       expect(state.pcv.musd.after).to.equal(state.pcv.musd.before)
       expect(recipientAfter.musd).equal(recipientBefore.musd)
     })
+
+    it("decrements stabilityPoolBTC when withdrawing collateral", async () => {
+      // Create a liquidation so StabilityPool has BTC gains for PCV
+      const whaleMusd = "300,000"
+      await openTrove(contracts, {
+        musdAmount: whaleMusd,
+        ICR: "200",
+        sender: whale.wallet,
+      })
+      await createLiquidationEvent(contracts, deployer)
+
+      expect(await contracts.pcv.stabilityPoolBTC()).to.equal(0n)
+
+      // Withdraw directly - BTC gains arrive via receive() and are forwarded
+      // to recipient. stabilityPoolBTC should net to 0 (incremented in
+      // receive, decremented in withdrawFromStabilityPool).
+      const recipientBefore = await ethers.provider.getBalance(alice.address)
+      await contracts.pcv
+        .connect(treasury.wallet)
+        .withdrawFromStabilityPool(0n, alice.address)
+      const recipientAfter = await ethers.provider.getBalance(alice.address)
+
+      expect(await contracts.pcv.stabilityPoolBTC()).to.equal(0n)
+      expect(recipientAfter).to.be.greaterThan(recipientBefore)
+    })
+
+    it("preserves stabilityPoolBTC from prior claims not yet withdrawn", async () => {
+      // Create a liquidation
+      const whaleMusd = "300,000"
+      await openTrove(contracts, {
+        musdAmount: whaleMusd,
+        ICR: "200",
+        sender: whale.wallet,
+      })
+      await createLiquidationEvent(contracts, deployer)
+
+      // Trigger BTC gain claim via deposit (this claims all current gains)
+      await contracts.musd.unprotectedMint(deployer.address, 1n)
+      await contracts.musd.connect(deployer.wallet).approve(addresses.pcv, 1n)
+      await PCVDeployer.depositToStabilityPool(1n)
+
+      const stabilityBTCAfterClaim = await contracts.pcv.stabilityPoolBTC()
+      expect(stabilityBTCAfterClaim).to.be.greaterThan(0n)
+
+      // Now withdraw from SP - no new gains to claim (already claimed above),
+      // so collateralChange is 0 and stabilityPoolBTC stays the same.
+      await contracts.pcv
+        .connect(treasury.wallet)
+        .withdrawFromStabilityPool(0n, alice.address)
+
+      expect(await contracts.pcv.stabilityPoolBTC()).to.equal(
+        stabilityBTCAfterClaim,
+      )
+    })
   })
 
   describe("distributeMUSD()", () => {
@@ -1157,7 +1211,9 @@ describe("PCV", () => {
       expect(await btcRecipientMock.totalBTCReceived()).to.equal(btcAmount)
     })
 
-    it("can be called by anyone (permissionless)", async () => {
+    it("can be called by distributor", async () => {
+      await PCVDeployer.setDistributor(alice.address)
+
       const btcAmount = to1e18("7")
       await deployer.wallet.sendTransaction({
         to: addresses.pcv,
@@ -1166,6 +1222,18 @@ describe("PCV", () => {
 
       await contracts.pcv.connect(alice.wallet).distributeBTC()
       expect(await btcRecipientMock.totalBTCReceived()).to.equal(btcAmount)
+    })
+
+    it("reverts when called by unauthorized user", async () => {
+      const btcAmount = to1e18("7")
+      await deployer.wallet.sendTransaction({
+        to: addresses.pcv,
+        value: btcAmount,
+      })
+
+      await expect(
+        contracts.pcv.connect(alice.wallet).distributeBTC(),
+      ).to.be.revertedWith("PCV: caller not authorized")
     })
 
     it("distributes all available collateral", async () => {
@@ -1275,6 +1343,238 @@ describe("PCV", () => {
           contracts.pcv.connect(treasury.wallet).distributeBTC(),
         ).to.be.revertedWith("BTCFeeRecipientMock: forced revert")
       })
+
+      it("does not distribute stability BTC", async () => {
+        // Create a liquidation so StabilityPool has BTC gains for PCV
+        const whaleMusd = "300,000"
+        await openTrove(contracts, {
+          musdAmount: whaleMusd,
+          ICR: "200",
+          sender: whale.wallet,
+        })
+        await createLiquidationEvent(contracts, deployer)
+
+        // Trigger BTC gain claim by depositing 1 wei MUSD to StabilityPool
+        await contracts.musd.unprotectedMint(deployer.address, 1n)
+        await contracts.musd.connect(deployer.wallet).approve(addresses.pcv, 1n)
+        await PCVDeployer.depositToStabilityPool(1n)
+
+        const stabilityBTC = await contracts.pcv.stabilityPoolBTC()
+        expect(stabilityBTC).to.be.greaterThan(0n)
+
+        // Also send some redemption fee BTC directly
+        const redemptionBTC = to1e18("1")
+        await deployer.wallet.sendTransaction({
+          to: addresses.pcv,
+          value: redemptionBTC,
+        })
+
+        const pcvBalanceBefore = await ethers.provider.getBalance(addresses.pcv)
+        expect(pcvBalanceBefore).to.equal(stabilityBTC + redemptionBTC)
+
+        // Distribute should only send the redemption BTC
+        await contracts.pcv.connect(treasury.wallet).distributeBTC()
+
+        const pcvBalanceAfter = await ethers.provider.getBalance(addresses.pcv)
+        expect(pcvBalanceAfter).to.equal(stabilityBTC)
+        expect(await btcRecipientMock.totalBTCReceived()).to.equal(
+          redemptionBTC,
+        )
+      })
+
+      it("does nothing when only stability BTC exists", async () => {
+        // Create a liquidation so StabilityPool has BTC gains for PCV
+        const whaleMusd = "300,000"
+        await openTrove(contracts, {
+          musdAmount: whaleMusd,
+          ICR: "200",
+          sender: whale.wallet,
+        })
+        await createLiquidationEvent(contracts, deployer)
+
+        // Trigger BTC gain claim
+        await contracts.musd.unprotectedMint(deployer.address, 1n)
+        await contracts.musd.connect(deployer.wallet).approve(addresses.pcv, 1n)
+        await PCVDeployer.depositToStabilityPool(1n)
+
+        const stabilityBTC = await contracts.pcv.stabilityPoolBTC()
+        expect(stabilityBTC).to.be.greaterThan(0n)
+
+        // No redemption fee BTC - only stability BTC
+        await contracts.pcv.connect(treasury.wallet).distributeBTC()
+
+        // Nothing should have been distributed
+        expect(await btcRecipientMock.totalBTCReceived()).to.equal(0n)
+        expect(await ethers.provider.getBalance(addresses.pcv)).to.equal(
+          stabilityBTC,
+        )
+      })
+    })
+  })
+
+  describe("receive()", () => {
+    it("increments stabilityPoolBTC when BTC comes from StabilityPool", async () => {
+      // Create a liquidation so StabilityPool has BTC gains for PCV
+      const whaleMusd = "300,000"
+      await openTrove(contracts, {
+        musdAmount: whaleMusd,
+        ICR: "200",
+        sender: whale.wallet,
+      })
+      await createLiquidationEvent(contracts, deployer)
+
+      expect(await contracts.pcv.stabilityPoolBTC()).to.equal(0n)
+
+      // Trigger BTC gain claim by depositing to StabilityPool
+      await contracts.musd.unprotectedMint(deployer.address, 1n)
+      await contracts.musd.connect(deployer.wallet).approve(addresses.pcv, 1n)
+      await PCVDeployer.depositToStabilityPool(1n)
+
+      const stabilityBTC = await contracts.pcv.stabilityPoolBTC()
+      expect(stabilityBTC).to.be.greaterThan(0n)
+    })
+
+    it("does not increment stabilityPoolBTC when BTC comes from other addresses", async () => {
+      const btcAmount = to1e18("5")
+      await deployer.wallet.sendTransaction({
+        to: addresses.pcv,
+        value: btcAmount,
+      })
+
+      expect(await contracts.pcv.stabilityPoolBTC()).to.equal(0n)
+      expect(await ethers.provider.getBalance(addresses.pcv)).to.equal(
+        btcAmount,
+      )
+    })
+  })
+
+  describe("withdrawStabilityBTC()", () => {
+    async function setupStabilityBTC() {
+      // Create a liquidation so StabilityPool has BTC gains for PCV
+      const whaleMusd = "300,000"
+      await openTrove(contracts, {
+        musdAmount: whaleMusd,
+        ICR: "200",
+        sender: whale.wallet,
+      })
+      await createLiquidationEvent(contracts, deployer)
+
+      // Trigger BTC gain claim
+      await contracts.musd.unprotectedMint(deployer.address, 1n)
+      await contracts.musd.connect(deployer.wallet).approve(addresses.pcv, 1n)
+      await PCVDeployer.depositToStabilityPool(1n)
+    }
+
+    it("sends escrowed stability BTC to whitelisted recipient", async () => {
+      await setupStabilityBTC()
+
+      const stabilityBTC = await contracts.pcv.stabilityPoolBTC()
+      expect(stabilityBTC).to.be.greaterThan(0n)
+
+      const recipientBefore = await ethers.provider.getBalance(alice.address)
+      await contracts.pcv
+        .connect(treasury.wallet)
+        .withdrawStabilityBTC(stabilityBTC, alice.address)
+      const recipientAfter = await ethers.provider.getBalance(alice.address)
+
+      expect(recipientAfter - recipientBefore).to.equal(stabilityBTC)
+      expect(await contracts.pcv.stabilityPoolBTC()).to.equal(0n)
+    })
+
+    it("emits StabilityBTCWithdrawn event", async () => {
+      await setupStabilityBTC()
+
+      const stabilityBTC = await contracts.pcv.stabilityPoolBTC()
+
+      await expect(
+        contracts.pcv
+          .connect(treasury.wallet)
+          .withdrawStabilityBTC(stabilityBTC, alice.address),
+      )
+        .to.emit(contracts.pcv, "StabilityBTCWithdrawn")
+        .withArgs(alice.address, stabilityBTC)
+    })
+
+    it("allows partial withdrawal", async () => {
+      await setupStabilityBTC()
+
+      const stabilityBTC = await contracts.pcv.stabilityPoolBTC()
+      const halfAmount = stabilityBTC / 2n
+
+      await contracts.pcv
+        .connect(treasury.wallet)
+        .withdrawStabilityBTC(halfAmount, alice.address)
+
+      expect(await contracts.pcv.stabilityPoolBTC()).to.equal(
+        stabilityBTC - halfAmount,
+      )
+    })
+
+    it("reverts when amount exceeds stabilityPoolBTC", async () => {
+      await setupStabilityBTC()
+
+      const stabilityBTC = await contracts.pcv.stabilityPoolBTC()
+
+      await expect(
+        contracts.pcv
+          .connect(treasury.wallet)
+          .withdrawStabilityBTC(stabilityBTC + 1n, alice.address),
+      ).to.be.revertedWith("PCV: amount exceeds stability BTC")
+    })
+
+    it("reverts for non-governance caller", async () => {
+      await setupStabilityBTC()
+
+      await expect(
+        contracts.pcv
+          .connect(alice.wallet)
+          .withdrawStabilityBTC(1n, alice.address),
+      ).to.be.revertedWith("PCV: caller must be owner or council or treasury")
+    })
+
+    it("reverts for non-whitelisted recipient", async () => {
+      await setupStabilityBTC()
+
+      await expect(
+        contracts.pcv
+          .connect(treasury.wallet)
+          .withdrawStabilityBTC(1n, bob.address),
+      ).to.be.revertedWith("PCV: recipient must be in whitelist")
+    })
+  })
+
+  describe("setDistributor()", () => {
+    it("sets distributor address", async () => {
+      await PCVDeployer.setDistributor(alice.address)
+      expect(await contracts.pcv.distributor()).to.equal(alice.address)
+    })
+
+    it("emits DistributorSet event", async () => {
+      await expect(PCVDeployer.setDistributor(alice.address))
+        .to.emit(contracts.pcv, "DistributorSet")
+        .withArgs(alice.address)
+    })
+
+    it("can be set to zero address (disabling bot role)", async () => {
+      await PCVDeployer.setDistributor(alice.address)
+      await PCVDeployer.setDistributor(ZERO_ADDRESS)
+      expect(await contracts.pcv.distributor()).to.equal(ZERO_ADDRESS)
+    })
+
+    it("can be called by council", async () => {
+      await contracts.pcv.connect(council.wallet).setDistributor(alice.address)
+      expect(await contracts.pcv.distributor()).to.equal(alice.address)
+    })
+
+    it("can be called by treasury", async () => {
+      await contracts.pcv.connect(treasury.wallet).setDistributor(alice.address)
+      expect(await contracts.pcv.distributor()).to.equal(alice.address)
+    })
+
+    it("reverts for non-governance caller", async () => {
+      await expect(
+        contracts.pcv.connect(alice.wallet).setDistributor(bob.address),
+      ).to.be.revertedWith("PCV: caller must be owner or council or treasury")
     })
   })
 })


### PR DESCRIPTION
Separate BTC earned from redemption fees from BTC earned by StabilityPool from taking liquidations. Only the redemption fee BTC can be distributed to the MUSD Savings Rate. Also, made the distribution call permissioned.

Refs https://linear.app/thesis-co/issue/MEZO-4357/pcv-musd-savings-rate-yield-conversion-updates-for-btc

